### PR TITLE
AT-6411 initialized file structure setup for STEP 1 of the wizard.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app>
     <SecurityBanner />
+    <ATATSideBar v-if="loginStatus" />
     <ATATHeader />
-    <ATATSideBar v-show="loginStatus" />
-    <v-main>
+    <v-main style="padding-top: 90px;">
       <v-container fluid>
-        <router-view></router-view>
+        <router-view> </router-view>
       </v-container>
     </v-main>
     <ATATFooter />

--- a/src/components/ATATSideBar.vue
+++ b/src/components/ATATSideBar.vue
@@ -2,7 +2,6 @@
   <v-navigation-drawer
     app
     clipped
-    v-model="drawer"
     mini-variant-width="70"
     :mini-variant.sync="show"
     permanent

--- a/src/components/ATATSideBar.vue
+++ b/src/components/ATATSideBar.vue
@@ -2,10 +2,11 @@
   <v-navigation-drawer
     app
     clipped
+    v-model="drawer"
     mini-variant-width="70"
     :mini-variant.sync="show"
     permanent
-    class="body-bg"
+    class="global-side-nav-bar"
   >
     <v-list dense>
       <div class="d-flex flex-row">
@@ -42,18 +43,13 @@
         </div>
       </div>
       <v-divider></v-divider>
-      <v-list-item-group v-if="!show" v-model="selectedItem" color="primary">
+      <v-list-item-group v-if="!show" color="primary">
         <v-list-item v-for="(item, i) in items" :key="i" :ripple="false">
           <v-list-item-content>
             <router-link :to="item.link" v-slot="{ href, navigate, isActive }">
-              <NavLink
-                class="body"
-                :active="isActive"
-                :href="href"
-                @click="navigate"
-              >
+              <a class="body" :active="isActive" :href="href" @click="navigate">
                 {{ item.text }}
-              </NavLink>
+              </a>
             </router-link>
           </v-list-item-content>
         </v-list-item>
