### PR TITLE
Feature/at-6839-step1-error-alert

### DIFF
--- a/src/wizard/Step1/components/CloudServiceProviderForm.vue
+++ b/src/wizard/Step1/components/CloudServiceProviderForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="body-lg content-max-width">
-    <fieldset>
+    <fieldset id="cloud-service-provider" class="atat-radio-button-cards">
       <legend>Cloud Service Provider</legend>
       <p class="mb-1">
         Select the CSP where you want to deploy this portfolio.<strong

--- a/src/wizard/Step1/components/CreatePorfolioForm.vue
+++ b/src/wizard/Step1/components/CreatePorfolioForm.vue
@@ -26,6 +26,21 @@
         </p>
       </v-col>
     </v-row>
+    <ATATAlert
+      type="error"
+      class="mt-0 mb-8"
+      :closeButton="false"
+      v-if="_erroredFields.length > 0"
+    >
+      <template v-slot:content>
+        Please review the fields below and take any necessary actions.
+        <ul>
+          <li v-for="(item, index) in _erroredFields" :key="index">
+            {{ item.message }}
+          </li>
+        </ul>
+      </template>
+    </ATATAlert>
     <v-row class="mt-0 pt-0">
       <v-col class="py-0 input-max-width">
         <atat-text-field
@@ -117,15 +132,17 @@
 </template>
 
 <script lang="ts">
-import { ValidatableForm } from "types/Wizard";
+import { ErrorPanelMessages, ValidatableForm } from "types/Wizard";
 import Vue from "vue";
 import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
 import dodComponents from "../../../data/dodComponents";
 import ATATDivider from "@/components/ATATDivider.vue";
+import ATATAlert from "@/components/ATATAlert.vue";
 
 @Component({
   components: {
     "atat-divider": ATATDivider,
+    ATATAlert,
   },
 })
 export default class CreatePortfolioForm
@@ -141,6 +158,9 @@ export default class CreatePortfolioForm
     return this._dod_components.findIndex((d) => d === dodComp) > -1;
   }
   private stepHasBeenTouched = false;
+  @PropSync("erroredFields") private _erroredFields:
+    | ErrorPanelMessages[]
+    | undefined;
   @PropSync("name", { default: "", required: true }) portfolio_name!: string;
   @PropSync("description", { default: "", required: true })
   portfolio_description!: string;

--- a/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
+++ b/src/wizard/Step1/components/CreatePortfolioForm.spec.ts
@@ -30,6 +30,7 @@ describe("Testing CreatePortfolioForm Component", () => {
         name: undefined,
         description: "testDescription",
         dod_components: undefined,
+        erroredFields: [],
       },
     });
   });

--- a/src/wizard/Step1/views/Step1.spec.ts
+++ b/src/wizard/Step1/views/Step1.spec.ts
@@ -53,6 +53,9 @@ describe("Testing Step1 Component", () => {
         "atat-text-area",
         "atat-button-card",
       ],
+      propsData: {
+        step: 1,
+      },
       mocks: { $route },
     });
     wrapper.setData({
@@ -75,6 +78,22 @@ describe("Testing Step1 Component", () => {
 
   it("contains CloudServiceProviderForm Component", () => {
     expect(wrapper.vm.$refs.cloudServiceProviderForm).toBeDefined();
+  });
+
+  it("should get errorPanelMessages", async () => {
+    await wrapper.vm.errorPanelMessages;
+    expect(wrapper.vm.errorPanelMessages).toStrictEqual([
+      { display: false, id: 0, message: "Portfolio Name" },
+      { display: false, id: 1, message: "DoD Component" },
+      { display: false, id: 2, message: "Cloud Service Provider" },
+    ]);
+    await wrapper.vm.displayedErrorPanelMessages();
+  });
+  it("setTimeout in mount", async (done) => {
+    setTimeout(() => {
+      expect(wrapper.exists()).toBe(true);
+      done();
+    }, 1000);
   });
 
   it("test validate() ", async () => {

--- a/src/wizard/Step1/views/Step1.vue
+++ b/src/wizard/Step1/views/Step1.vue
@@ -6,6 +6,7 @@
       :description.sync="model.description"
       :dod_components.sync="model.dod_components"
       :validate-on-load="touched"
+      :erroredFields.sync="erroredFields"
     />
 
     <atat-divider />
@@ -23,7 +24,10 @@ import { Component } from "vue-property-decorator";
 
 import CreatePortfolioForm from "../components/CreatePorfolioForm.vue";
 import CloudServiceProvider from "../components/CloudServiceProviderForm.vue";
-import { CreatePortfolioFormModel } from "../../../../types/Wizard";
+import {
+  CreatePortfolioFormModel,
+  ErrorPanelMessages,
+} from "../../../../types/Wizard";
 import ValidatableWizardStep from "../../ValidatableWizardStep.vue";
 import ATATDivider from "@/components/ATATDivider.vue";
 
@@ -36,6 +40,8 @@ import ATATDivider from "@/components/ATATDivider.vue";
   // mixins: [ValidatableWizardStep],
 })
 export default class Step_1 extends ValidatableWizardStep<CreatePortfolioFormModel> {
+  private erroredFields: ErrorPanelMessages[] = [];
+
   $refs!: {
     createPortfolioForm: CreatePortfolioForm;
     cloudServiceProviderForm: CloudServiceProvider;
@@ -44,6 +50,40 @@ export default class Step_1 extends ValidatableWizardStep<CreatePortfolioFormMod
   model: CreatePortfolioFormModel =
     this.$store.getters["wizard/getStepModel"](1);
 
+  get errorPanelMessages(): ErrorPanelMessages[] {
+    return [
+      { id: 0, display: false, message: "Portfolio Name" },
+      { id: 1, display: false, message: "DoD Component" },
+      { id: 2, display: false, message: "Cloud Service Provider" },
+    ];
+  }
+  public async displayedErrorPanelMessages(): Promise<void> {
+    this.getPanelErrorMessages();
+    this.erroredFields = this.errorPanelMessages.filter((epm) => {
+      return epm.display === true;
+    });
+  }
+  public getPanelErrorMessages(): void {
+    this.errorPanelMessages[0].display = this.displayErrorInPanel(
+      "portfolio-name",
+      "atat-text-field"
+    );
+    this.errorPanelMessages[1].display = this.displayErrorInPanel(
+      "dod-component",
+      "atat-checkbox-list"
+    );
+    this.errorPanelMessages[2].display = this.displayErrorInPanel(
+      "cloud-service-provider",
+      "atat-radio-button-cards"
+    );
+  }
+  public displayErrorInPanel(selectorId: string, type: string): boolean {
+    return (
+      document.querySelector(
+        "[id^='" + selectorId + "']." + type + " .error--text"
+      ) !== null
+    );
+  }
   public validate: () => Promise<boolean> = async () => {
     const createPortofolioValidation =
       this.$refs.createPortfolioForm.validateForm();
@@ -57,5 +97,11 @@ export default class Step_1 extends ValidatableWizardStep<CreatePortfolioFormMod
 
     return this.valid;
   };
+
+  public async mounted(): Promise<void> {
+    setTimeout(() => {
+      this.displayedErrorPanelMessages();
+    }, 1000);
+  }
 }
 </script>


### PR DESCRIPTION
Create the red alert message that displays towards the top of the Step 1 - Create Portfolio page in the Portfolio Wizard. This message should display the input fields that have an error (i.e. the user did not provide a valid input for Portfolio name, DoD Component, and/or Cloud Service Provider) after the user moves on to the next step.

