### PR TITLE
Feature/6860

### DIFF
--- a/src/wizard/Step2/components/ClinsCard.vue
+++ b/src/wizard/Step2/components/ClinsCard.vue
@@ -328,13 +328,9 @@ export default class ClinsCard extends Vue {
   private openItem = -1;
 
   private clinHelpText =
-    "This is the full amount of money requested\n" +
-    "in a task order. It does not have to be spent\n" +
-    "duing the CLIN’s period of performance.";
+    "This is the full amount of money requested in a task order. It does not have to be spent during the CLIN’s period of performance.";
   private obligatedFundsHelpText =
-    "Obligated funds are the legal amount allocated\n" +
-    "for a project or contract that can be spent during\n" +
-    "the CLIN’s period of performance.";
+    " Obligated funds are the legal amount allocated for a project or contract that can be spent during the CLIN’s period of performance.";
 
   private idiq_clin_items = [
     "IDIQ CLIN 0001 Unclassified IaaS/PaaS",

--- a/src/wizard/Step2/components/CreateTaskOrderForm.spec.ts
+++ b/src/wizard/Step2/components/CreateTaskOrderForm.spec.ts
@@ -7,6 +7,10 @@ import CreateTaskOrderForm from "@/wizard/Step2/components/CreateTaskOrderForm.v
 Vue.use(Vuetify);
 
 describe("Testing CreateTaskOrderForm", () => {
+  const $route = {
+    path: "editfunding/:id",
+    name: "editfunding",
+  };
   const localVue = createLocalVue();
   localVue.use(Vuex);
   let vuetify: any;
@@ -61,6 +65,9 @@ describe("Testing CreateTaskOrderForm", () => {
           },
         ],
         task_order_number: "12345678901234567",
+      },
+      mocks: {
+        $route,
       },
     });
   });

--- a/src/wizard/Step2/components/CreateTaskOrderForm.spec.ts
+++ b/src/wizard/Step2/components/CreateTaskOrderForm.spec.ts
@@ -37,6 +37,9 @@ describe("Testing CreateTaskOrderForm", () => {
         task_order_number: "12345678901234567",
       };
     },
