### PR TITLE
Give deploy job id-token access

### DIFF
--- a/.github/workflows/deploy-spa.yml
+++ b/.github/workflows/deploy-spa.yml
@@ -56,6 +56,8 @@ jobs:
     name: Deploy SPA to AWS
     runs-on: ubuntu-20.04
     needs: build
+    permissions:
+      id-token: write
     steps:
       # Ensure that the account ID does not appear in any log messages in the pipeline
       - run: echo ::add-mask::${{ secrets.AWS_US_GOV_ACCOUNT_ID }}


### PR DESCRIPTION
Without this the configure-aws-credentials action fails to actually grab
the OIDC token. This was an oversight in the initial implementation.

Ticket: AT-6847