### PR TITLE
Feature/at 6998

### DIFF
--- a/src/components/Charts/DonutChart.vue
+++ b/src/components/Charts/DonutChart.vue
@@ -12,21 +12,27 @@ import ChartDataLabels from "chartjs-plugin-datalabels";
 export default class DonutChart extends Vue {
   @Prop({ required: true, default: "myDonutChart" }) public chartId!: string;
   @Prop({ required: true, default: {} }) public chartData!: ChartData;
-  @Prop({ required: true, default: {} }) public chartOptions!: ChartOptions;
+  @Prop({ required: true, default: {} }) public chartOptions!: any;
   @Prop({ required: false, default: false })
-  public useChartDataLabels!: boolean;
   @Prop({ required: false, default: false }) public isArcGauge!: boolean;
   @Prop({ required: false, default: "" }) public centerText1!: string;
   @Prop({ required: false, default: "" }) public centerText2!: string;
+  @Prop({ required: false, default: false }) public useChartDataLabels!: boolean;
 
   private mounted() {
+    const toolTipExternalOptions = {
+      enabled: false,
+      position: "nearest",
+      external: this.externalTooltipHandler,
+    };
+    this.chartOptions.plugins.tooltip = toolTipExternalOptions;
     this.createChart();
   }
 
   public createChart(): void {
     const centertext = this.centertext(this);
+    let plugins: any = [centertext];
     if (this.chartId) {
-      let plugins: any = [centertext];
       if (this.useChartDataLabels) {
         plugins.push(ChartDataLabels);
       }
@@ -39,6 +45,104 @@ export default class DonutChart extends Vue {
       });
     }
   }
