### PR TITLE
Validate lockfileVersion during automated checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,24 @@ on:
   pull_request:
 
 jobs:
+  assertPackageLockVersion:
+    name: Ensure package-lock lockfileVersion has not changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Check package-lock.json
+        run: |
+          errors=0
+          for file in package-lock.json cdk/package-lock.json; do
+            if [ "$(cat $file | jq -r .lockfileVersion)" != "1" ]; then
+              echo "$file: lockfileVersion is invalid"
+              errors=$(( errors + 1 ))
+            else
+              echo "$file: lockfileVersion is okay"
+            fi
+          done
+          exit $errors
   lint:
     name: Lint the code base
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -293,6 +293,3 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,macos,vue,webstorm,pycharm,visualstudiocode
-
-# not relly on lock files
-package-lock.json


### PR DESCRIPTION
Adds a job to the GitHub workflow named `assertPackageLockVersion` that ensures all `package-lock.json` files in the repo consistently use a predetermined [lockfileVersion](https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#lockfileversion).

This has been in place on [dod-ccpo/atat-web-api](https://github.com/dod-ccpo/atat-web-api) for awhile now.  This stems from a conversation on stand up today.

Currently expecting lockfileVersion = 1.

This will remain the case until the repo switches to node v16 and npm 7. A migration to v2 should be considered at that time.