### PR TITLE
Fix building configuration URL

### DIFF
--- a/src/atat-config-builder.ts
+++ b/src/atat-config-builder.ts
@@ -39,6 +39,13 @@ const retrieveSessionConfig = (): ATATConfiguration | undefined => {
   return undefined;
 };
 
+const buildConfigurationUrl = (): string => {
+  const origin = window.location.origin;
+  const basePath = process.env.BASE_URL;
+  const endpoint = "configuration";
+  return `${origin}${basePath}${endpoint}`;
+};
+
 const getConfiguration = async (): Promise<ATATConfiguration> => {
   let atatConfig: ATATConfiguration;
 
@@ -63,13 +70,10 @@ const getConfiguration = async (): Promise<ATATConfiguration> => {
     return atatConfig;
   }
 
-  const baseURL =
-    window.location.hostname === "localhost"
-      ? "https://luv6hxil7k.execute-api.us-gov-west-1.amazonaws.com/prod/"
-      : window.location;
+  const configurationUrl = buildConfigurationUrl();
 
   try {
-    const response = await axios.get<ProxyConfig>(`${baseURL}configuration`);
+    const response = await axios.get<ProxyConfig>(configurationUrl);
 
     const proxy = response.data;
 


### PR DESCRIPTION
Because we previously returned if window.location.hostname was
"localhost", the ternary in this statement provided no value (since the
condition must always evaluate to false). We can instead operate
assuming that we are able to leverage `window.location` correctly.

This builds the configuration URL based on the origin, Vue.js
`publicPath` variable (exposed as `process.env.BASE_URL`), and
statically configured well-known value for the configuration endpoint
(`"configuration"`).

This also resolves a minor bug in the previous code that prevented the
configuration from being loaded if the user omitted the trailing `/` at
the end of the URL for the site. This also ensures that the
configuration can be loaded in the event that a user navigates somewhere
other than `/` first.

Ticket: AT-6772