### PR TITLE
Update infrastructure/CDK dependencies to v1.124.0

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -4,163 +4,177 @@
     "lockfileVersion": 1,
     "dependencies": {
         "@aws-cdk/assets": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.122.0.tgz",
-            "integrity": "sha512-jNY/nXEWtoIONZnXfRr22i8PVp2JPDai4hofzu2/vnwZuJF+a+BlEI3yWzXaQMZ7ZNMnT0KSXwkaSque+1xr3g==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/assets/-/assets-1.124.0.tgz",
+            "integrity": "sha512-3ObGSa+DAwBO0B81IWuGyjIveFak/eZjARKDR0ZxWqXXotrtC2NzT/cHsscqwLzTw0WdDBT9JT/r3ib+PxzZ7g==",
             "requires": {
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-applicationautoscaling": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.122.0.tgz",
-            "integrity": "sha512-iLXCGgQPfkL/bSIbtJXN5VlEqLyK/mnu+y8TtSsZ6ls0o3et1vHSZoVZvbtmlXdP/F+MF40rSwKqVrU1cMb70A==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.124.0.tgz",
+            "integrity": "sha512-gllRWs1PzmF2b+YjexjNx5fOKGJi9MfT3ggdPl/kVBbyc7qhyC6p6RVB0Q+FcTF9p0vM7ATAJgYN3eBzlB04/w==",
             "requires": {
-                "@aws-cdk/aws-autoscaling-common": "1.122.0",
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-autoscaling-common": "1.124.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-autoscaling-common": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.122.0.tgz",
-            "integrity": "sha512-vTkBJGOHKr16S+4XOhkqvHfzapSKVJ+eHe599B2imhC5n3hui/ly6jc0aUGXT8r2yIUqGYuqVJLVW0OlHZRjBQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.124.0.tgz",
+            "integrity": "sha512-Ef+YT0GSXtkc0jTwXmNqjbUtjHXgIg5FSt4lkfWRe2DzG/AeCEZDY0s+yUJMn6tXk1ubmqgIZO/i0VhTq8nW/g==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-certificatemanager": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.122.0.tgz",
-            "integrity": "sha512-ULrOt7JJWBisQz9ImjXQT/lSvOHobNqBGLP8nXTltlIktPO1oqdtcqJGYq0+XXXRz99xmw6O9K5raDpAc/eKIQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.124.0.tgz",
+            "integrity": "sha512-BICj4/t0BTOCMvbdJtBcMmvdAgTdOrzQbfO/BLAqz0naDKINISHcN7WwwC1de3b5WCDJ+NDfQVg9RGpgKO/NkQ==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-lambda": "1.122.0",
-                "@aws-cdk/aws-route53": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-lambda": "1.124.0",
+                "@aws-cdk/aws-route53": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-cloudformation": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.122.0.tgz",
-            "integrity": "sha512-ohI6cKwqd7YuibyvBGn9I0V8hf0MU1uHQvNRBy3teMMXOVwUrJbGKeeA5uBppAlJFmGanUpgiScEOJW9FvKW7Q==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.124.0.tgz",
+            "integrity": "sha512-7VCbW7e6zN4TjQxTM7iCOkx+NxlR6C8UShYrj79f2aWAmHU1qu5zcSKXeGvsC+jy63IW4w/becqG3TsM3L/Q4A==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-lambda": "1.122.0",
-                "@aws-cdk/aws-s3": "1.122.0",
-                "@aws-cdk/aws-sns": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-lambda": "1.124.0",
+                "@aws-cdk/aws-s3": "1.124.0",
+                "@aws-cdk/aws-sns": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-cloudwatch": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.122.0.tgz",
-            "integrity": "sha512-K7kFyc5MlWTBTxQrNg32DZWGJoYXTKxjc/5i5HJBPYPNOeG+joK+3fFiG9seBmea4O3xYMHg7vbuZxcvM7AbSA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.124.0.tgz",
+            "integrity": "sha512-+CeTPF9U+lb6sR40JacovT+/fAaxxCuEa6GCOEiwDqX3vJD5zlYQ4Aj58cvuY7jUB48aavk+aSpgS/DCIepFOw==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-codeguruprofiler": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.122.0.tgz",
-            "integrity": "sha512-gwMtyzr2EjvmOuzIPSM2ooUscmGZnhh/B2Zvjrl28/4UAH6EM2kOGdnZtbzFOzUqT5XqsttVfKycPFNYQscmJQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codeguruprofiler/-/aws-codeguruprofiler-1.124.0.tgz",
+            "integrity": "sha512-KSbxNZeIkp0C9PoSCpJAgFvX5BlrjRS62L9mMwaZZ3atzlrKJdvOhUPJ512UcA+y8GrsK4AU8cKlCznEtSWcsw==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-codestarnotifications": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.122.0.tgz",
-            "integrity": "sha512-STdYT94spdxtaODanwW5M0W6V9kaJ9szpPQubYXTKnpKxZ6UCKANKMj+Fqp/zJxlXQqnuaHuMtol0nA/Xt2bfg==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-codestarnotifications/-/aws-codestarnotifications-1.124.0.tgz",
+            "integrity": "sha512-4u8Sdd5hUMgWGdEVVp7q8yb7oG0LdVtJ443fNlcx2lNjz1OnUrM7sBHeodmT+8ILxDqbP+5qglwqHSWYBzzZ+w==",
             "requires": {
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-cognito": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.122.0.tgz",
-            "integrity": "sha512-eFdW890ZLaN5c7qQ0/RqQB2Ufta3aQC5tnJzGdkEb9JQfoM/fSL0s+jmpriUHUaD0wok9la34gPq7iKq55B29g==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-cognito/-/aws-cognito-1.124.0.tgz",
+            "integrity": "sha512-/LTEwGiS9DyGygf0J5Egc3WMgeGVlWjBbORWZPBbAD/pqTZ8SYuGoK6p48MlGxn1F1XND8cQn7L+AEx+dKGwAg==",
             "requires": {
-                "@aws-cdk/aws-certificatemanager": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-lambda": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/custom-resources": "1.122.0",
+                "@aws-cdk/aws-certificatemanager": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-lambda": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/custom-resources": "1.124.0",
                 "constructs": "^3.3.69",
                 "punycode": "^2.1.1"
             },
             "dependencies": {
                 "punycode": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                    "bundled": true
                 }
             }
         },
         "@aws-cdk/aws-ec2": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.122.0.tgz",
-            "integrity": "sha512-bKJGgd3KruFeOyP/5Fc/Ufr4BHB9+xVpXVGqCeKEInkq0f4ttWhHbfKRJdYEUBEF0xwDQEj7RM6EgaV0fdfb9g==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ec2/-/aws-ec2-1.124.0.tgz",
+            "integrity": "sha512-G7h7jhbK5DUrPvxb7DXh3/ZPR1UtVaek6Hgd7/gV1oySbCEmxkPcJuODB/4rWe7CJHDNZJm1K1fldB1lDjpBsQ==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-logs": "1.122.0",
-                "@aws-cdk/aws-s3": "1.122.0",
-                "@aws-cdk/aws-s3-assets": "1.122.0",
-                "@aws-cdk/aws-ssm": "1.122.0",
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
-                "@aws-cdk/region-info": "1.122.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-logs": "1.124.0",
+                "@aws-cdk/aws-s3": "1.124.0",
+                "@aws-cdk/aws-s3-assets": "1.124.0",
+                "@aws-cdk/aws-ssm": "1.124.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
+                "@aws-cdk/region-info": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-ecr": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.122.0.tgz",
-            "integrity": "sha512-FxM7Q/6VHquOdfWrKQArzs/91fxvZFwT/FkPIrEm+X10/voOFI6S6xRXaOlr2UVn6dji6J6DssY7YBvJq1ciOQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr/-/aws-ecr-1.124.0.tgz",
+            "integrity": "sha512-0MjU7r4CdGvKDcQHfwopihTBXE72Mnr05mmanZPOZ6JL1PwHqLGaeRODgaVF1v4GAw5v3zDoKx+LThCq833CUg==",
             "requires": {
-                "@aws-cdk/aws-events": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-events": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-ecr-assets": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.122.0.tgz",
-            "integrity": "sha512-BFYCNsUs/1Dlh41bXmFmq41RpNatqm/KHfIWA0eFNIAuG/IqOga9LF71zCBiqv4gfNmfGQg19Sq2BojGQwisVA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.124.0.tgz",
+            "integrity": "sha512-wsajG5+wqwZ9+0dS18bCtVe4X6noJT8WKNNoe8nSk2UkUZwtt0J56Y9P7qtCrnMQFysBjIH0EP7jT6BUIAq01Q==",
             "requires": {
-                "@aws-cdk/assets": "1.122.0",
-                "@aws-cdk/aws-ecr": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-s3": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/assets": "1.124.0",
+                "@aws-cdk/aws-ecr": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-s3": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69",
                 "minimatch": "^3.0.4"
             },
             "dependencies": {
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "bundled": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -168,230 +182,244 @@
             }
         },
         "@aws-cdk/aws-efs": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.122.0.tgz",
-            "integrity": "sha512-CFvqAVv2BX31j+tGxM2a8CaTbf2QqMoeegORRJzipykeX+wCPu/5nYA7jWOXlCLYZ2MnLRHaAZzzVtLRvgNSWw==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-efs/-/aws-efs-1.124.0.tgz",
+            "integrity": "sha512-bhzFlyTcFTxPO4eEqHh06DFR7kxqtUcTZe9Wbd/gGrksJIU6LpmFOvGzuxBtDb/YyrjQmDc3yU+aeQo9htCm6A==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/aws-ec2": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-events": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.122.0.tgz",
-            "integrity": "sha512-Nc6flYv4Z0P6yK0rIhuUnjsOVEucgv0WdV7va3WzPzp8B253ea0XdLfpSJxGArKAH6qcmCJmd07ls+N2omzFBg==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-events/-/aws-events-1.124.0.tgz",
+            "integrity": "sha512-zF1RWh6YdGdns0zbym6b3mnp0LNsX0lPfyronHHZuHcybnPFLaCbHyUUZaw2iKnztIid4tGxnpKgxkfBIr/MsQ==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-iam": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.122.0.tgz",
-            "integrity": "sha512-IGPA+m45NFZijzRgXpKeKemt2+8Yba7Se1ru1/h7t2obhpdw/tcsTLhkBVagWGjSyw7zfVDIEJZTe5y5lxyQbw==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-iam/-/aws-iam-1.124.0.tgz",
+            "integrity": "sha512-fuN+M7y/t8GH9KVgui84yTCM1zz7m/MZU/8a8lggkiP9j0d/wKiDq/vtiyvuNvPr0Mow9gFOB1y3DCunF48IwQ==",
             "requires": {
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/region-info": "1.122.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/region-info": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-kms": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.122.0.tgz",
-            "integrity": "sha512-oVaHgb5L4MXVt/mb1HpDr1dgVuyBNjbVe2To8WOuY1Iah6on7dh725479IObSw72lLS/5STo8XOAGKZ9h0aobA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-kms/-/aws-kms-1.124.0.tgz",
+            "integrity": "sha512-fsJCcRGZFGRruK0o3LbklHtMGV4rEvmDRLkEbWXu/U8sfn2uEF7MfdQHKjpVhkNT33pGTeEwYUO+vneZZsXfew==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-lambda": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.122.0.tgz",
-            "integrity": "sha512-tAJqGEfyrdVebq99V5vCYg8y/6lhcRlhIbSPRn4h3tKzkSfOhiXqRZD+0qfBA1nF6l64oWI5K+Y2N3DyQEemXg==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-lambda/-/aws-lambda-1.124.0.tgz",
+            "integrity": "sha512-45Ttb6JCgDAlKXc3KR2dCUVM/SCkO2YArsI/mSWb7ECt676c4Ykhmaz/Zvrnl/3/21KVkG1hjLEY7ZoLa1ExNQ==",
             "requires": {
-                "@aws-cdk/aws-applicationautoscaling": "1.122.0",
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-codeguruprofiler": "1.122.0",
-                "@aws-cdk/aws-ec2": "1.122.0",
-                "@aws-cdk/aws-ecr": "1.122.0",
-                "@aws-cdk/aws-ecr-assets": "1.122.0",
-                "@aws-cdk/aws-efs": "1.122.0",
-                "@aws-cdk/aws-events": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-logs": "1.122.0",
-                "@aws-cdk/aws-s3": "1.122.0",
-                "@aws-cdk/aws-s3-assets": "1.122.0",
-                "@aws-cdk/aws-signer": "1.122.0",
-                "@aws-cdk/aws-sqs": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
-                "@aws-cdk/region-info": "1.122.0",
+                "@aws-cdk/aws-applicationautoscaling": "1.124.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-codeguruprofiler": "1.124.0",
+                "@aws-cdk/aws-ec2": "1.124.0",
+                "@aws-cdk/aws-ecr": "1.124.0",
+                "@aws-cdk/aws-ecr-assets": "1.124.0",
+                "@aws-cdk/aws-efs": "1.124.0",
+                "@aws-cdk/aws-events": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-logs": "1.124.0",
+                "@aws-cdk/aws-s3": "1.124.0",
+                "@aws-cdk/aws-s3-assets": "1.124.0",
+                "@aws-cdk/aws-signer": "1.124.0",
+                "@aws-cdk/aws-sqs": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
+                "@aws-cdk/region-info": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-logs": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.122.0.tgz",
-            "integrity": "sha512-AKoqNClzvkjcFQYJoYZ9VpjmQfqVtGIJ9pTrOlfWQJV+MI7H2wyK5hiX5gOWDOyd1fqXtGTdrI/fvfIbDo2UQQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-logs/-/aws-logs-1.124.0.tgz",
+            "integrity": "sha512-V5SnKmueSkgzMMJH+8SWWUFp3eQjmplNDGRjXfgBVYcrQU3AAvMw9KzP+PfFnjUBH40RUFyGIhPnCH4X+yTngA==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-s3-assets": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-s3-assets": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-route53": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.122.0.tgz",
-            "integrity": "sha512-rGuohz5NyujKGS2pnS78DsFS7ucvcvlzKVnah62LHYdZq9MO6ZfHpa79d1zWaeyOOS3ELD2nopAeLIfE84pEUQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-route53/-/aws-route53-1.124.0.tgz",
+            "integrity": "sha512-HgCzDT6GmwV8M305yS5lDGXlIC/jopLBPysxd8lOJ1Os8f/BDKtPg2upFUj0g6j0N5qUsgihftLSVpsKvB2SFg==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-logs": "1.122.0",
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/custom-resources": "1.122.0",
+                "@aws-cdk/aws-ec2": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-logs": "1.124.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/custom-resources": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-s3": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.122.0.tgz",
-            "integrity": "sha512-QveBi5KrUusyEc9Ap3998Gs6gUq5H5FQeYAHX+bDIsYgwOWajVStYpzefPfjnAR5TuH8+hXWVFaDzY7BaID4Uw==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3/-/aws-s3-1.124.0.tgz",
+            "integrity": "sha512-9S0NZrIMX9wf2snJZVrumR3eSTExAznFBA/vgnVfGulcp9O+U81TEygHPORWSSB23pUGk2e0tDRQHKsrZ4v/aA==",
             "requires": {
-                "@aws-cdk/aws-events": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/aws-events": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-s3-assets": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.122.0.tgz",
-            "integrity": "sha512-+Zqt3lK4fXoAUmGFGI5dKGe3ErwOIBrZlejTsXcO7DbrBYXGu2Wxpk3yMgsDkkSyP2uXyEnhxSqCahZOS2vRZQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.124.0.tgz",
+            "integrity": "sha512-tl6AyIOIWWbLcBP1jjaWIkSiG3n0L9UhDJzrD68rybNKS6qOdxlcQqvNbsZWBBmZrypU+AjlhY5vx40WbDficQ==",
             "requires": {
-                "@aws-cdk/assets": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-s3": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/assets": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-s3": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-sam": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.122.0.tgz",
-            "integrity": "sha512-POuc49ctbNHMnbEdA7vR2h2e+tWasmmYtl2vBYlGqMRNXsBm+o6LvE9+x7/kAcJArGbVB9U42FebcdQN8kAdew==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sam/-/aws-sam-1.124.0.tgz",
+            "integrity": "sha512-5yQsH3FNp+Mc4FdNwtrG1uRGqzXFSZEcds0FeVs338wDYLPDMnBe4kZzmOO4hY7d7siKP3E5tn+v8cSGvTUiSA==",
             "requires": {
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-secretsmanager": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.122.0.tgz",
-            "integrity": "sha512-wsmsD4z+SSrljj0u3Nk9/xLzcRusCTxGO4JrlC4gTn5YwIhSqDbsxOauSLRHnM+/tOE6C+t5vOfFd3ZrV2YH9Q==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.124.0.tgz",
+            "integrity": "sha512-rZt1Jo2u83YE4TbaqZmoxaWYfPNNr+Me56AzqfRmKiLmxjxuHIgymoqMx+KTO5Ag3eOw6t6F8MRmk1dX+svfgw==",
             "requires": {
-                "@aws-cdk/aws-ec2": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-lambda": "1.122.0",
-                "@aws-cdk/aws-sam": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
+                "@aws-cdk/aws-ec2": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-lambda": "1.124.0",
+                "@aws-cdk/aws-sam": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-signer": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.122.0.tgz",
-            "integrity": "sha512-6J59KrTKtOyH1i3MxQ/9zIfYIocUgGZdqyq9cV7srZ6yUSQp1s3xR+b7LWbBUxs3UMMLXTwchhX/Birc5mXsUg==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-signer/-/aws-signer-1.124.0.tgz",
+            "integrity": "sha512-wxZxzCSAcb1WCzikiUh3KYvW8b2L0/lh77R+54rbWQYgKhUlQn+DF3IK4ngg7vVFBXtYgIKxEY2Mqf3AqbW0fw==",
             "requires": {
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-sns": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.122.0.tgz",
-            "integrity": "sha512-nAB4eMJI4tHBsLjsLdPmwhkZkl1M8t9JFv6L1VdH6Y0yxz8V4fVOkPf2btovmVQ/oyniHX+DPkJzmyGw8lnsjQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sns/-/aws-sns-1.124.0.tgz",
+            "integrity": "sha512-cG1VyT6jM9SARw8aqPMdLtjbta1+hPhlFgyuAln8PvwhHSHPSyDDvkojd7zcxvVzELRj64IQ8HZ5l07JT76t+Q==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-codestarnotifications": "1.122.0",
-                "@aws-cdk/aws-events": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/aws-sqs": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-codestarnotifications": "1.124.0",
+                "@aws-cdk/aws-events": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/aws-sqs": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-sqs": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.122.0.tgz",
-            "integrity": "sha512-ZamVuEfLMj8JpidjqbYR6jiAIvc8yl/WUoDS73nrypWFZf5G9IF7dDPMZ6NXGKnwF6WUD629UpUNgB7grmB4Qg==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-sqs/-/aws-sqs-1.124.0.tgz",
+            "integrity": "sha512-yUOe+jC5fi+NHOEr3f5UHLJJxW2HRdE4aUjlF1wsAa+kwG9lecN4TlP2POTkZm0SkXeaA/4WHhhimDxKy54Djg==",
             "requires": {
-                "@aws-cdk/aws-cloudwatch": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-cloudwatch": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/aws-ssm": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.122.0.tgz",
-            "integrity": "sha512-yoB4tUeV8GgA2MylEMAXlJQUbD9mvOUoZk9zTEGmNyjhpTZBGB24YbBfeoqnq2Igh9PfAlNZkPtguGp/tPZVJQ==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/aws-ssm/-/aws-ssm-1.124.0.tgz",
+            "integrity": "sha512-41mopAh9ZTg3SL04P0WOO1d3sCDYJL3A/fPWCxDuzizSojdI2EWqvKf/5Lu1NY1jYZG+2ls7xqgG4b8x9BDILw==",
             "requires": {
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-kms": "1.122.0",
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-kms": "1.124.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/cloud-assembly-schema": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.122.0.tgz",
-            "integrity": "sha512-xyVIaRZbQEoVI8VPbgreK18o0BVVthavn3zUKw6p+S1NF+FMgqatTLU0pq+bMLOHwI/zyNKuZs3KhBoMLyhZMA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.124.0.tgz",
+            "integrity": "sha512-emrkfHetGoh6lhrT7ato06VAZun1UVYjJueL9avHxFgzX5qiobP4iWk6M0EZpk7yHlDOtJtp86MJalYYMS6Oww==",
             "requires": {
                 "jsonschema": "^1.4.0",
                 "semver": "^7.3.5"
             },
             "dependencies": {
+                "jsonschema": {
+                    "version": "1.4.0",
+                    "bundled": true
+                },
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "semver": {
                     "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "bundled": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "bundled": true
                 }
             }
         },
         "@aws-cdk/core": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.122.0.tgz",
-            "integrity": "sha512-8yQmOH1e4YvL/MVIDQj2JS1YeijIePshP2fPw7X5iP4tdLcPcHPTXHXJAp2ARF7XL5u03juVENn/hG7G0B91nw==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/core/-/core-1.124.0.tgz",
+            "integrity": "sha512-QsTLvOuF+WJdtF11Bwuh+THWry7OmErs3XDaiHFweZPLMc2O3EEQvCgSKstH7Y9HUTpW7ZSGQHryxCjpTl1Wmg==",
             "requires": {
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
-                "@aws-cdk/region-info": "1.122.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
+                "@aws-cdk/region-info": "1.124.0",
                 "@balena/dockerignore": "^1.0.2",
                 "constructs": "^3.3.69",
                 "fs-extra": "^9.1.0",
@@ -399,59 +427,117 @@
                 "minimatch": "^3.0.4"
             },
             "dependencies": {
+                "@balena/dockerignore": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "at-least-node": {
+                    "version": "1.0.0",
+                    "bundled": true
+                },
+                "balanced-match": {
+                    "version": "1.0.2",
+                    "bundled": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.11",
+                    "bundled": true,
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true
+                },
+                "fs-extra": {
+                    "version": "9.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "at-least-node": "^1.0.0",
+                        "graceful-fs": "^4.2.0",
+                        "jsonfile": "^6.0.1",
+                        "universalify": "^2.0.0"
+                    }
+                },
+                "graceful-fs": {
+                    "version": "4.2.6",
+                    "bundled": true
+                },
                 "ignore": {
                     "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+                    "bundled": true
+                },
+                "jsonfile": {
+                    "version": "6.1.0",
+                    "bundled": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.6",
+                        "universalify": "^2.0.0"
+                    }
                 },
                 "minimatch": {
                     "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+                    "bundled": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
+                },
+                "universalify": {
+                    "version": "2.0.0",
+                    "bundled": true
                 }
             }
         },
         "@aws-cdk/custom-resources": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.122.0.tgz",
-            "integrity": "sha512-vdipr6cpCIYl0lokS0HQI3kY34mqpxns82+MzqYc95xZ7HPYOjnP0aKqL+UKIpaQsTVVUkOqfxZ9cXNdv04Xag==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/custom-resources/-/custom-resources-1.124.0.tgz",
+            "integrity": "sha512-sR9igvDNXTscRs3YjXab32u5vs1SLtOr6pxxnzxt53wZ6vkzOwEUGpXMY5seXd/IWKe5vV1LhTfFZ+U+lG7tsQ==",
             "requires": {
-                "@aws-cdk/aws-cloudformation": "1.122.0",
-                "@aws-cdk/aws-ec2": "1.122.0",
-                "@aws-cdk/aws-iam": "1.122.0",
-                "@aws-cdk/aws-lambda": "1.122.0",
-                "@aws-cdk/aws-logs": "1.122.0",
-                "@aws-cdk/aws-sns": "1.122.0",
-                "@aws-cdk/core": "1.122.0",
+                "@aws-cdk/aws-cloudformation": "1.124.0",
+                "@aws-cdk/aws-ec2": "1.124.0",
+                "@aws-cdk/aws-iam": "1.124.0",
+                "@aws-cdk/aws-lambda": "1.124.0",
+                "@aws-cdk/aws-logs": "1.124.0",
+                "@aws-cdk/aws-sns": "1.124.0",
+                "@aws-cdk/core": "1.124.0",
                 "constructs": "^3.3.69"
             }
         },
         "@aws-cdk/cx-api": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.122.0.tgz",
-            "integrity": "sha512-x2SPWc3RNBWi5UBdq/gZvW5He9X5NRb2j9pcBcUPhVSSEB7Fl5lqPU82q8mBy+76zHkfWILpLGJr/jNQ4ZRAeA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.124.0.tgz",
+            "integrity": "sha512-InBcAoFJ0Ail7/IhJhhw2OwGyWgBv4HShRA20/czxvlQ2pOezcUxQOCJr5USM6dGvTOlDL38XVrw469m9boUzw==",
             "requires": {
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
                 "semver": "^7.3.5"
             },
             "dependencies": {
+                "lru-cache": {
+                    "version": "6.0.0",
+                    "bundled": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
                 "semver": {
                     "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "bundled": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
+                },
+                "yallist": {
+                    "version": "4.0.0",
+                    "bundled": true
                 }
             }
         },
         "@aws-cdk/region-info": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.122.0.tgz",
-            "integrity": "sha512-6nFk66RE+PYh85aU07tA3TxsfKUHZZxnPITidwnyJYZ2OgimxMRIuWQce1bSLkZrcaQhachcJTJ1o8mF20kJmg=="
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.124.0.tgz",
+            "integrity": "sha512-v8Msal5kCv5Juscj6Dxjzx4HHiYKD3rWDLBAvaDN/V3zCNGga3s8M2aM/n7po7HLjVW333VzyuOCHBYnSrtMIg=="
         },
         "@babel/code-frame": {
             "version": "7.12.11",
@@ -463,9 +549,9 @@
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.14.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-            "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
+            "version": "7.15.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+            "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
             "dev": true
         },
         "@babel/highlight": {
@@ -497,11 +583,6 @@
                     "dev": true
                 }
             }
-        },
-        "@balena/dockerignore": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
-            "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="
         },
         "@eslint/eslintrc": {
             "version": "0.4.3",
@@ -584,19 +665,19 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.9.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
-            "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==",
+            "version": "16.9.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.6.tgz",
+            "integrity": "sha512-YHUZhBOMTM3mjFkXVcK+WwAcYmyhe1wL4lfqNtzI0b3qAy7yuSetnM7QJazgE5PFmgVTNGiLOgRFfJMqW7XpSQ==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.1.tgz",
-            "integrity": "sha512-UDqhWmd5i0TvPLmbK5xY3UZB0zEGseF+DHPghZ37Sb83Qd3p8ujhvAtkU4OF46Ka5Pm5kWvFIx0cCTBFKo0alA==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.31.2.tgz",
+            "integrity": "sha512-w63SCQ4bIwWN/+3FxzpnWrDjQRXVEGiTt9tJTRptRXeFvdZc/wLiz3FQUwNQ2CVoRGI6KUWMNUj/pk63noUfcA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "4.31.1",
-                "@typescript-eslint/scope-manager": "4.31.1",
+                "@typescript-eslint/experimental-utils": "4.31.2",
+                "@typescript-eslint/scope-manager": "4.31.2",
                 "debug": "^4.3.1",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.1.0",
@@ -605,55 +686,55 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.1.tgz",
-            "integrity": "sha512-NtoPsqmcSsWty0mcL5nTZXMf7Ei0Xr2MT8jWjXMVgRK0/1qeQ2jZzLFUh4QtyJ4+/lPUyMw5cSfeeME+Zrtp9Q==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.31.2.tgz",
+            "integrity": "sha512-3tm2T4nyA970yQ6R3JZV9l0yilE2FedYg8dcXrTar34zC9r6JB7WyBQbpIVongKPlhEMjhQ01qkwrzWy38Bk1Q==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.7",
-                "@typescript-eslint/scope-manager": "4.31.1",
-                "@typescript-eslint/types": "4.31.1",
-                "@typescript-eslint/typescript-estree": "4.31.1",
+                "@typescript-eslint/scope-manager": "4.31.2",
+                "@typescript-eslint/types": "4.31.2",
+                "@typescript-eslint/typescript-estree": "4.31.2",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.1.tgz",
-            "integrity": "sha512-dnVZDB6FhpIby6yVbHkwTKkn2ypjVIfAR9nh+kYsA/ZL0JlTsd22BiDjouotisY3Irmd3OW1qlk9EI5R8GrvRQ==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.31.2.tgz",
+            "integrity": "sha512-EcdO0E7M/sv23S/rLvenHkb58l3XhuSZzKf6DBvLgHqOYdL6YFMYVtreGFWirxaU2mS1GYDby3Lyxco7X5+Vjw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "4.31.1",
-                "@typescript-eslint/types": "4.31.1",
-                "@typescript-eslint/typescript-estree": "4.31.1",
+                "@typescript-eslint/scope-manager": "4.31.2",
+                "@typescript-eslint/types": "4.31.2",
+                "@typescript-eslint/typescript-estree": "4.31.2",
                 "debug": "^4.3.1"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.1.tgz",
-            "integrity": "sha512-N1Uhn6SqNtU2XpFSkD4oA+F0PfKdWHyr4bTX0xTj8NRx1314gBDRL1LUuZd5+L3oP+wo6hCbZpaa1in6SwMcVQ==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.31.2.tgz",
+            "integrity": "sha512-2JGwudpFoR/3Czq6mPpE8zBPYdHWFGL6lUNIGolbKQeSNv4EAiHaR5GVDQaLA0FwgcdcMtRk+SBJbFGL7+La5w==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.31.1",
-                "@typescript-eslint/visitor-keys": "4.31.1"
+                "@typescript-eslint/types": "4.31.2",
+                "@typescript-eslint/visitor-keys": "4.31.2"
             }
         },
         "@typescript-eslint/types": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.1.tgz",
-            "integrity": "sha512-kixltt51ZJGKENNW88IY5MYqTBA8FR0Md8QdGbJD2pKZ+D5IvxjTYDNtJPDxFBiXmka2aJsITdB1BtO1fsgmsQ==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.31.2.tgz",
+            "integrity": "sha512-kWiTTBCTKEdBGrZKwFvOlGNcAsKGJSBc8xLvSjSppFO88AqGxGNYtF36EuEYG6XZ9vT0xX8RNiHbQUKglbSi1w==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.1.tgz",
-            "integrity": "sha512-EGHkbsUvjFrvRnusk6yFGqrqMBTue5E5ROnS5puj3laGQPasVUgwhrxfcgkdHNFECHAewpvELE1Gjv0XO3mdWg==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.31.2.tgz",
+            "integrity": "sha512-ieBq8U9at6PvaC7/Z6oe8D3czeW5d//Fo1xkF/s9394VR0bg/UaMYPdARiWyKX+lLEjY3w/FNZJxitMsiWv+wA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.31.1",
-                "@typescript-eslint/visitor-keys": "4.31.1",
+                "@typescript-eslint/types": "4.31.2",
+                "@typescript-eslint/visitor-keys": "4.31.2",
                 "debug": "^4.3.1",
                 "globby": "^11.0.3",
                 "is-glob": "^4.0.1",
@@ -662,12 +743,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "4.31.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.1.tgz",
-            "integrity": "sha512-PCncP8hEqKw6SOJY+3St4LVtoZpPPn+Zlpm7KW5xnviMhdqcsBty4Lsg4J/VECpJjw1CkROaZhH4B8M1OfnXTQ==",
+            "version": "4.31.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.31.2.tgz",
+            "integrity": "sha512-PrBId7EQq2Nibns7dd/ch6S6/M4/iwLM9McbgeEbCXfxdwRUNxJ4UNreJ6Gh3fI2GNKNrWnQxKL7oCPmngKBug==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "4.31.1",
+                "@typescript-eslint/types": "4.31.2",
                 "eslint-visitor-keys": "^2.0.0"
             }
         },
