### PR TITLE
Use better means to skip Sonar for Dependabot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
           path: dist
       - name: Trigger SonarCloud
         # This step will fail for external collaborators
-        if: ${{ github.event.sender != 'dependabot[bot]' }}
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
github.actor is always present and more clearly describes who/what
triggered the action.