### PR TITLE
Ensure only one deployment runs at a time

### DIFF
--- a/.github/workflows/deploy-spa.yml
+++ b/.github/workflows/deploy-spa.yml
@@ -1,6 +1,8 @@
 ---
 name: Build and Deploy SPA
 
+concurrency: "deploy-develop"
+
 on:
   push:
     branches:


### PR DESCRIPTION
Theoretically we could see a wonky deployment scenario where two PRs
merged at nearly the same time could result in a corrupted deployment
(or the older code getting deloyed). Limiting the concurrency using a
concurrency group on the critical section/job will prevent this.