@@ -702,9 +783,9 @@
             "dev": true
         },
         "ansi-regex": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true
         },
         "ansi-styles": {
@@ -761,25 +842,20 @@
             "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
             "dev": true
         },
-        "at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-        },
         "aws-cdk": {
-            "version": "1.122.0",
-            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.122.0.tgz",
-            "integrity": "sha512-AdWTa0Oxkcz51Cm6sdYwtTB0NQ32j8UW34W2C9Z2G5G8SMUSJd4tH+RS+XEHNaYyYLGaP+Gpvajt+cDviOIBjA==",
+            "version": "1.124.0",
+            "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-1.124.0.tgz",
+            "integrity": "sha512-6Wu4hG0I1xLOBoXIVYTCAccdk3cZpP/V9hP3Julzn9tvKV2agBIhQaENB3fYwaH8Ej2fcRkqfN4Ut0vqLJtdDA==",
             "requires": {
-                "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                "@aws-cdk/cloudformation-diff": "1.122.0",
-                "@aws-cdk/cx-api": "1.122.0",
-                "@aws-cdk/region-info": "1.122.0",
+                "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                "@aws-cdk/cloudformation-diff": "1.124.0",
+                "@aws-cdk/cx-api": "1.124.0",
+                "@aws-cdk/region-info": "1.124.0",
                 "@jsii/check-node": "1.33.0",
                 "archiver": "^5.3.0",
                 "aws-sdk": "^2.979.0",
                 "camelcase": "^6.2.0",
-                "cdk-assets": "1.122.0",
+                "cdk-assets": "1.124.0",
                 "colors": "^1.4.0",
                 "decamelize": "^5.0.0",
                 "fs-extra": "^9.1.0",
@@ -787,7 +863,7 @@
                 "json-diff": "^0.5.4",
                 "minimatch": ">=3.0",
                 "promptly": "^3.2.0",
-                "proxy-agent": "^4.0.1",
+                "proxy-agent": "^5.0.0",
                 "semver": "^7.3.5",
                 "source-map-support": "^0.5.19",
                 "table": "^6.7.1",
@@ -798,28 +874,28 @@
             },
             "dependencies": {
                 "@aws-cdk/cfnspec": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.122.0.tgz",
-                    "integrity": "sha512-41CyWYJLfWfQbJWONNwu1FBIsDfDn3r/0pukc+Bkrsmx2zcPRY/JW+THyFZCyG5x1lO6T4XfGRuF2DfCehLaOQ==",
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cfnspec/-/cfnspec-1.124.0.tgz",
+                    "integrity": "sha512-H0Yhx9I8hHLBvoRclOj61kALh3jYQssHK6iL9wlEHPs51Gq32GjWJCwqBx+2pEbp6oUpSsUIPw4XbGCEpj7PuA==",
                     "requires": {
                         "md5": "^2.3.0"
                     }
                 },
                 "@aws-cdk/cloud-assembly-schema": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.122.0.tgz",
-                    "integrity": "sha512-xyVIaRZbQEoVI8VPbgreK18o0BVVthavn3zUKw6p+S1NF+FMgqatTLU0pq+bMLOHwI/zyNKuZs3KhBoMLyhZMA==",
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-1.124.0.tgz",
+                    "integrity": "sha512-emrkfHetGoh6lhrT7ato06VAZun1UVYjJueL9avHxFgzX5qiobP4iWk6M0EZpk7yHlDOtJtp86MJalYYMS6Oww==",
                     "requires": {
                         "jsonschema": "^1.4.0",
                         "semver": "^7.3.5"
                     }
                 },
                 "@aws-cdk/cloudformation-diff": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.122.0.tgz",
