### PR TITLE
Shorten OIDC token validity

### DIFF
--- a/cdk/lib/atat-static-spa-stack.ts
+++ b/cdk/lib/atat-static-spa-stack.ts
@@ -72,8 +72,9 @@ export class StaticSiteStack extends cdk.Stack {
       supportedIdentityProviders: idpNames.map(
         cognito.UserPoolClientIdentityProvider.custom
       ),
-      accessTokenValidity: cdk.Duration.minutes(60),
-      refreshTokenValidity: cdk.Duration.days(1),
+      accessTokenValidity: cdk.Duration.minutes(5),
+      idTokenValidity: cdk.Duration.minutes(5),
+      refreshTokenValidity: cdk.Duration.minutes(30),
       oAuth: {
         flows: {
           authorizationCodeGrant: true,


### PR DESCRIPTION
Setting these values far lower lets us perform debugging and get an
understanding of the lifecycle and flow between Amplify and Cognito.
These very likely are still insufficient for production requirements but
it's a starting point for testing.