### PR TITLE
Feature/at 6546 added overlay when screen width is md breakpoint

### DIFF
--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -283,7 +283,6 @@ export default class ATATFileUpload extends Vue {
     event: Event,
     filesObj?: FileList
   ): Promise<void> {
-    debugger;
     let files = filesObj || (this.$refs.fileInput as HTMLInputElement).files;
     if (files && files[0]) {
       let file = files[0];

--- a/src/components/SideDrawer.vue
+++ b/src/components/SideDrawer.vue
@@ -5,8 +5,10 @@
       :width="drawerWidth + 'px'"
       app
       clipped
+      :temporary="showOverlay"
       permanent
       right
+      v-click-outside="hide"
       tabindex="3"
       :style="{
         height: getHeight,
@@ -97,6 +99,10 @@ export default class SideDrawer extends Vue {
     return this.$store.state.sideDrawer;
   }
 
+  get showOverlay(): boolean {
+    return this.$vuetify.breakpoint.sm || this.$vuetify.breakpoint.xs;
+  }
+
   @Watch("$store.state.isSideDrawerFocused")
   setFocus(newVal: boolean): void {
     if (newVal && this.isSideDrawerOpen) {
@@ -105,7 +111,7 @@ export default class SideDrawer extends Vue {
       }, 500);
     }
   }
-  
+
   //method
   private hide(): Promise<boolean> {
     return this.$store.dispatch("closeSideDrawer");

--- a/src/wizard/Navigation/ButtonNavigation.vue
+++ b/src/wizard/Navigation/ButtonNavigation.vue
@@ -6,7 +6,6 @@
     class="d-flex justify-end"
     style="position: fixed; bottom: 40px; left: 0px; z-index: 2"
   >
-
     <v-btn
       v-for="button in pageButtonPanel.buttons"
       :ripple="false"
@@ -49,11 +48,17 @@ export default class ButtonNavigation extends Vue {
   }
 
   get getbuttonNavBarWidth(): string {
+    const windowWidth = window.innerWidth;
+    const smBreakPoint = this.$vuetify.breakpoint.sm;
     const _isSideDrawerOpened = this.$store.state.sideDrawer;
+
+    if (_isSideDrawerOpened && smBreakPoint){
+      return "100%";
+    }
+
     return (
-      (_isSideDrawerOpened
-        ? ((window.innerWidth - 400) / window.innerWidth) * 100
-        : 100) + "%"
+      (_isSideDrawerOpened ? ((windowWidth - 400) / windowWidth) * 100 : 100) +
+      "%"
     );
   }
 


### PR DESCRIPTION
When then window width < 960px Ithe current .sm breakpoint) 
- [x] overlay appears
- [x] controls cannot be accessed underneath the overlay 
- [x] elements below the overlay remain in place, including the wizard button bar at the bottom right.

![image](https://user-images.githubusercontent.com/84856468/135455446-5bc7c464-87f0-4870-aa0c-0ead28cbe43f.png)

below is the same page at the same width.  Please note the placement of all items that were below the overlay in the above screencap remained stationary when side drawer was expanded/closed.

![image](https://user-images.githubusercontent.com/84856468/135455427-4e937672-aeaf-4971-95e4-7b886406d8e4.png)