-                    "integrity": "sha512-syTS6fPd0IASzsOGJUbZtpPzHhW0aTtoPauN4NK7T2ynyEGVMmdW5vikdWBt3Kg5mkTTVvxQix7r1aLiQyMYIw==",
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.124.0.tgz",
+                    "integrity": "sha512-gUmhwfHE/AolTiVtjPCJGf0Gsp5nV+PDAtcJ7ZtjrLMJ2vIKonT29qbeFclyw8EBCCfX5SLH7ByeaUiFFocj2w==",
                     "requires": {
-                        "@aws-cdk/cfnspec": "1.122.0",
+                        "@aws-cdk/cfnspec": "1.124.0",
                         "@types/node": "^10.17.60",
                         "colors": "^1.4.0",
                         "diff": "^5.0.0",
@@ -829,18 +905,18 @@
                     }
                 },
                 "@aws-cdk/cx-api": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.122.0.tgz",
-                    "integrity": "sha512-x2SPWc3RNBWi5UBdq/gZvW5He9X5NRb2j9pcBcUPhVSSEB7Fl5lqPU82q8mBy+76zHkfWILpLGJr/jNQ4ZRAeA==",
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/cx-api/-/cx-api-1.124.0.tgz",
+                    "integrity": "sha512-InBcAoFJ0Ail7/IhJhhw2OwGyWgBv4HShRA20/czxvlQ2pOezcUxQOCJr5USM6dGvTOlDL38XVrw469m9boUzw==",
                     "requires": {
-                        "@aws-cdk/cloud-assembly-schema": "1.122.0",
+                        "@aws-cdk/cloud-assembly-schema": "1.124.0",
                         "semver": "^7.3.5"
                     }
                 },
                 "@aws-cdk/region-info": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.122.0.tgz",