+    getStepTouched: () => (stepNumber: number) => {
+      return false;
+    },
   };
   const store = new Vuex.Store({
     getters,

--- a/src/wizard/Step2/components/CreateTaskOrderForm.vue
+++ b/src/wizard/Step2/components/CreateTaskOrderForm.vue
@@ -1,16 +1,23 @@
 <template>
   <v-form ref="form" lazy-validation class="body-lg">
     <section role="region" title="Page Overview" class="content-max-width">
-      <h1 v-if="!isEdit" tabindex="-1">Add a New Task Order</h1>
-      <p v-if="!isEdit" class="ma-0 mt-4 body-lg text--base-darkest">
+      <h1 v-if="!stepHasBeenTouched" tabindex="-1">
+        Let’s add a new task order
+      </h1>
+      <p
+        v-if="!stepHasBeenTouched"
+        class="ma-0 mt-4 body-lg text--base-darkest"
+      >
         You will find this information in your awarded task order that funds
         your ATAT portfolio. If you have more than one task order, we will walk
         through them one at a time. Select <strong>Next</strong> to view all of
         your funding sources.
       </p>
       <!--      edit-->
-      <h1 v-if="isEdit" tabindex="-1">Let’s update your task order details</h1>
-      <p v-if="isEdit" class="ma-0 mt-4 body-lg text--base-darkest">
+      <h1 v-if="stepHasBeenTouched" tabindex="-1">
+        Let’s update your task order details
+      </h1>
+      <p v-if="stepHasBeenTouched" class="ma-0 mt-4 body-lg text--base-darkest">
         You will find this information in your awarded task order that funds
         your ATAT portfolio. Select <strong>Next</strong> when you are done
         making changes, or to skip to your task order summary. From there, you
@@ -167,7 +174,7 @@ export default class CreateTaskOrderForm extends Vue {
     Form 1449: Enter the “Order Number”
     Form 1155: Enter the “Delivery Order/Call No.”`;
   private savedTaskOrderSigned = false;
-  private isEdit = false;
+  private stepHasBeenTouched = false;
 
   @PropSync("task_order_number") _task_order_number!: number;
   @PropSync("task_order_file") _task_order_file!: TaskOrderFile;
@@ -251,9 +258,7 @@ export default class CreateTaskOrderForm extends Vue {
       this.isTaskOrderSigned(this._signed);
     }
 
-    if (this.$route.name === "editfunding") {
-      this.isEdit = true;
-    }
+    this.stepHasBeenTouched = this.$store.getters.getStepTouched(2);
   }
 
   private async onRemoveFile(): Promise<void> {

--- a/src/wizard/Step2/components/CreateTaskOrderForm.vue
+++ b/src/wizard/Step2/components/CreateTaskOrderForm.vue
@@ -1,12 +1,20 @@
 <template>
   <v-form ref="form" lazy-validation class="body-lg">
     <section role="region" title="Page Overview" class="content-max-width">
-      <h1 tabindex="-1">Add a New Task Order</h1>
-      <p class="ma-0 mt-4 body-lg text--base-darkest">
+      <h1 v-if="!isEdit" tabindex="-1">Add a New Task Order</h1>
+      <p v-if="!isEdit" class="ma-0 mt-4 body-lg text--base-darkest">
         You will find this information in your awarded task order that funds
         your ATAT portfolio. If you have more than one task order, we will walk
         through them one at a time. Select <strong>Next</strong> to view all of
         your funding sources.
+      </p>
+      <!--      edit-->
+      <h1 v-if="isEdit" tabindex="-1">Let’s update your task order details</h1>
+      <p v-if="isEdit" class="ma-0 mt-4 body-lg text--base-darkest">
+        You will find this information in your awarded task order that funds
+        your ATAT portfolio. Select <strong>Next</strong> when you are done
+        making changes, or to skip to your task order summary. From there, you
+        can add additional task orders to your portfolio, if needed
       </p>
     </section>
 
@@ -26,14 +34,14 @@
           :validate-on-load="validateOnLoad"
         />
         <p class="mt-2 mb-7 text--base">
-          This number must be between 13 and 17 digits
+          This number must be either 13 or 17 digits.
         </p>
         <atat-file-upload
           ref="pdfFileUpload"
           :multiple="false"
           :pdfFile.sync="_task_order_file"
           label="Upload Your Approved Task Order"
-          message="Only PDF files with a max file size of 20 MB"
+          message="Only PDF files with a max file size of 10 MB"
           :errorMessageFromParent.sync="fileUploadRequiredErrorMessage"
           :maxFileSize="20"
           :stepNumber="2"
@@ -47,9 +55,9 @@
         who has the authority to execute the task order on your agency’s behalf?
       </p>
       <p>
-        By selecting yes, you certify that the contracting officer has
+        By selecting yes, you certify that the Contracting Officer has
         authorized you to upload the task order in accordance with your agency’s
-        policy and procedures.
+        policies and procedures.
       </p>
       <div
         v-if="signedTaskOrderErrorMessage !== ''"
@@ -99,17 +107,17 @@
         </div>
         <div class="black--text body-lg ml-2 mr-2">
           <p>
-            You will not be able to provision cloud resources within ATAT
-            without an awarded Task Order that is signed by a duly warranted
-            Contracting Officer. Please contact your Contracting Officer for
-            questions regarding your Task Order status or to obtain
-            authorization to spend government funds.
+            You cannot provision cloud resources within ATAT without an awarded
+            task order that is signed by a duly warranted Contracting Officer.
+            Please contact your Contracting Officer for questions regarding your
+            task order status or to obtain authorization to spend government
+            funds.
           </p>
           <p class="mb-0">
             You are subject to potential penalties that may include fines,
             imprisonment, or both, under the U.S. law and regulations for any
-            false statement or misrepresentation in association with this Task
-            Order submission or on any accompanying documentation.
+            false statement or misrepresentation in association with this task
+            order submission or on any accompanying documentation.
           </p>
         </div>
       </v-alert>
@@ -120,9 +128,9 @@
     <section role="region" title="Contract Line Items">
       <h2>Contract Line Items</h2>
       <p class="mb-0 content-max-width">
-        A CLIN is a line in your contract that lists the services and products
-        to be delivered with a price or ceiling which cannot be exceeded. Refer
-        to your task order to locate your Contract Line Item Numbers (CLINs).
+        A Contract Line Item Number (CLIN) is a line in your task order that
+        lists the services and products to be delivered with a price or ceiling
+        which cannot be exceeded. Refer to your task order to locate your CLINs.
       </p>
       <clins-card-list
         class="my-9 mt-7"
@@ -155,10 +163,11 @@ export default class CreateTaskOrderForm extends Vue {
   public isYesButtonClicked = false;
   public isNoButtonClicked = false;
   private fileUploadRequiredErrorMessage = "";
-  private helpText = `If your contracting officer used:
-    Form 1149: Enter the “Order Number”
+  private helpText = `If your Contracting Officer used:
+    Form 1449: Enter the “Order Number”
     Form 1155: Enter the “Delivery Order/Call No.”`;
   private savedTaskOrderSigned = false;
+  private isEdit = false;
 
   @PropSync("task_order_number") _task_order_number!: number;
   @PropSync("task_order_file") _task_order_file!: TaskOrderFile;
@@ -240,6 +249,10 @@ export default class CreateTaskOrderForm extends Vue {
     ) {
       this.savedTaskOrderSigned = true;
       this.isTaskOrderSigned(this._signed);
+    }
+
+    if (this.$route.name === "editfunding") {
+      this.isEdit = true;
     }
   }
 

--- a/src/wizard/Step5/views/PostReview.vue
+++ b/src/wizard/Step5/views/PostReview.vue
@@ -14,7 +14,7 @@
           A duly warranted Contracting Officer, who has the authority to execute
           task orders on your agency’s behalf, must authorize you to upload task
           orders and provision cloud resources, in accordance with agency policy
-          and procedures
+          and procedures.
         </p>
       </v-col>
     </v-row>

--- a/src/wizard/Step5/views/PostReview.vue
+++ b/src/wizard/Step5/views/PostReview.vue
@@ -14,7 +14,7 @@
           A duly warranted Contracting Officer, who has the authority to execute
           task orders on your agency’s behalf, must authorize you to upload task
           orders and provision cloud resources, in accordance with agency policy
-          and procedures.
+          and procedures
         </p>
       </v-col>
     </v-row>


### PR DESCRIPTION
Update verbiage in Step 2’s ‘Add New Task Order’ page of the Portfolio Provisioning Wizard. All surrounding verbiage and edit history can be checked in this Google Doc if needed. The recommendation when updating verbiage is to copy-paste to ensure word-for-word changes, and not to worry about the details of the updates. The exception is italicized indicators of where the text is going to be, such as “* Tooltip:” and “* Subtext:”.