### PR TITLE
feature AT 6873

### DIFF
--- a/src/wizard/Step0/components/CreatePortfolio/CreatePortfolio.vue
+++ b/src/wizard/Step0/components/CreatePortfolio/CreatePortfolio.vue
@@ -2,19 +2,19 @@
   <div class="main-content-wrapper body-lg">
     <div class="content-max-width">
       <h1 tabindex="-1">
-        Hi {{ user.given_name }}, let’s create your first portfolio!
+        {{ user.given_name }}, let’s create your first portfolio!
       </h1>
       <p>
         To get started with provisioning your cloud resources, you will need to
         set up a portfolio. We will walk you through adding your contract
         information, as well as establishing the workspaces and team members
-        that will develop your provisioned applications within the CSP console.
+        that will develop your provisioned applications within the cloud service
+        provider console.
       </p>
       <p>
         You will need to have an approved task order to fund your project, prior
-        to completing your portfolio submission. But don't worry, you can save a
-        draft and come back to it at any time prior to provisioning. You can
-        even invite other portfolio managers to help you out along the way!
+        to completing your portfolio submission. Regardless, you can start and
+        save a draft, and come back to it at any time prior to provisioning.
       </p>
       <p>Let’s get started!</p>
 


### PR DESCRIPTION
1. The verbiage in the page header when the users accesses the Dashboard screen is as follows:

[User’s first name], let’s create your first portfolio!

2. The verbiage in paragraphs immediately below the page header is as follows:

To get started with provisioning your cloud resources, you will need to set up a portfolio. We will walk you through adding your contract information, as well as establishing the workspaces and team members that will develop your provisioned applications within the cloud service provider console.

You will need to have an approved task order to fund your project, prior to completing your portfolio submission. Regardless, you can start and save a draft, and come back to it at any time prior to provisioning.

Let’s get started!