-                    "integrity": "sha512-6nFk66RE+PYh85aU07tA3TxsfKUHZZxnPITidwnyJYZ2OgimxMRIuWQce1bSLkZrcaQhachcJTJ1o8mF20kJmg=="
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/@aws-cdk/region-info/-/region-info-1.124.0.tgz",
+                    "integrity": "sha512-v8Msal5kCv5Juscj6Dxjzx4HHiYKD3rWDLBAvaDN/V3zCNGga3s8M2aM/n7po7HLjVW333VzyuOCHBYnSrtMIg=="
                 },
                 "@jsii/check-node": {
                     "version": "1.33.0",
@@ -1067,12 +1143,12 @@
                     "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
                 },
                 "cdk-assets": {
-                    "version": "1.122.0",
-                    "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.122.0.tgz",
-                    "integrity": "sha512-AbJgrROkwj0hmFLcCtqxJLTAVqFyMP+rIS9XM9nfrEIgoNzJnmy1KgJneuXNA9U7dquSFlTPYfAoy2UCTrryBw==",
+                    "version": "1.124.0",
+                    "resolved": "https://registry.npmjs.org/cdk-assets/-/cdk-assets-1.124.0.tgz",
+                    "integrity": "sha512-QKwXVPfXYbqwmJY+IvJRWZl5CEjUCz3kl7jPTul2KrTC2CvJ3f9JKc9qu2PIv6R8ITVjIKPPZnB/dVvzeBZHrw==",
                     "requires": {
-                        "@aws-cdk/cloud-assembly-schema": "1.122.0",
-                        "@aws-cdk/cx-api": "1.122.0",
+                        "@aws-cdk/cloud-assembly-schema": "1.124.0",
+                        "@aws-cdk/cx-api": "1.124.0",
                         "archiver": "^5.3.0",
                         "aws-sdk": "^2.848.0",
                         "glob": "^7.1.7",
@@ -1245,13 +1321,14 @@
                     "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
                 },
                 "degenerator": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.yarnpkg.com/degenerator/-/degenerator-2.2.0.tgz#49e98c11fa0293c5b26edfbb52f15729afcdb254",
-                    "integrity": "sha512-aiQcQowF01RxFI4ZLFMpzyotbQonhNpBao6dkI8JPk5a+hmSjR5ErHp2CQySmQe8os3VBqLCIh87nDBgZXvsmg==",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.yarnpkg.com/degenerator/-/degenerator-3.0.1.tgz#7ef78ec0c8577a544477308ddf1d2d6e88d51f5b",
+                    "integrity": "sha512-LFsIFEeLPlKvAKXu7j3ssIG6RT0TbI7/GhsqrI0DnHASEQjXQ0LUSYcjJteGgRGmZbl1TnMSxpNQIAiJ7Du5TQ==",
                     "requires": {
                         "ast-types": "^0.13.2",
                         "escodegen": "^1.8.1",
-                        "esprima": "^4.0.0"
+                        "esprima": "^4.0.0",
+                        "vm2": "^3.9.3"
                     }
                 },
                 "depd": {
@@ -1732,9 +1809,9 @@
                     }
                 },
                 "pac-proxy-agent": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-4.1.0.tgz#66883eeabadc915fc5e95457324cb0f0ac78defb",
