### PR TITLE
Increase refresh token validity to 60min

### DIFF
--- a/cdk/lib/atat-static-spa-stack.ts
+++ b/cdk/lib/atat-static-spa-stack.ts
@@ -74,7 +74,7 @@ export class StaticSiteStack extends cdk.Stack {
       ),
       accessTokenValidity: cdk.Duration.minutes(5),
       idTokenValidity: cdk.Duration.minutes(5),
-      refreshTokenValidity: cdk.Duration.minutes(30),
+      refreshTokenValidity: cdk.Duration.minutes(60),
       oAuth: {
         flows: {
           authorizationCodeGrant: true,


### PR DESCRIPTION
This is the minimum allowed validity; we cannot go lower than 60min.
