### PR TITLE
file upload fix

### DIFF
--- a/src/api/utility/index.ts
+++ b/src/api/utility/index.ts
@@ -1,0 +1,20 @@
+import { TaskOrderFile } from "types/Wizard";
+import ApiClient from "../apiClient";
+
+const client = new ApiClient("");
+
+export const uploadTaskOrderFile = async (
+  file: FormData
+): Promise<TaskOrderFile> => {
+  const response = await client.post("taskOrderFiles", file, {
+    headers: {
+      "Content-Type": "multipart/form-data",
+    },
+  });
+
+  if (response.status !== 201) {
+    throw Error(" error uploading file");
+  }
+  const data = response.data as TaskOrderFile;
+  return data;
+};

--- a/src/api/utility/index.ts
+++ b/src/api/utility/index.ts
@@ -15,6 +15,5 @@ export const uploadTaskOrderFile = async (
   if (response.status !== 201) {
     throw Error(" error uploading file");
   }
-  const data = response.data as TaskOrderFile;
-  return data;
+  return response.data as TaskOrderFile;
 };

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -172,9 +172,8 @@
 import Vue from "vue";
 import { Component, Prop, Watch, PropSync } from "vue-property-decorator";
 import { UploadedFile } from "../../types/FormFields";
-import { TaskOrderFile } from "types/Wizard";
-import axios from "axios";
-import { retrieveSessionConfig } from "@/atat-config-builder";
+import { TaskOrderFile } from "types/Wizard";;
+import { uploadTaskOrderFile } from "@/api/utility";
 
 @Component
 export default class ATATFileUpload extends Vue {
@@ -394,25 +393,14 @@ export default class ATATFileUpload extends Vue {
     const formData = new FormData();
     formData.append(taskOrderFile.name, this.files[0]);
 
-    const uploadUrl = retrieveSessionConfig()?.apiUrl;
-
-    await axios
-      .post(`${uploadUrl}/taskOrderFiles`, formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
-      })
-      .then((response) => {
-        this.taskOrderFile = response.data;
-        this.uploadedFile = [this.taskOrderFile];
-        // todo add this._pdfFile = taskOrderFile when
-        // API is ready
-        // console.log(this);
-        this._pdfFile = this.taskOrderFile;
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+    try {
+      const uploadedTaskOrderFile = await uploadTaskOrderFile(formData);
+      this.taskOrderFile = uploadedTaskOrderFile;
+      this.uploadedFile = [this.taskOrderFile];
+       this._pdfFile = this.taskOrderFile;
+    } catch (error) {
+      console.log(error);
+    }
   }
   /**
    * validates file and returns a Promise<boolean> for valid/invalid file


### PR DESCRIPTION
fixes broken file upload after API update to require Auth token.  The file upload component was calling axios directly and didn't have the token injected into the axios instance. Added upload file utility call that makes use of the ApiClient class