### PR TITLE
Fix TypeScript compilation errors

### DIFF
--- a/cdk/index.ts
+++ b/cdk/index.ts
@@ -56,7 +56,7 @@ if (!util.isString(environmentParam)) {
 const environmentName = util.normalizeEnvironmentName(environmentParam);
 const environmentId = util.lowerCaseEnvironmentId(environmentParam);
 
-const spaStack = new StaticSiteStack(app, environmentName + "StaticSpa", {
+new StaticSiteStack(app, environmentName + "StaticSpa", {
   environmentId,
 });
 app.synth();

--- a/cdk/util.ts
+++ b/cdk/util.ts
@@ -44,5 +44,5 @@ export function lowerCaseEnvironmentId(id: string): string {
  * @returns true if the input is a non-empty string and false otherwise
  */
 export function isString(str: unknown): str is string {
-  return str && typeof str === "string";
+  return typeof str === "string" && !!str;
 }


### PR DESCRIPTION
It seems like these two issues made TypeScript somewhat grumpy recently.
They're trivial issues. For some reason, TypeScript's compiler is happier
to see us throw away the result of calling the stack's constructor than
to save it to a variable. And technically the type of `string &&
boolean` expression is `string | boolean` so we need to coerce the
string to a boolean and `!!str` does just fine at that.

Both of these issues prevented a successful deployment and these are the
exact changes that were deployed. I would prefer to see this merged and
resolve other issues in a followup PR.