### PR TITLE
features/AT-6809-revisions-001

### DIFF
--- a/src/components/ATATDatePicker.vue
+++ b/src/components/ATATDatePicker.vue
@@ -119,7 +119,7 @@
           </div>
         </div>
         <div class="width-100 d-flex justify-start mt-2 text--base">
-            Month, Day, Year (e.g. MM/DD/YYYY)
+          Month, Day, Year (e.g. MM/DD/YYYY)
         </div>
       </div>
       <v-menu
@@ -250,8 +250,8 @@ export default class ATATDatePicker extends Vue {
   private isDatePickerAdvancing = false;
   private isKeyboardEvent = false;
   private isTabEvent = false;
- 
-   /**
+
+  /**
    * textboxes date mask
    */
   public dateMask = [
@@ -335,7 +335,7 @@ export default class ATATDatePicker extends Vue {
 
     //resets datepicker to correct month depending
     //on what text box is focused.
-    
+
     if (this.isStartTextBoxFocused) {
       this.firstMonth = this.startDate;
     } else if (this.isEndTextBoxFocused) {
@@ -349,7 +349,6 @@ export default class ATATDatePicker extends Vue {
   private getId(prependString: string): string {
     return prependString + "-" + this.id;
   }
-
 
   /**
    * @param dateString - date string
@@ -640,10 +639,16 @@ export default class ATATDatePicker extends Vue {
    * off of each button to the right of the textboxes
    */
   public onTab(event: KeyboardEvent): void {
+    const isTabbingBackward = event.shiftKey === true;
     this.isKeyboardEvent = true;
-    if (!this.isDateValid(this.startDate) || !this.isDateValid(this.endDate)) {
-      this.setFocusOnDatePicker();
-      event.preventDefault();
+    if (!isTabbingBackward) {
+      if (
+        !this.isDateValid(this.startDate) ||
+        !this.isDateValid(this.endDate)
+      ) {
+        this.setFocusOnDatePicker();
+        event.preventDefault();
+      }
     }
   }
 
@@ -671,7 +676,6 @@ export default class ATATDatePicker extends Vue {
     } else {
       event.preventDefault();
     }
-
   }
 
   /**

--- a/src/sass/components/_v_datepicker.scss
+++ b/src/sass/components/_v_datepicker.scss
@@ -163,9 +163,10 @@
             tbody{
               tr{
                 td{
-                  button.v-btn:not(.v-date-picker-table__current){
+                  button.v-btn{
                     &:focus,
                     &:focus::before,
+                    &:focus-visible::before,
                     &:hover:not(.date-picker-end-date),
                     &:hover:not(.date-picker-end-date)::before{
                       border-radius:  8px 0px 0px 8px !important;
@@ -173,9 +174,17 @@
                       box-sizing: border-box !important;
                       box-shadow: none !important;
                     }
+                    &.v-date-picker-table__current{
+                      &:focus::before,
+                      &:focus-visible::before,
+                      &:hover,
+                      &:hover::before{
+                        opacity: 0!important;
+                      }
+                    }
                   }
                 }
-              }
+              } 
             }
           }
         }
@@ -185,15 +194,24 @@
             tbody{
               tr{
                 td{
-                  button.v-btn:not(.v-date-picker-table__current){
+                  button.v-btn{
                     &:focus,
                     &:focus::before,
+                    &:focus-visible::before,
                     &:hover:not(.date-picker-start-date),
                     &:hover:not(.date-picker-start-date)::before{
                       border-radius:  0px 8px 8px 0px !important;
                       border: 4px solid $primary_vivid !important;
                       box-sizing: border-box !important;
                       box-shadow: none !important;
+                    }
+                    &.v-date-picker-table__current{
+                      &:focus::before,
+                      &:focus-visible::before,
+                      &:hover,
+                      &:hover::before{
+                        opacity: 0!important;
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
- [x] If I open the calendar and navigate with my keyboard to the
       X close the date picker, and then click Shift+Tab to focus on
       the end date calendar icon, I get stuck. Cannot Tab to go
       forward or Shift+Tab to go back. I have open the date picker
       and navigate to the X to close the modal again to “unstick” myself.
- [x] The focus state on today’s date is different when tabbing the days.
      (The hover state for today’s date is also missing, so that issue
      could be linked)
AT-6809