### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: daily
+  - package-ecosystem: npm
+    directory: "/cdk"
+    schedule:
+      interval: daily
+    reviewers:
+      # Since this particular directory's ownership is shared between the two
+      # teams, each team is specifically listed in reviewers to ensure both
+      # get notified of updates.
+      - dod-ccpo/platform-team
+      - dod-ccpo/portal-team
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    reviewers:
+      # Since this particular directory's ownership is shared between the two
+      # teams, each team is specifically listed in reviewers to ensure both
+      # get notified of updates.
+      - dod-ccpo/platform-team
+      - dod-ccpo/portal-team


### PR DESCRIPTION
This enables dependabot for the base project, the CDK project
separately, and for GitHub Actions. It also ensures that both teams get
notified on dependency update PRs for GitHub Actions and for the CDK by
specifying both teams as reviwers.

Ideally, we would specify the Platform team as assignees for the CDK and
GitHub Actions PRs; however, GitHub does not currently permit assigning
a PR to a particular team (only individuals).