-                    "integrity": "sha512-ejNgYm2HTXSIYX9eFlkvqFp8hyJ374uDf0Zq5YUAifiSh1D6fo+iBivQZirGvVv8dCYUsLhmLBRhlAYvBKI5+Q==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-5.0.0.tgz#b718f76475a6a5415c2efbe256c1c971c84f635e",
+                    "integrity": "sha512-CcFG3ZtnxO8McDigozwE3AqAw15zDvGH+OjXO4kzf7IkEKkQ4gxQ+3sdF50WmhQ4P/bVusXcqNE2S3XrNURwzQ==",
                     "requires": {
                         "@tootallnate/once": "1",
                         "agent-base": "6",
@@ -1742,17 +1819,17 @@
                         "get-uri": "3",
                         "http-proxy-agent": "^4.0.1",
                         "https-proxy-agent": "5",
-                        "pac-resolver": "^4.1.0",
+                        "pac-resolver": "^5.0.0",
                         "raw-body": "^2.2.0",
                         "socks-proxy-agent": "5"
                     }
                 },
                 "pac-resolver": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-4.2.0.tgz#b82bcb9992d48166920bc83c7542abb454bd9bdd",
-                    "integrity": "sha512-rPACZdUyuxT5Io/gFKUeeZFfE5T7ve7cAkE5TUZRRfuKP0u5Hocwe48X7ZEm6mYB+bTB0Qf+xlVlA/RM/i6RCQ==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-5.0.0.tgz#1d717a127b3d7a9407a16d6e1b012b13b9ba8dc0",
+                    "integrity": "sha512-H+/A6KitiHNNW+bxBKREk2MCGSxljfqRX76NjummWEYIat7ldVXRU3dhRIE3iXZ0nvGBk6smv3nntxKkzRL8NA==",
                     "requires": {
-                        "degenerator": "^2.2.0",
+                        "degenerator": "^3.0.1",
                         "ip": "^1.1.5",
                         "netmask": "^2.0.1"
                     }
