### PR TITLE
updates to postbuild to bundle material icon paths

### DIFF
--- a/servicenow.config.js
+++ b/servicenow.config.js
@@ -15,12 +15,12 @@ const servicenowConfig = {
      * Image files (png, jpg, gif)
      * SVG files will be embedded into javascript files
      */
-    IMG_API_PATH: '/api/x_744337_vue_app/container/img/',
+    IMG_API_PATH: 'api/x_744337_vue_app/container/img/',
     /**
      * ServiceNow path to GET resource which serves
      * other files, like fonts etc.
      */
-    ASSETS_API_PATH: '/api/x_744337_vue_app/container/other_assets/',
+    ASSETS_API_PATH: 'api/x_744337_vue_app/container/other_assets/',
     /**
      * fonts and images below this size will be put inside
      * JS chunks, instead of being saved as separate files

--- a/servicenow.postbuild.js
+++ b/servicenow.postbuild.js
@@ -5,7 +5,9 @@ const servicenowConfig = require('./servicenow.config')
 const fs = require('fs')
 const dirTree = require('directory-tree')
 const clear = require('clear')
-const { Console } = require('console')
+const {
+  Console
+} = require('console')
 const PATH_TO_DIST_HTML = 'dist/index.html'
 const linkRelRegEx = /<\s*link[^>]*(.*?)>/g;
 const scriptTagRegEx = /<script\b[^>]*>[\s\S/]*?<\/script\b[^>]*>/g
@@ -192,7 +194,7 @@ function decorateIndexHTML(pathToHTML) {
 function updateAssetPaths() {
 
   debugger;
-  
+
   clear();
 
   console.log('\n');
@@ -207,12 +209,11 @@ function updateAssetPaths() {
     const vendorJsPath = `./dist/js/${vendorJsFile}`;
     const vendorJsContent = fs.readFileSync(vendorJsPath, 'utf-8');
     let vendorJs = vendorJsContent;
-    vendorJs = vendorJs.replace(materialIconsRegEx, 
-    `${servicenowConfig.ASSETS_API_PATH}MaterialIcons`);
+    vendorJs = vendorJs.replace(materialIconsRegEx,
+      `${servicenowConfig.ASSETS_API_PATH}MaterialIcons`);
 
     fs.writeFileSync(vendorJsPath, vendorJs, 'utf-8');
-  }
-  else{
+  } else {
 
     console.error("unable to locate vendor js file");
   }

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -1,6 +1,5 @@
 import Vue from "vue";
 import Vuetify from "vuetify/lib";
-import "typeface-source-sans-pro";
 import "material-design-icons-iconfont/dist/material-design-icons.css";
 import light from "./theme";
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -49,21 +49,36 @@ module.exports = {
 
     if (process.env.NODE_ENV === 'production') {
       config.module
-          .rule("images")
-          .use("url-loader")
-          .loader("url-loader")
-          .tap(options => Object.assign(options,
-              {
-                limit: CONFIG.ASSET_SIZE_LIMIT,
-                fallback: {
-                  ...options.fallback,
-                  options: {
-                    name: 'img/[name]-[hash:6]-[ext]',
-                  }
+        .rule("images")
+        .use("url-loader")
+        .loader("url-loader")
+        .tap(options => Object.assign(options, {
+          limit: CONFIG.ASSET_SIZE_LIMIT,
+          fallback: {
+            ...options.fallback,
+            options: {
+              name: 'img/[name]-[hash:6]-[ext]',
+            }
 
-                }
+          }
 
-              }));
+        }));
+
+      config.module
+        .rule("fonts")
+        .use("url-loader")
+        .loader("url-loader")
+        .tap(options => Object.assign(options, {
+          limit: CONFIG.ASSET_SIZE_LIMIT,
+          fallback: {
+            ...options.fallback,
+            options: {
+              name: 'other_assets/[name]-[hash:6]-[ext]',
+            }
+
+          }
+
+        }));
 
       if (process.env.NODE_ENV === 'development') {
         config.plugin('define').tap((definitions) => {
@@ -72,19 +87,6 @@ module.exports = {
           return definitions;
         });
       }
-
-
-      // imgsRule.options = {
-      //   limit: CONFIG.ASSET_SIZE_LIMIT,
-      //   name: 'img/[name]-[hash:6]-[ext]',
-      // }
-
-      //   config.module.rule('fonts').
-      //   fonts.options = {
-      //     limit: CONFIG.ASSET_SIZE_LIMIT,
-      //     name: 'assets/[name]-[hash:6]-[ext]',
-      //   }
-      // }
     }
   },
   css: {


### PR DESCRIPTION
Material icon fonts are now dropped into "other_assets" folder post build
Postbuild script replaces Material icon references in vendor js to match service now scripted api 