### PR TITLE
Increase memory size on the proxy function

### DIFF
--- a/cdk/lib/apigateway-proxy.ts
+++ b/cdk/lib/apigateway-proxy.ts
@@ -19,6 +19,7 @@ export class ApiGatewayProxy extends cdk.Construct {
 
     const lambdaProxy = new lambdaNodeJs.NodejsFunction(this, "Proxy", {
       entry: "functions/proxy.ts",
+      memorySize: 512,
       environment: {
         SPA_BUCKET_NAME: props.bucket.bucketName,
         ENVIRONMENT_ID: props.environmentId,


### PR DESCRIPTION
We're seeing a few 502s on larger files. Lambda allocates
CPU/network/disk proportionally to the amount of memory allocated. This
means that increasing the allocated memory increases these other values
as well, hopefully reducing the number of timeouts that we see on the
backing Lambda function.