@@ -1786,16 +1863,16 @@
                     }
                 },
                 "proxy-agent": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-4.0.1.tgz#326c3250776c7044cd19655ccbfadf2e065a045c",
-                    "integrity": "sha512-ODnQnW2jc/FUVwHHuaZEfN5otg/fMbvMxz9nMSUQfJ9JU7q2SZvSULSsjLloVgJOiv9yhc8GlNMKc4GkFmcVEA==",
+                    "version": "5.0.0",
+                    "resolved": "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-5.0.0.tgz#d31405c10d6e8431fde96cba7a0c027ce01d633b",
+                    "integrity": "sha512-gkH7BkvLVkSfX9Dk27W6TyNOWWZWRilRfk1XxGNWOYJ2TuedAv1yFpCaU9QSBmBe716XOTNpYNOzhysyw8xn7g==",
                     "requires": {
                         "agent-base": "^6.0.0",
                         "debug": "4",
                         "http-proxy-agent": "^4.0.0",
                         "https-proxy-agent": "^5.0.0",
                         "lru-cache": "^5.1.1",
-                        "pac-proxy-agent": "^4.1.0",
+                        "pac-proxy-agent": "^5.0.0",
                         "proxy-from-env": "^1.0.0",
                         "socks-proxy-agent": "^5.0.0"
                     },
