### PR TITLE
Ensure the SPA works when URL accessed directly

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,5 +15,6 @@ resource "azurerm_storage_account" "spa_storage_account" {
 
   static_website {
     index_document = "index.html"
+    error_404_document = "index.html"
   }
 }


### PR DESCRIPTION
Since the paths (for example /dashboard) don't exist directly in the
storage container, they previously would have resulted in a 404. By
using the index.html as the document for 404s as well this can be
mitigated. Azure Storage still returns a 404 status code but at least
the content loads. This could mitigated if we had a CDN similar resource
in front to rewrite the status codes. But the HTTP status code is of
minimal concern so long as the content itself loads for now.

This resolves the issue @palaparthi-ccpo pointed out.