@@ -70,7 +66,6 @@ import { Component } from "vue-property-decorator";
 export default class ATATSideBar extends Vue {
   private show = true;
 
-  private selectedItem = 0;
   private items = [
     { text: "Dashboard", link: "/createportfolio" },
     { text: "My Portfolios", link: "/portfolios" },

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,20 +17,10 @@ import ATATTextField from "./components/ATATTextField.vue";
 import SecurityBanner from "./components/SecurityBanner.vue";
 import StyledFields from "./components/StyledFields.vue";
 import USAGovBanner from "./components/USAGovBanner.vue";
-import ViewPortfolio from "./wizard/Step_1/components/ViewPortfolio.vue";
-import CreatePortfolio from "@/wizard/Step_1/components/CreatePortfolio.vue";
 
-Vue.component('atat-footer', ATATFooter);
-Vue.component('atat-header', ATATHeader);
-Vue.component('atat-header-nav', ATATHeaderNav);
-Vue.component('atat-select', ATATSelect);
-Vue.component('atat-sidebar', ATATSideBar);
-Vue.component('atat-text-field', ATATTextField);
-Vue.component('security-banner', SecurityBanner);
-Vue.component('styled-fields', StyledFields);
-Vue.component('usa-gov-banner', USAGovBanner);
-Vue.component('view-portfolio',ViewPortfolio)
-Vue.component('create-portfolio',CreatePortfolio)
+// wizard
+import ViewPortfolio from "./wizard/Step_0/components/ViewPortfolio/ViewPortfolio.vue";
+import CreatePortfolio from "./wizard/Step_0/components/CreatePortfolio/CreatePortfolio.vue";
 
 Vue.config.productionTip = false;
 Vue.prototype.moment = moment;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,19 +32,27 @@ const routes: Array<RouteConfig> = [
       import(/* webpackChunkName: "style" */ "../views/sample/Style.vue"),
   },
   {
-    path: "/wizard/step-1",
+    path: "/wizard/step1",
     name: "step1",
     component: () =>
       import(
-        /* webpackChunkName: "style" */ "../wizard/Step_1/views/Step_1.vue"
+        /* webpackChunkName: "style" */ "../wizard/Step1/views/Step1.vue"
       ),
   },
   {
-    path: "/wizard/step-2",
+    path: "/wizard",
+    name: "wizard",
+    component: () =>
+      import(
+        /* webpackChunkName: "style" */ "../wizard/wizard.vue"
+      ),
+  },
+  {
+    path: "/wizard/step2",
     name: "step2",
     component: () =>
       import(
-        /* webpackChunkName: "style" */ "../wizard/Step_2/views/Step_2.vue"
+        /* webpackChunkName: "style" */ "../wizard/Step2/views/Step2.vue"
       ),
   },
   {
@@ -52,7 +60,7 @@ const routes: Array<RouteConfig> = [
     name: "portfolios",
     component: () =>
       import(
-        /* webpackChunkName: "style" */ "../wizard/Step_1/components/ViewPortfolio.vue"
+        /* webpackChunkName: "style" */ "../wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue"
       ),
   },
   {
@@ -60,7 +68,7 @@ const routes: Array<RouteConfig> = [
     name: "createPortfolio",
     component: () =>
       import(
-        /* webpackChunkName: "style" */ "../wizard/Step_1/components/CreatePortfolio.vue"
+        /* webpackChunkName: "style" */ "../wizard/Step0/components/CreatePortfolio/CreatePortfolio.vue"
       ),
   },
 ];

--- a/src/sass/atat.scss
+++ b/src/sass/atat.scss
@@ -1,17 +1,20 @@
-@import "./components/v-text-field.scss";
-@import "./components/v-alerts";
+
 @import "./utils/typography.scss";
 @import "./utils/colors.scss";
-@import "./components/v-button";
-@import "./components/app-bar-top-nav";
+
 @import "./components/_atat_sidebar";
+@import "./components/app-bar-top-nav";
+@import "./components/v-alerts";
+@import "./components/v-button";
 @import "./components/v-card";
+@import "./components/v-list_item";
+@import "./components/v-text-field.scss";
 
 body,html{
     background-color: $light_gray !important;
 }
 .v-main{
-    padding: 90px 0px 39px 0px !important;
+    @extend .body;
 }
 
 .v-navigation-drawer{

--- a/src/sass/components/_v-list_item.scss
+++ b/src/sass/components/_v-list_item.scss
@@ -1,0 +1,20 @@
+.global-side-nav-bar{
+  &.v-navigation-drawer {
+    .v-list-item__content{
+        a{
+          text-decoration: none !important;
+        }
+      }
+    .v-list-item-group .v-list-item--active {
+      color: inherit;
+      border-left: solid 4px;
+      .v-list-item__content{
+        a{
+          font-weight: bolder !important;
+        }
+      }
+    }
+  }
+}
+
+

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,12 +1,12 @@
 <template>
   <v-container class="dashboard-body body-lg">
     <v-row>
-      <v-col cols="6" offset="2">
-        <h1 class="my-5 h1 font-weight-bold">ATAT Cloud Services</h1>
+      <v-col cols="6">
+        <h1 class="mb-5 h1 font-weight-bold">ATAT Cloud Services</h1>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="6" offset="2">
+      <v-col cols="6">
         <h3 class="h3 mb-7">
           Welcome to the Account Tracking and Automation Tool, Maria!
         </h3>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,56 +1,54 @@
 <template>
-  <div class="home-view">
-    <v-container>
-      <div class="text-center mb-10 h1 font-weight-bold">
-        Access the ATAT Cloud
-      </div>
-      <v-row>
-        <v-col class="d-flex justify-center py-2">
-          <img
-            alt="CCPO logo"
-            src="../assets/CCPO-Logo.png"
-            width="320"
-            id="atat-main-child-img"
-            class="mb-3"
-          />
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col class="d-flex justify-center mb-9">
-          <v-btn
-            large
-            color="primary"
-            class="text-capitalize"
-            :ripple="false"
-            @click="login()"
-            id="login_button"
-          >
-            Sign in
-          </v-btn>
-        </v-col>
-      </v-row>
-      <v-row>
-        <v-col class="d-flex justify-center mt-9">
-          <v-alert
-            outlined
-            color="cyan"
-            type="info"
-            class="text-left cyan info_lighter black-icon"
-            border="left"
-            width="600"
-          >
-            <div class="black--text h3">Certificate Selection</div>
-            <div class="black--text body-lg">
-              When you are prompted to select a certificate, please select an
-              <br />
-              Authentication (Identification) Certificate from the provided
-              choices.
-            </div>
-          </v-alert>
-        </v-col>
-      </v-row>
-    </v-container>
-  </div>
+  <v-container>
+    <div class="text-center mb-10 h1 font-weight-bold">
+      Access the ATAT Cloud
+    </div>
+    <v-row>
+      <v-col class="d-flex justify-center py-2">
+        <img
+          alt="CCPO logo"
+          src="../assets/CCPO-Logo.png"
+          width="320"
+          id="atat-main-child-img"
+          class="mb-3"
+        />
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col class="d-flex justify-center mb-9">
+        <v-btn
+          large
+          color="primary"
+          class="text-capitalize"
+          :ripple="false"
+          @click="login()"
+          id="login_button"
+        >
+          Sign in
+        </v-btn>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col class="d-flex justify-center mt-9">
+        <v-alert
+          outlined
+          color="cyan"
+          type="info"
+          class="text-left cyan info_lighter black-icon"
+          border="left"
+          width="600"
+        >
+          <div class="black--text h3">Certificate Selection</div>
+          <div class="black--text body-lg">
+            When you are prompted to select a certificate, please select an
+            <br />
+            Authentication (Identification) Certificate from the provided
+            choices.
+          </div>
+        </v-alert>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script lang="ts">

--- a/src/wizard/Navigation/ButtonNavigation.vue
+++ b/src/wizard/Navigation/ButtonNavigation.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h3 class="h3">Button Navigation Component</h3>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class ButtonNavigation extends Vue {}
+</script>

--- a/src/wizard/Navigation/Stepper.vue
+++ b/src/wizard/Navigation/Stepper.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h3 class="h3">Stepper Navigation Component</h3>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class Stepper extends Vue {}
+</script>

--- a/src/wizard/Step0/components/CreatePortfolio/CreatePortfolio.vue
+++ b/src/wizard/Step0/components/CreatePortfolio/CreatePortfolio.vue
@@ -1,22 +1,20 @@
 <template>
   <v-container class="dashboard-body body-lg wizard-step-1-view">
     <v-row>
-      <v-col cols="6" offset="2">
-        <h1 class="h1 step-1-title my-5font-weight-bold">
-          ATAT Cloud Services
-        </h1>
+      <v-col cols="6">
+        <h1 class="h1 step-1-title font-weight-bold">ATAT Cloud Services</h1>
       </v-col>
     </v-row>
 
     <br />
     <v-row>
-      <v-col cols="6" offset="2">
+      <v-col cols="6">
         <h2 class="h2 step-1-subtitle">Create a Portfolio</h2>
       </v-col>
     </v-row>
     <br />
     <v-row>
-      <v-col cols="6" offset="2">
+      <v-col cols="6">
         <p class="p step-1">
           To get started with provisioning your cloud resources, you will need
           to set up a Portfolio. We will walk you through adding your contract
@@ -38,15 +36,15 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="2" offset="2">
+      <v-col cols="2">
         <hr class="hr step-1-divider" />
       </v-col>
     </v-row>
     <br />
     <v-row>
-      <v-col cols="6" offset="2">
+      <v-col cols="6">
         <div :icon="false" class="bg-base-lightest body-lg border px-13 py-5">
-          <v-btn class="primary" block :ripple="false" to="/wizard/step-2">
+          <v-btn class="primary" block :ripple="false" to="/wizard">
             Create a New Portfolio
           </v-btn>
         </div>

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -1,22 +1,22 @@
 <template>
-  <v-container class="view-portfolio body">
+  <v-container class="view-portfolio">
     <v-row>
-      <v-col cols="12" offset="2">
-        <h1 class="mt-5 mb-3 h1 font-weight-bold">My Porfolios WIP</h1>
+      <v-col cols="12">
+        <h1 class="mb-3 h1 font-weight-bold">My Porfolios</h1>
       </v-col>
     </v-row>
-    <v-row class="d-flex portfolio-banner">
-      <v-col class="h3" offset="2"
-        >My Portfolios</v-col
-      >
-      <v-col class="d-flex justify-space-around">
-        <v-btn class="primary" :ripple="false" to="/wizard/step-1">
-          Create a New Portfolio
-        </v-btn>
+    <v-row class="portfolio-banner">
+      <v-col class="d-flex justify-space-between align-center">
+        <div class="h3">My Portfolios</div>
+        <div>
+          <v-btn class="primary" :ripple="false" to="/wizard">
+            Create a New Portfolio
+          </v-btn>
+        </div>
       </v-col>
     </v-row>
     <v-row>
-      <v-col class="d-flex flex-row" offset="2">
+      <v-col class="d-flex flex-row">
         <v-card
           width="40rem"
           class="v-card ma-9 ml-0 body"
@@ -98,7 +98,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
-import { Portfolios } from "../../../../types/Portfolios";
+import { Portfolios } from "types/Portfolios";
 @Component({})
 export default class ViewPortfolio extends Vue {
   get portfolios(): Portfolios {

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -36,7 +36,6 @@
                 class="body font-weight-bold pa-2 ml-5 mt-4 rounded-0"
                 label
                 color="success"
-                outline
               >
                 DRAFT
               </v-chip>

--- a/src/wizard/Step1/components/CreatePorfolioForm.vue
+++ b/src/wizard/Step1/components/CreatePorfolioForm.vue
@@ -1,0 +1,17 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h3 class="h3">Create Portfolio Form Component</h3>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class CreatePorfolioForm extends Vue {}
+</script>

--- a/src/wizard/Step1/components/InvitePortfolioManagersTable.vue
+++ b/src/wizard/Step1/components/InvitePortfolioManagersTable.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h3 class="h3">Invite Portfolio Managers Table Component</h3>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12">
+        <PortfolioPermissionsMenu />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import PortfolioPermissionsMenu from "./PortfolioPermissionsMenu.vue";
+import PermissionsModal from "./PermissionsModal.vue";
+
+@Component({
+  components: {
+    PortfolioPermissionsMenu,
+    PermissionsModal 
+  },
+})
+export default class InvitePortfolioManagersTable extends Vue {}
+</script>

--- a/src/wizard/Step1/components/PermissionsModal.vue
+++ b/src/wizard/Step1/components/PermissionsModal.vue
@@ -1,11 +1,11 @@
-<!--<template></template>-->
+<template>
+  <div>Permissions Modal</div>
+</template>
 
 <script lang="ts">
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
 
 @Component({})
-export default class Step_2 extends Vue {}
+export default class PermissionsModal extends Vue {}
 </script>
-
-<style scoped></style>

--- a/src/wizard/Step1/components/PortfolioPermissionsMenu.vue
+++ b/src/wizard/Step1/components/PortfolioPermissionsMenu.vue
@@ -1,0 +1,39 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h4 class="h4">
+          Portfolio Permissions Menu Component that is to appear in each row
+        </h4>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12">
+        <PermissionsModal />
+      </v-col>
+      <v-col cols="12">
+        <RevokeInvitationModal />
+      </v-col>
+      <v-col cols="12">
+        <ResendInvitationToast />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import PermissionsModal from "./PermissionsModal.vue";
+import ResendInvitationToast from "./ResendInvitationToast.vue";
+import RevokeInvitationModal from "./RevokeInvitationModal.vue";
+
+@Component({
+  components: {
+    PermissionsModal,
+    RevokeInvitationModal,
+    ResendInvitationToast,
+  },
+})
+export default class PortfolioPermissionsMenu extends Vue {}
+</script>

--- a/src/wizard/Step1/components/ResendInvitationToast.vue
+++ b/src/wizard/Step1/components/ResendInvitationToast.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>Resend Invitation Toast Component</div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class ResendInvitationToast extends Vue {}
+</script>

--- a/src/wizard/Step1/components/RevokeInvitationModal.vue
+++ b/src/wizard/Step1/components/RevokeInvitationModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <h1>Step1</h1>
+  <div>RevokeInvitationModal</div>
 </template>
 
 <script lang="ts">
@@ -7,7 +7,5 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 
 @Component({})
-export default class Step_1 extends Vue {}
+export default class RevokeInvitationModal extends Vue {}
 </script>
-
-<style></style>

--- a/src/wizard/Step1/views/Step1.vue
+++ b/src/wizard/Step1/views/Step1.vue
@@ -1,0 +1,32 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col cols="12">
+        <h1 class="h1 step-1-title my-5font-weight-bold">Step 1</h1>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12">
+        <CreatePortfolioForm />
+      </v-col>
+      <v-col cols="12">
+        <InvitePortfolioManagersTable />
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import CreatePortfolioForm from "../components/CreatePorfolioForm.vue";
+import InvitePortfolioManagersTable from "../components/InvitePortfolioManagersTable.vue";
+
+@Component({
+  components: {
+    CreatePortfolioForm,
+    InvitePortfolioManagersTable,
+  },
+})
+export default class Step_1 extends Vue {}
+</script>

--- a/src/wizard/Step2/views/Step2.vue
+++ b/src/wizard/Step2/views/Step2.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>Step 2 View</div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class Step_2 extends Vue {}
+</script>
+
+<style scoped></style>

--- a/src/wizard/wizard.vue
+++ b/src/wizard/wizard.vue
@@ -1,0 +1,40 @@
+<template>
+  <div>
+    <v-container>
+      <v-row>
+        <v-col cols="12">
+          <Stepper />
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="12">
+          <Step1 />
+        </v-col>
+      </v-row>
+      <v-row>
+        <v-col cols="12">
+          <ButtonNavigation />
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import Stepper from "./Navigation/Stepper.vue";
+import ButtonNavigation from "./Navigation/ButtonNavigation.vue";
+import Step1 from "./Step1/views/Step1.vue";
+import Step2 from "./Step2/views/Step2.vue";
+
+@Component({
+  components: {
+    Stepper,
+    Step1,
+    Step2,
+    ButtonNavigation,
+  },
+})
+export default class Wizard extends Vue {}
+</script>


### PR DESCRIPTION
The code artifacts in the `src\wizard folder` are to be structured like as shown below to accommodate all components for Step 0 (existing View Portfolio and Create Portfolio page) and Step 1 of the wizard as well as the wizard navigation (Button Navigation & Stepper)

![image](https://user-images.githubusercontent.com/84856468/126800290-c61310b1-29c8-4ce9-a4de-ca8a705385b8.png)

Sidebar menu covers content in step1 and all other existing pages. Please fix. 