+
+  public getOrCreateTooltip = (chart: any) => {
+    let tooltipEl = chart.canvas.parentNode.querySelector("div#donutChartTooltip");
+    if (!tooltipEl) {
+      tooltipEl = document.createElement("div");
+      tooltipEl.setAttribute("id", "donutChartTooltip");
+      tooltipEl.style.background = "rgba(27, 27, 27, 0.9)";
+      tooltipEl.style.borderRadius = "3px";
+      tooltipEl.style.color = "white";
+      tooltipEl.style.opacity = 1;
+      tooltipEl.style.pointerEvents = "none";
+      tooltipEl.style.position = "absolute";
+      tooltipEl.style.transform = "translate(8%, -50%)";
+      tooltipEl.style.transition = "all .1s ease";
+
+      const table = document.createElement("table");
+      table.setAttribute("id", "donutChartTooltipTable");
+      table.style.margin = "0px";
+
+      tooltipEl.appendChild(table);
+      chart.canvas.parentNode.appendChild(tooltipEl);
+    }
+
+    return tooltipEl;
+  };
+
+  public externalTooltipHandler = (context: any) => {
+    // Tooltip Element
+    const { chart, tooltip } = context;
+    const tooltipEl = this.getOrCreateTooltip(chart);
+
+    // Hide if no tooltip
+    if (tooltip.opacity === 0) {
+      tooltipEl.style.opacity = 0;
+      return;
+    }
+    // Set Text
+    if (tooltip.body) {
+      const bodyLines = tooltip.body.map((b: any) => b.lines);
+      const tableBody = document.createElement("tbody");
+      bodyLines.forEach((body: any, i: any) => {
+        if (body[0].toLowerCase().indexOf("burn") === -1) {
+          const colors = tooltip.labelColors[i];
+
+          const span = document.createElement("span");
+          span.style.background = colors.backgroundColor;
+          span.style.borderColor = "#ffffff";
+          span.style.borderStyle = "solid";
+          span.style.borderWidth = "1px";
+          span.style.marginRight = "12px";
+          span.style.height = "14px";
+          span.style.width = "14px";
+          span.style.display = "inline-block";
+
+          const tr = document.createElement("tr");
+          tr.style.backgroundColor = "inherit";
+          tr.style.borderWidth = "0";
+
+          const td = document.createElement("td");
+          td.style.borderWidth = "0";
+          const sep = body[0].indexOf(":");
+          const labelText = body[0].slice(0, sep);
+          const labelValue = "$" + body[0].slice(sep + 2, body[0].length);
+          const text = document.createTextNode(labelText);
+          const val = document.createTextNode(labelValue);
+
+          td.appendChild(span);
+          td.appendChild(text);
+          tr.appendChild(td);
+
+          const td2 = document.createElement("td");
+          td2.style.paddingLeft = "8px";
+          td2.appendChild(val);
+          tr.appendChild(td2);
+
+          tableBody.appendChild(tr);
+        }
+      });
+
+      const tableRoot = tooltipEl.querySelector("table#donutChartTooltipTable");
+      // Remove old children
+      while (tableRoot.firstChild) {
+        tableRoot.firstChild.remove();
+      }
+      // Add new children
+      tableRoot.appendChild(tableBody);
+    }
+
+    const { offsetLeft: positionX, offsetTop: positionY } = chart.canvas;
+
+    // Display, position, and set styles for font
+    tooltipEl.style.opacity = 1;
+    tooltipEl.style.left = positionX + tooltip.caretX + "px";
+    tooltipEl.style.top = positionY + tooltip.caretY + "px";
+    tooltipEl.style.font = tooltip.options.bodyFont.string;
+    tooltipEl.style.padding =
+      tooltip.options.padding + "px " + tooltip.options.padding + "px";
+  };
 
   public centertext(self: any): any {
     const centertext: any = {

--- a/src/sass/atat.scss
+++ b/src/sass/atat.scss
@@ -13,6 +13,7 @@
 @import "./components/_atat_pillbox";
 @import "./components/_atat_portfolio_summary_card";
 @import "./components/_atat_toast";
+@import "./components/_charts";
 @import "./components/v_alerts";
 @import "./components/v_button";
 @import "./components/v_card";

--- a/src/sass/components/_accessibility.scss
+++ b/src/sass/components/_accessibility.scss
@@ -300,3 +300,12 @@ a.v-tab {
     content: "expand_more";
   }
 }
+
+.hidden-table-headers {
+    font-size: 0px;
+    tr {
+        position: absolute;
+        left: -10000;
+
+    }
+}

--- a/src/sass/components/_atat_tabbar.scss
+++ b/src/sass/components/_atat_tabbar.scss
@@ -1,8 +1,11 @@
 .atat-tabbar{
+  .theme--light.v-tabs-items{
+    background-color: transparent !important;
+  }
   .v-tabs-bar{
-    height: 44px !important;  
+    height: 44px !important;
     .v-slide-group__wrapper {
-      
+
       padding-bottom: 3px;
     }
     .v-slide-group__content.v-tabs-bar__content{
@@ -11,9 +14,6 @@
       flex-shrink: 0;
       flex-basis: auto;
       gap:24px;
-    }
-    .theme--light.v-tabs-items{
-      background-color: transparent !important;
     }
     .v-tab {
       padding: 0;

--- a/src/sass/components/_charts.scss
+++ b/src/sass/components/_charts.scss
@@ -1,0 +1,13 @@
+.chart-legend-table {
+  td {
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+}
+
+.chart-legend-square {
+  width: 16px;
+  height: 16px;
+  display: inline-block;
+  margin-right: 8px;
+}

--- a/src/sass/utils/colors.scss
+++ b/src/sass/utils/colors.scss
@@ -140,3 +140,15 @@ $chart_color7: $chart_yellow;
 $chart_color8: $chart_violet-warm;
 $chart_color9: $chart_mint-cool;
 $chart_color10: $chart_orange-warm;
+
+.bg-chart_color1 { background-color: $chart_color1 !important }
+.bg-chart_color2 { background-color: $chart_color2 !important }
+.bg-chart_color3 { background-color: $chart_color3 !important }
+.bg-chart_color4 { background-color: $chart_color4 !important }
+.bg-chart_color5 { background-color: $chart_color5 !important }
+.bg-chart_color6 { background-color: $chart_color6 !important }
+.bg-chart_color7 { background-color: $chart_color7 !important }
+.bg-chart_color8 { background-color: $chart_color8 !important }
+.bg-chart_color9 { background-color: $chart_color9 !important }
+.bg-chart_color10 { background-color: $chart_color10 !important }
+.bg-chart_gray { background-color: $chart_gray !important }

--- a/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
+++ b/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
@@ -183,7 +183,7 @@
                 :chart-data="donutChartData"
                 :chart-options="donutChartOptions"
                 :use-chart-data-labels="true"
-                center-text1="$1,200,000"
+                center-text1="$200,000"
                 center-text2="Total Portfolio Funds"
               />
             </v-col>

--- a/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
+++ b/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
@@ -477,7 +477,6 @@ export default class FundingTracker extends Vue {
     this.chartDataColorSequence[1],
     this.chartDataColors.gray,
   ];
-  public donutChartTotal = 200000.00;
   public donutChartData = {
     labels: ["Funds spent", "Funds awaiting invoice", "Funds remaining"],
     datasets: [
@@ -494,7 +493,6 @@ export default class FundingTracker extends Vue {
       },
     ],
   };
-
   public donutChartOptions = {
     layout: {
       padding: 20,

--- a/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
+++ b/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
@@ -477,13 +477,13 @@ export default class FundingTracker extends Vue {
     this.chartDataColorSequence[1],
     this.chartDataColors.gray,
   ];
-
+  public donutChartTotal = 200000.00;
   public donutChartData = {
     labels: ["Funds spent", "Funds awaiting invoice", "Funds remaining"],
     datasets: [
       {
         label: "Funding Status",
-        data: [73.7, 4.2, 22],
+        data: [147469.04, 8452.48, 44078.48],
         backgroundColor: this.donutChartColors,
         hoverBackgroundColor: this.donutChartColors,
         hoverBorderColor: this.donutChartColors,
@@ -509,8 +509,17 @@ export default class FundingTracker extends Vue {
         align: "end",
         anchor: "end",
         offset: 10,
-        formatter: function (value: number): string {
-          return value ? value + "%" : "";
+        formatter: (value: number, ctx: any) => {
+          let sum = 0;
+          const dataArr = ctx.chart.data.datasets[0].data;
+          dataArr.map((data: number) => {
+            sum += data;
+          });
+          const percentage = Number((value * 100 / sum).toFixed(1));
+          const percentString = !(percentage % 1)
+            ? percentage.toFixed() + "%"
+            : percentage + "%";
+          return percentString;
         },
       },
     },

--- a/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
+++ b/src/views/PortfolioSummary/FundingTracker/views/FundingTracker.vue
@@ -177,7 +177,7 @@
             active task orders during this period of performance.
           </p>
           <v-row>
-            <v-col class="col-sm-5 ml-n6">
+            <v-col class="col-sm-12 col-md-6 col-lg-5 ml-n6">
               <donut-chart
                 chart-id="DonutChart2"
                 :chart-data="donutChartData"
@@ -187,7 +187,63 @@
                 center-text2="Total Portfolio Funds"
               />
             </v-col>
-            <v-col class="col-sm-7"> { legend } </v-col>
+            <v-col class="col-sm-12 col-md-6 col-lg-7">
+              <div class="d-flex height-100 align-center">
+                <div>
+                  <table class="width-100 chart-legend-table">
+                    <thead class="hidden-table-headers">
+                      <tr>
+                        <th>Funds Type</th>
+                        <th>Amount</th>
+                        <th>Percentage of Total Portfolio Funds</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td class="d-flex align-center pr-4">
+                          <span
+                            class="chart-legend-square"
+                            :class="'bg-chart_color' + 1"
+                          >
+                          </span>
+                          <strong>Funds spent</strong>
+                        </td>
+                        <td class="text-right pr-4">$147,469.04</td>
+                        <td class="text-right font-weight-bold">73.7%</td>
+                      </tr>
+                      <tr>
+                        <td class="d-flex align-center pr-4 nowrap">
+                          <span
+                            class="chart-legend-square"
+                            :class="'bg-chart_color' + 2"
+                          >
+                          </span>
+                          <strong>Funds awaiting invoice</strong>
+                        </td>
+                        <td class="text-right pr-4">$8,452.48</td>
+                        <td class="text-right font-weight-bold">4.2%</td>
+                      </tr>
+                      <tr>
+                        <td class="d-flex align-center pr-4">
+                          <span class="chart-legend-square bg-chart_gray"></span>
+                          <strong>Funds remaining</strong>
+                        </td>
+                        <td class="text-right pr-4">$44,078.48</td>
+                        <td class="text-right font-weight-bold">22%</td>
+                      </tr>
+                      <tr>
+                        <td colspan="3" class="py-2"><v-divider /></td>
+                      </tr>
+                      <tr>
+                        <td><strong>Total Portfolio Funds</strong></td>
+                        <td class="text-right pr-4">$200,000.00</td>
+                        <td></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </v-col>
           </v-row>
         </v-card>
       </v-col>


### PR DESCRIPTION
1. Global styles have been updated for data visualizations using the correct palette sequence as listed under ‘Used in Data Visualizations’ in the design library here.
2. The “Breakdown of Actual and Estimated Spend” card exists below the “Spend Summary for Cloud Resources” card with correct formatting, header text, and description text.
3. There is a donut chart, with…
  - The three categories of “Funds spent”, “Funds awaiting invoice”, and “Funds remaining”.
  - Small percentage labels outside each section of the chart.
  - Hover states exist for each category on the chart. When you hover over one category…
    - The category being hovered over grows larger, slightly, outward (not inward towards the center).
    - A tooltip appears, displaying…
      - A box of the color of the category being highlighted.
      - The name of the category being highlighted.
      - The amount in USD that that category represents.
4. The Total Portfolio Funds, with a label beneath it, is displayed in the center of the donut chart.
5. To the right of the chart is a legend, displaying the “Funds spent”, “Funds awaiting invoice”, and “Funds remaining” categories, each with…
  - A square representing their corresponding color in the donut chart to the left of each label.
  - The total amount amount in USD that the category represents.
  - The percentage of the total portfolio funds that the category represents.
6. Underneath the legend is a dividing line, and a line of text displaying the Total Portfolio Funds.
7. The “Breakdown of Actual and Estimated Spend” card is accessible via screen reader.