### PR TITLE
feature/AT-6856

### DIFF
--- a/src/router/wizard.ts
+++ b/src/router/wizard.ts
@@ -37,6 +37,18 @@ const addportfolio: RouteConfigSingleView = {
     step: 1,
   },
 };
+const editportfolio: RouteConfigSingleView = {
+  path: "editportfolio/:id",
+  name: "editportfolio",
+  meta: {
+    title: "Edit Portfolio Details and CSP Selection",
+  },
+  component: () =>
+    import(/* webpackChunkName: "style" */ "../wizard/Step1/views/Step1.vue"),
+  props: {
+    step: 1,
+  },
+};
 
 const addfunding: RouteConfigSingleView = {
   path: "addfunding",
@@ -188,6 +200,7 @@ const wizard: RouteConfigSingleView = {
   children: [
     //main routes
     CreateWizardRoute(addportfolio, undefined, addfunding.name, 1),
+    CreateWizardRoute(editportfolio, undefined, addfunding.name, 1),
     CreateWizardRoute(addfunding, addportfolio.name, fundingsummary.name, 2),
     CreateWizardRoute(fundingsummary, addfunding.name, addapplication.name, 2),
     CreateWizardRoute(
@@ -258,4 +271,5 @@ export {
   addteammembers,
   editmembers,
   teammembersummary,
+  editportfolio,
 };

--- a/src/wizard/Step1/components/CloudServiceProviderForm.vue
+++ b/src/wizard/Step1/components/CloudServiceProviderForm.vue
@@ -3,12 +3,10 @@
     <fieldset>
       <legend>Cloud Service Provider</legend>
       <p class="mb-1">
-        Select the cloud service provider where you want to deploy this
-        portfolio.
-        <strong>
-          Your selection must match the CSP listed in your awarded task
-          order(s).
-        </strong>
+        Select the CSP where you want to deploy this portfolio.<strong
+          >Your selection must match the CSP listed in your awarded task
+          order(s).</strong
+        >
       </p>
       <v-form ref="form" lazy-validation>
         <atat-button-card

--- a/src/wizard/Step1/components/CreatePorfolioForm.vue
+++ b/src/wizard/Step1/components/CreatePorfolioForm.vue
@@ -3,15 +3,15 @@
     <v-row>
       <v-col class="mb-4">
         <h1 tabindex="-1">
-          Let’s start with some details about your portfolio
+          {{ route }}
         </h1>
         <p>
           Your portfolio is a collection of your funding sources and
-          applications within a single cloud service provider. If you would like
-          like to create a multi-cloud application with environments deployed
-          different CSPs, you will need to create a portfolio for each CSP. When
-          you are done, click <strong>Next</strong> and we will walk you through
-          through adding your funding sources.
+          applications within a single Cloud Service Provider (CSP). If you
+          would like to create a multi-cloud application with environments
+          deployed to different CSPs, you will need to create a portfolio for
+          each CSP. When you are done, click <strong>Next</strong> and we will
+          walk you through adding your funding sources.
         </p>
       </v-col>
     </v-row>
@@ -121,7 +121,7 @@ export default class CreatePortfolioForm
   extends Vue
   implements ValidatableForm
 {
-  private valid = true;
+  private titleText = "";
   private dodComponents = dodComponents;
   private portfolioDetailsDescription = `Choose a name that is descriptive enough for users to identify the portfolio. Consider naming based on your organization.`;
   private portfolioDescriptionText = `Add a brief one to two sentence description of your Portfolio.
@@ -147,6 +147,11 @@ export default class CreatePortfolioForm
   }
   get Form(): Vue & { validate: () => boolean } {
     return this.$refs.form as Vue & { validate: () => boolean };
+  }
+  get route(): string {
+    return this.$route.name == "editportfolio"
+      ? "Let’s update your portfolio details"
+      : "Let’s start with some details about your portfolio";
   }
 
   get rules(): any {

--- a/src/wizard/Step1/components/CreatePorfolioForm.vue
+++ b/src/wizard/Step1/components/CreatePorfolioForm.vue
@@ -1,9 +1,9 @@
 <template>
   <v-form ref="form" lazy-validation class="body-lg content-max-width">
     <v-row>
-      <v-col class="mb-4">
+      <v-col v-if="!stepHasBeenTouched" class="mb-4">
         <h1 tabindex="-1">
-          {{ route }}
+          Let’s start with some details about your portfolio
         </h1>
         <p>
           Your portfolio is a collection of your funding sources and
@@ -12,6 +12,17 @@
           deployed to different CSPs, you will need to create a portfolio for
           each CSP. When you are done, click <strong>Next</strong> and we will
           walk you through adding your funding sources.
+        </p>
+      </v-col>
+      <v-col v-else class="mb-4">
+        <h1 tabindex="-1">Let’s update your portfolio details</h1>
+        <p>
+          Your portfolio is a collection of your funding sources and
+          applications within a single Cloud Service Provider (CSP). If you
+          would like to create a multi-cloud application with environments
+          deployed to different CSPs, you will need to create a portfolio for
+          each CSP. When you are done, click <strong>Next</strong> to continue
+          reviewing your portfolio.
         </p>
       </v-col>
     </v-row>
@@ -121,7 +132,6 @@ export default class CreatePortfolioForm
   extends Vue
   implements ValidatableForm
 {
-  private titleText = "";
   private dodComponents = dodComponents;
   private portfolioDetailsDescription = `Choose a name that is descriptive enough for users to identify the portfolio. Consider naming based on your organization.`;
   private portfolioDescriptionText = `Add a brief one to two sentence description of your Portfolio.
@@ -130,6 +140,7 @@ export default class CreatePortfolioForm
   private isChecked(dodComp: string) {
     return this._dod_components.findIndex((d) => d === dodComp) > -1;
   }
+  private stepHasBeenTouched = false;
   @PropSync("name", { default: "", required: true }) portfolio_name!: string;
   @PropSync("description", { default: "", required: true })
   portfolio_description!: string;
@@ -147,11 +158,6 @@ export default class CreatePortfolioForm
   }
   get Form(): Vue & { validate: () => boolean } {
     return this.$refs.form as Vue & { validate: () => boolean };
-  }
-  get route(): string {
-    return this.$route.name == "editportfolio"
-      ? "Let’s update your portfolio details"
-      : "Let’s start with some details about your portfolio";
   }
 
   get rules(): any {
@@ -180,6 +186,9 @@ export default class CreatePortfolioForm
     });
 
     return validated && typeof this.isDodComponentsValid === "boolean";
+  }
+  private mounted(): void {
+    this.stepHasBeenTouched = this.$store.getters.getStepTouched(1);
   }
 }
 </script>

--- a/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
+++ b/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
@@ -1,25 +1,29 @@
 import Vue from "vue";
 import Vuetify from "vuetify";
-
+import Vuex from "vuex";
 import { createLocalVue, mount } from "@vue/test-utils";
 import CreatePortfolioForm from "@/wizard/Step1/components/CreatePorfolioForm.vue";
 
 Vue.use(Vuetify);
 
 describe("Testing CreatePortfolioForm Component", () => {
-  const $route = {
-    path: "editportfolio/:id",
-    name: "editportfolio",
-  };
   const localVue = createLocalVue();
-
+  localVue.use(Vuex);
   let vuetify: any;
   let wrapper: any;
-
+  const getters: any = {
+    getStepTouched: () => (stepNumber: number) => {
+      return false;
+    },
+  };
+  const store = new Vuex.Store({
+    getters,
+  });
   beforeEach(() => {
     vuetify = new Vuetify();
     wrapper = mount(CreatePortfolioForm, {
       localVue,
+      store,
       vuetify,
       stubs: ["atat-text-field", "atat-text-area"],
       propsData: {
@@ -27,7 +31,6 @@ describe("Testing CreatePortfolioForm Component", () => {
         description: "testDescription",
         dod_components: undefined,
       },
-      mocks: { $route },
     });
   });
 

--- a/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
+++ b/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
@@ -1,12 +1,18 @@
 import Vue from "vue";
 import Vuetify from "vuetify";
+
 import { createLocalVue, mount } from "@vue/test-utils";
 import CreatePortfolioForm from "@/wizard/Step1/components/CreatePorfolioForm.vue";
 
 Vue.use(Vuetify);
 
 describe("Testing CreatePortfolioForm Component", () => {
+  const $route = {
+    path: "editportfolio/:id",
+    name: "editportfolio",
+  };
   const localVue = createLocalVue();
+
   let vuetify: any;
   let wrapper: any;
 
@@ -21,6 +27,7 @@ describe("Testing CreatePortfolioForm Component", () => {
         description: "testDescription",
         dod_components: undefined,
       },
+      mocks: { $route },
     });
   });
 

--- a/src/wizard/Step1/views/Step1.spec.ts
+++ b/src/wizard/Step1/views/Step1.spec.ts
@@ -9,6 +9,10 @@ import VueAxios from "vue-axios";
 Vue.use(Vuetify);
 
 describe("Testing Step1 Component", () => {
+  const $route = {
+    path: "editportfolio/:id",
+    name: "editportfolio",
+  };
   const localVue = createLocalVue();
   localVue.use(Vuex);
   localVue.use(VueAxios, axios);
@@ -49,6 +53,7 @@ describe("Testing Step1 Component", () => {
         "atat-text-area",
         "atat-button-card",
       ],
+      mocks: { $route },
     });
     wrapper.setData({
       model: {

--- a/src/wizard/Step3/components/CreateApplicationForm.vue
+++ b/src/wizard/Step3/components/CreateApplicationForm.vue
@@ -3,10 +3,10 @@
     <div class="content-max-width">
       <h1 tabindex="-1">Let’s create your new application</h1>
       <p>
-        In this section, we’ll set up your cloud workspaces within
+        In this section, we will set up your cloud workspaces within
         <strong>{{ this.$store.getters.getPortfolio.csp }}</strong
         >. If you have more than one application, we will walk through them one
-        at a time. Select <strong>Next</strong> to view your applications
+        at a time. Select <strong>Next</strong> to view your application
         summary.
       </p>
     </div>
@@ -102,10 +102,8 @@ export default class CreateApplicationForm extends Vue {
   @PropSync("application") _application!: CreateApplicationModel;
   @Prop({ default: false }) private validateOnLoad!: boolean;
 
-  private applicationNameHelpText = `This name will be displayed within the cloud provider’s console. It should be intuitive
-    and easily recognizable for all of your team members.`;
-  private applicationDetailsHelpText = `Add a brief one to two sentence description of your application.
-    Consider using the “Description of Work” from your task order.`;
+  private applicationNameHelpText = `This name will be displayed within the cloud provider’s console. It should be intuitive and easily recognizable for all of your team members.`;
+  private applicationDetailsHelpText = `Add a brief one to two sentence description of your application. Consider using the “Description of Work” from your task order.`;
 
   get rules(): unknown {
     return {

--- a/src/wizard/Step5/components/PortfolioSummaryCard.spec.ts
+++ b/src/wizard/Step5/components/PortfolioSummaryCard.spec.ts
@@ -2,6 +2,7 @@ import Vue from "vue";
 import Vuetify from "vuetify";
 import { createLocalVue, mount } from "@vue/test-utils";
 import VueRouter from "vue-router";
+import Vuex from "vuex";
 import PortfolioSummaryCard from "@/wizard/Step5/components/PortfolioSummaryCard.vue";
 
 Vue.use(Vuetify);
@@ -9,16 +10,21 @@ Vue.use(Vuetify);
 describe("Testing PortfolioSummaryCard Component", () => {
   const localVue = createLocalVue();
   localVue.use(VueRouter);
+  localVue.use(Vuex);
   const router = new VueRouter();
   let vuetify: any;
+  let store: any;
   let wrapper: any;
+  const state = {};
 
   beforeEach(() => {
     vuetify = new Vuetify();
+    store = new Vuex.Store(state);
     wrapper = mount(PortfolioSummaryCard, {
       localVue,
       router,
       vuetify,
+      store,
       propsData: {
         portfolio: {
           name: "Tracker",

--- a/src/wizard/Step5/components/PortfolioSummaryCard.vue
+++ b/src/wizard/Step5/components/PortfolioSummaryCard.vue
@@ -81,8 +81,8 @@ export default class PortfolioSummaryCard extends Vue {
 
   public onEdit(): void {
     this.$router.push({
-      name: "addportfolio",
-      params: { id: `${this.portfolio.id}` },
+      name: "editportfolio",
+      params: { id: `${this.$store.state.currentPortfolioId}` },
     });
   }
 }


### PR DESCRIPTION
Update verbiage in Step 1 of the Portfolio Provisioning Wizard. All surrounding verbiage and edit history can be checked in this Google Doc if needed. The recommendation when updating verbiage is to copy-paste to ensure word-for-word changes, and not to worry about the details of the updates. The exception is italicized indicators of where the text is going to be, such as “* Tooltip:” and “* Subtext:”.