@@ -2094,6 +2171,11 @@
                     "resolved": "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2",
                     "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
                 },
+                "vm2": {
+                    "version": "3.9.3",
+                    "resolved": "https://registry.yarnpkg.com/vm2/-/vm2-3.9.3.tgz#29917f6cc081cc43a3f580c26c5b553fd3c91f40",
+                    "integrity": "sha512-smLS+18RjXYMl9joyJxMNI9l4w7biW8ilSDaVRvFBDwOH8P0BK1ognFQTpg0wyQ6wIKLTblHJvROW692L/E53Q=="
+                },
                 "word-wrap": {
                     "version": "1.2.3",
                     "resolved": "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c",
@@ -2194,12 +2276,14 @@
         "balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true
         },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2299,7 +2383,8 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
         },
         "confusing-browser-globals": {
             "version": "1.0.10",
@@ -2308,9 +2393,9 @@
             "dev": true
         },
         "constructs": {
-            "version": "3.3.147",
-            "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.147.tgz",
-            "integrity": "sha512-xTSA87W5hscsHdFC2NcbJWALeMt8QWoCvVXRHPIuoBDDXdvBuNoqL2a5kY1yEWSMLQvBPnrDyinfz3twTX6dAw=="
+            "version": "3.3.150",
+            "resolved": "https://registry.npmjs.org/constructs/-/constructs-3.3.150.tgz",
+            "integrity": "sha512-i++Z38CgBF7kDsKJ2PtdRpXbqL4vwule8tSxcI/PkCbj6LXmokyr7givjzPavgfMhYncDB6J4RoBjfLFMOKRxA=="
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -2390,22 +2475,24 @@
             }
         },
         "es-abstract": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
