### PR TITLE
feature/AT-6815

### DIFF
--- a/src/components/SideDrawer.vue
+++ b/src/components/SideDrawer.vue
@@ -49,6 +49,9 @@
         v-if="sideDrawerType === 'profile'"
         :scrollableDivHeight="setScrollableDivHeight(95)"
       ></ProfileDrawer>
+      <PortfolioFilterDrawer
+        v-if="sideDrawerType === 'portfoliofilter'"
+      ></PortfolioFilterDrawer>
       <SubmitDrawer v-if="sideDrawerType === 'submit'"></SubmitDrawer>
       <TeamMemberRolesDrawer
         v-if="sideDrawerType === 'teammemberroles'"
@@ -63,12 +66,14 @@ import Vue from "vue";
 
 import { Component, Prop, Watch } from "vue-property-decorator";
 import ProfileDrawer from "./SideDrawerComponents/ProfileDrawer.vue";
+import PortfolioFilterDrawer from "./SideDrawerComponents/PortfolioFilterDrawer.vue";
 import SubmitDrawer from "./SideDrawerComponents/SubmitDrawer.vue";
 import TeamMemberRolesDrawer from "./SideDrawerComponents/TeamMemberRolesDrawer.vue";
 
 @Component({
   components: {
     ProfileDrawer,
+    PortfolioFilterDrawer,
     SubmitDrawer,
     TeamMemberRolesDrawer,
   },
@@ -102,6 +107,9 @@ export default class SideDrawer extends Vue {
       case "submit":
       case "teammemberroles":
         title = "Learn More";
+        break;
+      case "portfoliofilter":
+        title = "Filter Your Results";
         break;
       default:
         break;

--- a/src/components/SideDrawerComponents/PortfolioFilterDrawer.vue
+++ b/src/components/SideDrawerComponents/PortfolioFilterDrawer.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="body-lg">
+    <v-divider></v-divider>
+    <div class="mx-6 mt-6">
+      { This is the portfolio filter placeholder }
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+@Component({})
+export default class PortfolioFilterDrawer extends Vue {}
+</script>

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -142,7 +142,6 @@ export default class ViewPortfolio extends Vue {
       "portfoliofilter",
       "PortfolioFilter",
     ]);
-
   }
 
   private toggleSortMenu(event: KeyboardEvent) {

--- a/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
+++ b/src/wizard/Step0/components/ViewPortfolio/ViewPortfolio.vue
@@ -34,7 +34,7 @@
             single-line
             hide-details
             clearable
-            aria-label="Search"
+            aria-label="Search Term"
             v-model="searchTerm"
           />
           <v-btn
@@ -59,7 +59,13 @@
           >
             Portfolio Name A-Z
           </a>
-          <v-btn class="filter px-0" outlined>
+          <v-btn
+            aria-label="Open panel to filter portfolio results"
+            id="PortfolioFilter"
+            class="filter px-0"
+            outlined
+            @click="openFilterPanel"
+          >
             <v-icon class="icon-24">filter_alt</v-icon>
           </v-btn>
         </div>
@@ -129,6 +135,14 @@ export default class ViewPortfolio extends Vue {
 
   private async mounted(): Promise<void> {
     await this.loadPortfolioDrafts();
+  }
+
+  private openFilterPanel(): void {
+    this.$store.dispatch("openSideDrawer", [
+      "portfoliofilter",
+      "PortfolioFilter",
+    ]);
+
   }
 
   private toggleSortMenu(event: KeyboardEvent) {


### PR DESCRIPTION
1. The Filter button exists on the Portfolios Page.
2. Clicking on the button opens the filter drawer to the right side of the portfolios page.
    - When the filter drawer opens, the portfolio card lists should adjust in width to accommodate for the size of the filter drawer so both are viewable side-by-side.
    - 'FILTER YOUR RESULTS’ header text is present at the top of the filter drawer.
    - 'X' icon is present in the top right corner.
      - When clicked, the filter drawer is closed and the portfolio card lists should revert back to their original width prior to opening the drawer. 
3. The button is accessible via keyboard and screen reader.