### PR TITLE
Scroll pages to top when navigating

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3842,18 +3842,6 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
         "micromatch": {
           "version": "3.1.10",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
@@ -3934,18 +3922,6 @@
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
           "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
           "dev": true
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.5.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.5.0.tgz",
-          "integrity": "sha512-WXh+7AgFxGTgb5QAkQtFeUcHNIEq3PGVQ8WskY5ZiFbWBkOwcCPRs4w/2tVyTbh2q6TVRlO3xfvIukUtjsu62A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -4503,6 +4479,11 @@
         "@webassemblyjs/wast-parser": "1.9.0",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@webcomponents/webcomponentsjs": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.6.0.tgz",
+      "integrity": "sha512-Moog+Smx3ORTbWwuPqoclr+uvfLnciVd6wdCaVscHPrxbmQ/IJKm3wbB7hpzJtXWjAq2l/6QMlO85aZiOdtv5Q=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -7183,9 +7164,9 @@
       }
     },
     "core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q=="
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.0.tgz",
+      "integrity": "sha512-WJeQqq6jOYgVgg4NrXKL0KLQhi0CT4ZOCvFL+3CQ5o7I6J8HkT5wd53EadMfqTDp1so/MT1J+w2ujhWcCJtN7w=="
     },
     "core-js-compat": {
       "version": "3.15.2",
@@ -18632,9 +18613,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -22229,6 +22210,32 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.6.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.6.0.tgz",
+      "integrity": "sha512-0VveRdfbvvJdnFWID2X64XSABczpzItF//WRWRVta7UPP56PVIA5DdBw1TJLtDfQNIv2Sh2yZ+umGyjALuVoEg==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
         }
       }
     },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -55,6 +55,9 @@ const router = new VueRouter({
   mode: "history",
   base: process.env.BASE_URL,
   routes,
+  scrollBehavior (to, from, savedPosition) {
+    return { x: 0, y: 0 }
+  },
 });
 
 export default router;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -120,7 +120,7 @@ export default new Vuex.Store({
       state.portfolioSteps[stepIndex].model = model;
       state.portfolioSteps[stepIndex].touched = true;
 
-      const es: string[] = state.erroredSteps;
+      const es: number[] = state.erroredSteps;
       const erroredStepIndex = es.indexOf(stepNumber);
       if (erroredStepIndex > -1 && valid) {
         es.splice(erroredStepIndex, 1);
@@ -130,7 +130,7 @@ export default new Vuex.Store({
     },
 
     doSetErroredStep(state, [stepNumber, isErroredStep]) {
-      const es: string[] = state.erroredSteps;
+      const es: number[] = state.erroredSteps;
       if (isErroredStep) {
         es.push(stepNumber);
       } else {

--- a/src/wizard/Navigation/ButtonNavigation.vue
+++ b/src/wizard/Navigation/ButtonNavigation.vue
@@ -4,7 +4,7 @@
     elevation="0"
     width="100%"
     class="d-flex justify-end"
-    style="position: fixed; bottom: 40px; left: 0px"
+    style="position: fixed; bottom: 40px; left: 0px; z-index: 2;"
   >
     <v-btn
       v-for="button in pageButtonPanel.buttons"


### PR DESCRIPTION
When page loads (e.g., navigating between steps), scroll user to top of page.

Navigating between steps now scrolls user to top of next/clicked step. This behavior is app-wide, so if e.g., scrolled down to bottom of a step, clicking to dashboard or other page will scroll user to top of that page as well. 