-            "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+            "version": "1.18.6",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.6.tgz",
+            "integrity": "sha512-kAeIT4cku5eNLNuUKhlmtuk1/TRZvQoYccn6TO0cSVdf1kzB0T7+dYuVK9MWM7l+/53W2Q8M7N2c6MQvhXFcUQ==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
                 "get-intrinsic": "^1.1.1",
+                "get-symbol-description": "^1.0.0",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.2",
-                "is-callable": "^1.2.3",
+                "internal-slot": "^1.0.3",
+                "is-callable": "^1.2.4",
                 "is-negative-zero": "^2.0.1",
-                "is-regex": "^1.1.3",
-                "is-string": "^1.0.6",
-                "object-inspect": "^1.10.3",
+                "is-regex": "^1.1.4",
+                "is-string": "^1.0.7",
+                "object-inspect": "^1.11.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
@@ -2784,17 +2871,6 @@
             "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
             "dev": true
         },
-        "fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
-        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2822,6 +2898,16 @@
                 "function-bind": "^1.1.1",
                 "has": "^1.0.3",
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "get-symbol-description": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+            "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "get-intrinsic": "^1.1.1"
             }
         },
         "glob": {
@@ -2871,9 +2957,10 @@
             }
         },
         "graceful-fs": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -2901,6 +2988,15 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
         },
         "hosted-git-info": {
             "version": "2.8.9",
@@ -2946,6 +3042,17 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "internal-slot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2953,24 +3060,28 @@
             "dev": true
         },
         "is-bigint": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-            "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
-            "dev": true
-        },
-        "is-boolean-object": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
-            "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+            "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
             "dev": true,
             "requires": {
-                "call-bind": "^1.0.2"
+                "has-bigints": "^1.0.1"
+            }
+        },
+        "is-boolean-object": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+            "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "has-tostringtag": "^1.0.0"
             }
         },
         "is-callable": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
-            "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.4.tgz",
+            "integrity": "sha512-nsuwtxZfMX67Oryl9LCQ+upnC0Z0BgpwntpS89m1H/TLF0zNfzfLMV/9Wa/6MZsj0acpEjAO0KF1xT6ZdLl95w==",
             "dev": true
         },
         "is-core-module": {
@@ -2983,10 +3094,13 @@
             }
         },
         "is-date-object": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
-            "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==",
-            "dev": true
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+            "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -3022,26 +3136,32 @@
             "dev": true
         },
         "is-number-object": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
-            "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==",
-            "dev": true
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
+            "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-regex": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
-            "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+            "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "has-symbols": "^1.0.2"
+                "has-tostringtag": "^1.0.0"
             }
         },
         "is-string": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
-            "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==",
-            "dev": true
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+            "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+            "dev": true,
+            "requires": {
+                "has-tostringtag": "^1.0.0"
+            }
         },
         "is-symbol": {
             "version": "1.0.4",
@@ -3101,20 +3221,6 @@
                 "minimist": "^1.2.0"
             }
         },
-        "jsonfile": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-            "requires": {
-                "graceful-fs": "^4.1.6",
-                "universalify": "^2.0.0"
-            }
-        },
-        "jsonschema": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
-            "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
-        },
         "levn": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3169,6 +3275,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -3540,6 +3647,17 @@
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
         },
+        "side-channel": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
+            "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.0",
+                "get-intrinsic": "^1.0.2",
+                "object-inspect": "^1.9.0"
+            }
+        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -3791,11 +3909,6 @@
                 "which-boxed-primitive": "^1.0.2"
             }
         },
-        "universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        },
         "uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3858,7 +3971,8 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         }
     }
 }

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -15,12 +15,12 @@
         "typescript": "^4.4"
     },
     "dependencies": {
-        "@aws-cdk/aws-cognito": "^1.122.0",
-        "@aws-cdk/aws-iam": "^1.122.0",
-        "@aws-cdk/aws-s3": "^1.122.0",
-        "@aws-cdk/aws-secretsmanager": "^1.122.0",
-        "@aws-cdk/aws-ssm": "^1.122.0",
-        "@aws-cdk/core": "^1.122.0",
-        "aws-cdk": "^1.122.0"
+        "@aws-cdk/aws-cognito": "^1.124.0",
+        "@aws-cdk/aws-iam": "^1.124.0",
+        "@aws-cdk/aws-s3": "^1.124.0",
+        "@aws-cdk/aws-secretsmanager": "^1.124.0",
+        "@aws-cdk/aws-ssm": "^1.124.0",
+        "@aws-cdk/core": "^1.124.0",
+        "aws-cdk": "^1.124.0"
     }
 }


### PR DESCRIPTION
Updates the following to v1.124.0:

- `@aws-cdk/aws-cognito`
- `@aws-cdk/aws-iam`
- `@aws-cdk/aws-s3`
- `@aws-cdk/aws-secretsmanager`
- `@aws-cdk/aws-ssm`
- `@aws-cdk/core`
- `aws-cdk`