### PR TITLE
Fixup Cognito allowed URLs

### DIFF
--- a/cdk/functions/s3-helper.ts
+++ b/cdk/functions/s3-helper.ts
@@ -8,7 +8,7 @@ import * as lambdaTypes from "aws-lambda";
 // The names of our asset directories
 const ASSET_DIR_REGEX = /^\/(?:css|fonts|img|js)\//i;
 // All routes are words (and usually camelCase)
-const LOOKS_LIKE_ROUTE = /^\/[a-z]*\/?/i;
+const LOOKS_LIKE_ROUTE = /^\/[a-z]*\/?$/i;
 
 /**
  * Map a URL path to an S3 path

--- a/cdk/lib/atat-static-spa-stack.ts
+++ b/cdk/lib/atat-static-spa-stack.ts
@@ -43,7 +43,9 @@ export class StaticSiteStack extends cdk.Stack {
     const siteUrls = [proxy.api.urlForPath()];
     // TODO: Only include localhost in pre-staging environments.
     for (const port of ["8080", "8081"]) {
-      siteUrls.push(`https://localhost:${port}/index.html`);
+      siteUrls.push(
+        `https://localhost:${port}/${proxy.api.deploymentStage.stageName}/`
+      );
     }
     this.userPoolClient = userPool.addClient("ApplicationUserPoolClient", {
       supportedIdentityProviders: idpNames.map(

--- a/src/aws-exports.ts
+++ b/src/aws-exports.ts
@@ -9,7 +9,7 @@ const ENVIRONMENT_ID = "dev";
 /* END MODIFICATIONS */
 
 const REGION = USER_POOL_ID.split("_")[0];
-const REDIRECT_URL = `${window.location.origin}/index.html`;
+const REDIRECT_URL = `${window.location.origin}${process.env.BASE_URL}`;
 
 export default Amplify.configure({
   Auth: {


### PR DESCRIPTION
This syncs up the Cognito callback/redirect URLs with the new URLs based
on the API Gateway proxy. This was missed in the earlier testing because
the configuratin endpoint isn't quite in place yet.