### PR TITLE
AT-6875: Updated apiUrl to reflect new SSM parameter name from API

### DIFF
--- a/cdk/functions/configuration.ts
+++ b/cdk/functions/configuration.ts
@@ -32,7 +32,7 @@ export async function handleConfigurationRoute(): Promise<lambdaTypes.APIGateway
   const region = process.env.AWS_REGION!;
   const configuration: ConfigurationData = {
     applicationConfig: {
-      apiUrl: await getStringValue(`/${ssmPrefix}/${environmentId}/api/url`),
+      apiUrl: await getStringValue(`/${ssmPrefix}/${environmentId}/draftApi/url`),
     },
     authenticationConfig: {
       userPoolId: await getStringValue(


### PR DESCRIPTION
Updated the `apiUrl` config to reflect that we now have two separate SSM parameters for API URLs - `draftApi/url` and `internalApi/url`. Using `draftApi` until we are ready to transition to the new `internalApi`.

This should merge at the same time as https://github.com/dod-ccpo/atat-web-api/pull/467/files, which changes the parameter in question.

Ticket: AT-6875