### PR TITLE
feature AT-6838 fix no access display issue

### DIFF
--- a/src/wizard/Step4/views/SummaryReview.vue
+++ b/src/wizard/Step4/views/SummaryReview.vue
@@ -104,7 +104,7 @@
         </div>
       </template>
       <template v-slot:item.operators="{ item }">
-        <div class="d-flex justify-space-between">
+        <div class="d-flex justify-space-between align-center">
           <div 
             class="body text--base-darkest pt-1"
           >

--- a/src/wizard/Step4/views/TeamView.vue
+++ b/src/wizard/Step4/views/TeamView.vue
@@ -299,29 +299,31 @@ export default class TeamView extends mixins(ApplicationData) {
             const i = this.applicationMembers.findIndex(
               (o) => o.email === op.email
             );
-            const workspace_roles =
-              i > -1
-                ? env.name +
-                  ": " +
-                  this.roleTranslation(op.access) +
-                  "  " +
-                  this.applicationMembers[i].workspace_roles
-                : env.name + ": " + this.roleTranslation(op.access);
-            if (i > -1) {
-              this.applicationMembers[i].workspace_roles = workspace_roles;
-            } else {
-              const opObj = {
-                id: op.id,
-                display_name:
-                  op.display_name || op.first_name + " " + op.last_name,
-                email: op.email,
-                workspace_roles: workspace_roles,
-              };
-              this.applicationMembers.push(opObj);
-            }
+            if (op.access !== "no_access") {
+              const workspace_roles =
+                i > -1
+                  ? env.name +
+                    ": " +
+                    this.roleTranslation(op.access) +
+                    "  " +
+                    this.applicationMembers[i].workspace_roles
+                  : env.name + ": " + this.roleTranslation(op.access);
+              if (i > -1) {
+                this.applicationMembers[i].workspace_roles = workspace_roles;
+              } else {
+                const opObj = {
+                  id: op.id,
+                  display_name:
+                    op.display_name || op.first_name + " " + op.last_name,
+                  email: op.email,
+                  workspace_roles: workspace_roles,
+                };
+                this.applicationMembers.push(opObj);
+              }
 
-            if (op.access === "administrator" && environmentWithoutAdminsIndex > -1) {
-              this.environmentsWithoutAdmins.splice(environmentWithoutAdminsIndex, 1)
+              if (op.access === "administrator" && environmentWithoutAdminsIndex > -1) {
+                this.environmentsWithoutAdmins.splice(environmentWithoutAdminsIndex, 1)
+              }
             }
 
           });

--- a/src/wizard/Step5/components/TeamMemberTable.vue
+++ b/src/wizard/Step5/components/TeamMemberTable.vue
@@ -171,24 +171,26 @@ export default class TeamMemberTable extends Vue {
         if (envOperators && envOperators.length > 0) {
           envOperators.forEach((op: any) => {
             const i = appEnvOps.findIndex((o) => o.email === op.email);
-            const workspace_roles =
-              i > -1
-                ? env.name +
-                  ": " +
-                  this.roleTranslation(op.access) +
-                  "  " +
-                  appEnvOps[i].workspace_roles
-                : env.name + ": " + this.roleTranslation(op.access);
-            if (i > -1) {
-              appEnvOps[i].workspace_roles = workspace_roles;
-            } else {
-              const opObj = {
-                id: op.id,
-                display_name: op.display_name,
-                email: op.email,
-                workspace_roles: workspace_roles,
-              };
-              appEnvOps.push(opObj);
+            if (op.access !== "no_access") {
+              const workspace_roles =
+                i > -1
+                  ? env.name +
+                    ": " +
+                    this.roleTranslation(op.access) +
+                    "  " +
+                    appEnvOps[i].workspace_roles
+                  : env.name + ": " + this.roleTranslation(op.access);
+              if (i > -1) {
+                appEnvOps[i].workspace_roles = workspace_roles;
+              } else {
+                const opObj = {
+                  id: op.id,
+                  display_name: op.display_name,
+                  email: op.email,
+                  workspace_roles: workspace_roles,
+                };
+                appEnvOps.push(opObj);
+              }
             }
           });
         }


### PR DESCRIPTION
When editing a Team Member's roles when assigned different roles for environments, if initially a user is set to "No access" in an environment, then user edits the member, but does not change the role from "No access" to anything else, when the member table re-renders on modal Save, the environment is displayed with "Unauthorized" as the access level. 

Expected: Do not list environment name when member has "No access"

![image](https://user-images.githubusercontent.com/90333349/143307115-88f1b1ca-96f9-4b9e-8429-d7e7bb369933.png)
