### PR TITLE
Feature/at 6604

### DIFF
--- a/src/sass/components/_atat_portfolio_summary_card.scss
+++ b/src/sass/components/_atat_portfolio_summary_card.scss
@@ -79,7 +79,6 @@
 
 .no-portfolio-search-results {
   text-align: center;
-  margin-top: 20px;
   .v-icon {
     font-size: 150px;
   }

--- a/src/sass/components/_atat_portfolio_summary_card.scss
+++ b/src/sass/components/_atat_portfolio_summary_card.scss
@@ -76,3 +76,11 @@
     line-height: 1;
   }
 }
+
+.no-portfolio-search-results {
+  text-align: center;
+  margin-top: 20px;
+  .v-icon {
+    font-size: 150px;
+  }
+}

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -35,6 +35,7 @@
             hide-details
             clearable
             aria-label="Search"
+            v-model="searchTerm"
           />
           <v-btn
             class="input-search-bar"
@@ -66,11 +67,19 @@
     </div>
 
     <v-row>
-      <div v-show="showNoSearchResults" class="no-portfolio-search-results wizard-content">
+      <v-col v-show="showNoSearchResults" class="no-portfolio-search-results">
         <!-- temporary logic to show the no search results content -->
-          <v-icon>search</v-icon>
-          <h2>No results for &ldquo;{ search string }&rdquo;</h2>
-      </div>
+          <div class="wizard-content">
+            <v-icon>search</v-icon>
+            <h2>No results for &ldquo;{{ searchTermNoResultsDisplay }}&rdquo;</h2>
+            <p>
+              Please try another search term or modify filters to be less specific.
+            </p>
+            <v-btn class="primary" @click="clearSearch">
+              {{ noResultsButtonText }}
+            </v-btn>
+          </div>
+      </v-col>
       <!-- temporary logic to show the no search results content 
            remove !showNoSearchResults when search logic is completed -->
       <v-col v-if="portfolios && portfolios.length > 0 && !showNoSearchResults">
@@ -109,6 +118,9 @@ export default class ViewPortfolio extends Vue {
   deletePortfolioDraft!: (draftId: string) => Promise<void>;
   private open = false;
   private showNoSearchResults = false;
+  private searchTerm = "";
+  private searchTermNoResultsDisplay = "";
+  private noResultsButtonText = "Clear search";
 
   get portfolios(): PortfolioDraft[] {
     return this.portfoliosState.portfolioDrafts;
@@ -126,9 +138,17 @@ export default class ViewPortfolio extends Vue {
     this.open = !this.open;
   }
 
+  private clearSearch(): void {
+    this.showNoSearchResults = false;
+    this.searchTerm = "";
+  }
+
   private searchPortfolios(): void {
     // temporary logic until search functionality is implemented
-    this.showNoSearchResults = !this.showNoSearchResults;
+    this.showNoSearchResults = this.searchTerm ? true : false;
+    this.searchTermNoResultsDisplay = this.searchTerm;
+    this.noResultsButtonText = "Clear search";
+    // when applying filters, button text will be "Clear filters"
   }
 
   private async onDeletePortfolio(id: string) {

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -40,6 +40,7 @@
             class="input-search-bar"
             color="primary"
             aria-label="Search Portfolio"
+            @click="searchPortfolios"
           >
             <v-icon>search</v-icon>
           </v-btn>
@@ -65,7 +66,14 @@
     </div>
 
     <v-row>
-      <v-col v-if="portfolios && portfolios.length > 0">
+      <div v-show="showNoSearchResults" class="no-portfolio-search-results wizard-content">
+        <!-- temporary logic to show the no search results content -->
+          <v-icon>search</v-icon>
+          <h2>No results for &ldquo;{ search string }&rdquo;</h2>
+      </div>
+      <!-- temporary logic to show the no search results content 
+           remove !showNoSearchResults when search logic is completed -->
+      <v-col v-if="portfolios && portfolios.length > 0 && !showNoSearchResults">
         <portfolio-summary
           :portfolioDrafts="portfolios"
           v-on:delete="onDeletePortfolio"
@@ -100,6 +108,7 @@ export default class ViewPortfolio extends Vue {
   @Action("deletePortfolioDraft", { namespace })
   deletePortfolioDraft!: (draftId: string) => Promise<void>;
   private open = false;
+  private showNoSearchResults = false;
 
   get portfolios(): PortfolioDraft[] {
     return this.portfoliosState.portfolioDrafts;
@@ -115,6 +124,11 @@ export default class ViewPortfolio extends Vue {
     }
     // complete functionality in future task, for now, just toggle this.open
     this.open = !this.open;
+  }
+
+  private searchPortfolios(): void {
+    // temporary logic until search functionality is implemented
+    this.showNoSearchResults = !this.showNoSearchResults;
   }
 
   private async onDeletePortfolio(id: string) {

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -120,7 +120,7 @@ export default class ViewPortfolio extends Vue {
   private showNoSearchResults = false;
   private searchTerm = "";
   private searchTermNoResultsDisplay = "";
-  private noResultsButtonText = "Clear search";
+  private noResultsButtonText = "Clear Search";
 
   get portfolios(): PortfolioDraft[] {
     return this.portfoliosState.portfolioDrafts;
@@ -147,8 +147,8 @@ export default class ViewPortfolio extends Vue {
     // temporary logic until search functionality is implemented
     this.showNoSearchResults = this.searchTerm ? true : false;
     this.searchTermNoResultsDisplay = this.searchTerm;
-    this.noResultsButtonText = "Clear search";
-    // when applying filters, button text will be "Clear filters"
+    this.noResultsButtonText = "Clear Search";
+    // when applying filters, button text will be "Clear Filters"
   }
 
   private async onDeletePortfolio(id: string) {


### PR DESCRIPTION
Magnifying glass icon is present with correct formatting.

‘No results for [Input text here]’ text is present with correct formatting.

‘Please try another search term or modify filters to be less specific’ help text is present with correct formatting.

Blue ‘Clear search’ button is present with correct formatting.

When clicked, all inputted text should be removed and the portfolios lists should be reverted back to the default state (no text inputted into search bar).

All text and buttons are accessible via keyboard and screen reader.