### PR TITLE
 verbiage for step 5 ready to submit

### DIFF
--- a/src/components/SideDrawerComponents/SubmitDrawer.vue
+++ b/src/components/SideDrawerComponents/SubmitDrawer.vue
@@ -8,13 +8,12 @@
       <p>Yes. However, ATAT is not a system of record.</p>
       <p>
         After provisioning, you will be able to add new task orders and team
-        members. This information will be submitted to your cloud service
-        provider, in order to keep your cloud resources funded and operational
-        in the future.
+        members. This information will be submitted to your CSP, in order to
+        keep your cloud resources funded and operational in the future.
       </p>
       <p>
         However, any updates made to existing task orders, applications,
-        environments and team member permissions within ATAT will not be
+        environments, and team member permissions within ATAT will not be
         reflected within your cloud service provider console. And vice versa,
         any changes that your team members make within the CSP console will not
         be synced with ATAT.

--- a/src/wizard/Step5/views/Submit.vue
+++ b/src/wizard/Step5/views/Submit.vue
@@ -2,13 +2,16 @@
   <div>
     <div class="content-max-width">
       <h1 tabindex="-1">Your portfolio is complete! Ready to submit?</h1>
-      <p class="body-lg">
-        You can save this portfolio as a draft and return to make edits at any
-        time. Once you are ready to submit your portfolio, click the
+      <p class="body-lg mb-0">
+        Once you are ready to submit your portfolio, click the
         <strong>Provision Cloud Resources</strong> button. We will send the
         information you provided to
         <strong> {{ this.$store.getters.getPortfolio.csp }} </strong> and begin
         the process of setting up your workspaces and team members.
+      </p>
+      <p class="body-lg mb-0 py-4">
+        <strong>Not quite ready?</strong> Save this portfolio as a draft and
+        return to make edits at any time.
       </p>
       <v-alert
         :icon="false"


### PR DESCRIPTION
Update verbiage in Step 5’s ‘Ready to Submit?’ page of the Portfolio Provisioning Wizard. All surrounding verbiage and edit history can be checked in this Google Doc if needed. The recommendation when updating verbiage is to copy-paste to ensure word-for-word changes, and not to worry about the details of the updates. The exception is italicized indicators of where the text is going to be, such as “* Tooltip:” and “* Subtext:”.