### PR TITLE
fixed verbiage on step 5

### DIFF
--- a/src/wizard/Step5/components/PortfolioSummary.vue
+++ b/src/wizard/Step5/components/PortfolioSummary.vue
@@ -2,7 +2,7 @@
   <v-container fluid>
     <v-row class="body-lg">
       <v-col class="content-max-width pb-0">
-        <h1 tabindex="-1">Let’s wrap up your Portfolio</h1>
+        <h1 tabindex="-1">Let’s wrap up your portfolio</h1>
         <p class="body-lg" v-if="!invalidStepsExist()">
           In this last step, we will review the information provided to make
           sure everything is complete and accurate. Once verified, we will

--- a/src/wizard/Step5/components/PortfolioSummary.vue
+++ b/src/wizard/Step5/components/PortfolioSummary.vue
@@ -4,10 +4,9 @@
       <v-col class="content-max-width pb-0">
         <h1 tabindex="-1">Let’s wrap up your Portfolio</h1>
         <p class="body-lg" v-if="!invalidStepsExist()">
-          In this last step, we will review the information that you provided to
-          make sure everything is complete and accurate. Once you have verified
-          your portfolio details, we will be able to provision your cloud
-          resources.
+          In this last step, we will review the information provided to make
+          sure everything is complete and accurate. Once verified, we will
+          provision your cloud resources.
         </p>
         <!-- Invalid steps found -->
         <p v-else>
@@ -90,6 +89,5 @@ export default class PortfolioSummary extends mixins(ApplicationData) {
     this.portfolio = this.$store.getters.getPortfolio;
     this.taskOrders = this.$store.getters.getTaskOrders;
   }
-
 }
 </script>


### PR DESCRIPTION
Update verbiage in Step 5’s ‘Review Portfolio’ page of the Portfolio Provisioning Wizard. All surrounding verbiage and edit history can be checked in this Google Doc if needed. The recommendation when updating verbiage is to copy-paste to ensure word-for-word changes, and not to worry about the details of the updates. The exception is italicized indicators of where the text is going to be, such as “* Tooltip:” and “* Subtext:”.