### PR TITLE
Feature/at 7110 cor contact form

### DIFF
--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -40,7 +40,11 @@
 
       <ContactInfoForm :isACOR="isACOR" v-show="showContactForm && !haveSelectedContact"/>
       
-      <section id="AccessRadioButtons" v-show="showContactForm || haveSelectedContact">
+      <section id="AccessRadioButtons" 
+        v-show="(showContactForm && selectedBranch) || haveSelectedContact"
+      >
+      <!-- EJY need to send up when branch is selected or civilian is selected from
+      the contact form -->
         <hr />
         <ATATRadioGroup
           legend="Does this individual need access to help you create this acquisition package in ATAT?"

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -38,10 +38,14 @@
         Manually enter your {{ corOrAcor }}’s contact information
       </a>
 
-      <ContactInfoForm :isACOR="isACOR" v-show="showContactForm && !haveSelectedContact"/>
+      <ContactInfoForm 
+        :isACOR="isACOR" 
+        v-show="showContactForm && !haveSelectedContact"
+        :showAccessRadioButtons.sync="showAccessRadioButtons"
+      />
       
       <section id="AccessRadioButtons" 
-        v-show="(showContactForm && selectedBranch) || haveSelectedContact"
+        v-show="showAccessRadioButtons || haveSelectedContact"
       >
       <!-- EJY need to send up when branch is selected or civilian is selected from
       the contact form -->
@@ -93,7 +97,7 @@ export default class COR_ACOR extends Vue {
   }
 
   // data
-
+  public showAccessRadioButtons = false;
   public showContactForm = false;
   private selectedAccessToEdit = "";
   private accessToEditOptions: RadioButton[] = [

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -47,8 +47,6 @@
       <section id="AccessRadioButtons" 
         v-show="(showContactForm && showAccessRadioButtons) || haveSelectedContact"
       >
-      <!-- EJY need to send up when branch is selected or civilian is selected from
-      the contact form -->
         <hr />
         <ATATRadioGroup
           legend="Does this individual need access to help you create this acquisition package in ATAT?"

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -45,7 +45,7 @@
       />
       
       <section id="AccessRadioButtons" 
-        v-show="showAccessRadioButtons || haveSelectedContact"
+        v-show="(showContactForm && showAccessRadioButtons) || haveSelectedContact"
       >
       <!-- EJY need to send up when branch is selected or civilian is selected from
       the contact form -->
@@ -108,7 +108,7 @@ export default class COR_ACOR extends Vue {
     },
     {
       id: "AccessToEdit_No",
-      label: "No",
+      label: "No.",
       value: "no",
     },
   ];

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -1,67 +1,66 @@
 <template>
-    <div class="pt-0">
-
-      <div class="max-width-640">
-        <ATATAutoComplete
-          id="SearchContact"
-          :class="haveSelectedContact ? 'mb-10' : 'mb-8'"
-          :label-sr-only="true"
-          :label="'Search for your ' + corOrAcor"
-          titleKey="FullName"
-          subtitleKey="Email"
-          :items="contactList"
-          :searchFields="['FullName', 'Email']"
-          :selectedItem.sync="selectedContact"
-          placeholder="Search by name or email"
-          icon="search"
-          :noResultsText="'Manually enter my ' + corOrAcor + '’s contact information'"
-          @autocompleteInputUpdate="autocompleteInputUpdate"
-        />
-
-        <PersonCard 
-          v-if="haveSelectedContact" 
-          :isACOR="isACOR"
-          :selectedContact.sync="selectedContact"
-          :showContactForm.sync="showContactForm"
-        />
-      </div>
-
-      <a 
-        id="ContactFormToggle"
-        v-show="!haveSelectedContact"
-        role="button" 
-        class="expandable-content-opener"
-        :class="showContactForm ? 'open' : 'closed'"
-        tabindex="0"
-        @click="toggleContactForm"
-      >
-        Manually enter your {{ corOrAcor }}’s contact information
-      </a>
-
-      <ContactInfoForm 
-        :isACOR="isACOR" 
-        v-show="showContactForm && !haveSelectedContact"
-        :showAccessRadioButtons.sync="showAccessRadioButtons"
+  <div class="pt-0">
+    <div class="max-width-640">
+      <ATATAutoComplete
+        id="SearchContact"
+        :class="haveSelectedContact ? 'mb-10' : 'mb-8'"
+        :label-sr-only="true"
+        :label="'Search for your ' + corOrAcor"
+        titleKey="FullName"
+        subtitleKey="Email"
+        :items="contactList"
+        :searchFields="['FullName', 'Email']"
+        :selectedItem.sync="selectedContact"
+        placeholder="Search by name or email"
+        icon="search"
+        :noResultsText="'Manually enter my ' + corOrAcor + '’s contact information'"
+        @autocompleteInputUpdate="autocompleteInputUpdate"
       />
-      
-      <section id="AccessRadioButtons" 
-        v-show="(showContactForm && showAccessRadioButtons) || haveSelectedContact"
-      >
-        <hr />
-        <ATATRadioGroup
-          legend="Does this individual need access to help you create this acquisition package in ATAT?"
-          id="AccessToEdit"
-          :items="accessToEditOptions"
-          :value.sync="selectedAccessToEdit"
-        />
-      </section>
 
+      <PersonCard 
+        v-if="haveSelectedContact" 
+        :isACOR="isACOR"
+        :selectedContact.sync="selectedContact"
+        :showContactForm.sync="showContactForm"
+      />
     </div>
+
+    <a 
+      id="ContactFormToggle"
+      v-show="!haveSelectedContact"
+      role="button" 
+      class="expandable-content-opener"
+      :class="showContactForm ? 'open' : 'closed'"
+      tabindex="0"
+      @click="toggleContactForm"
+    >
+      Manually enter your {{ corOrAcor }}’s contact information
+    </a>
+
+    <ContactInfoForm 
+      :isACOR="isACOR" 
+      v-show="showContactForm && !haveSelectedContact"
+      :showAccessRadioButtons.sync="showAccessRadioButtons"
+    />
+    
+    <section 
+      id="AccessRadioButtons" 
+      v-show="(showContactForm && showAccessRadioButtons) || haveSelectedContact"
+    >
+      <hr />
+      <ATATRadioGroup
+        legend="Does this individual need access to help you create this acquisition package in ATAT?"
+        id="AccessToEdit"
+        :items="accessToEditOptions"
+        :value.sync="selectedAccessToEdit"
+      />
+    </section>
+  </div>
 </template>
 <script lang="ts">
 import Vue from "vue";
 
-import {Component, Prop} from "vue-property-decorator";
+import { Component, Prop } from "vue-property-decorator";
 
 import ATATAutoComplete from "@/components/ATATAutoComplete.vue";
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
@@ -97,6 +96,7 @@ export default class COR_ACOR extends Vue {
   // data
   public showAccessRadioButtons = false;
   public showContactForm = false;
+
   private selectedAccessToEdit = "";
   private accessToEditOptions: RadioButton[] = [
     {
@@ -110,6 +110,7 @@ export default class COR_ACOR extends Vue {
       value: "no",
     },
   ];
+  
   public selectedContact = {};
   private contactList = [
     {

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -21,21 +21,20 @@
       placeholder=""
       :items="branchData"
       :selectedValue.sync="selectedBranch"
+      :showAccessRadioButtons.sync="showAccessRadioButtons"
     />
-
-
 
   </section>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
 
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
 import ATATSelect from "@/components/ATATSelect.vue";
 
-import { RadioButton, SelectData } from "../../../../types/Global";
+import { RadioButton, SelectData, AutoCompleteItem } from "../../../../types/Global";
 
 @Component({
   components: {
@@ -49,37 +48,19 @@ export default class ContactInfoForm extends Vue {
   //props
 
   @Prop({default: true}) private isACOR!: boolean;
+  @PropSync("showAccessRadioButtons") private _showAccessRadioButtons!: boolean;
 
   // data
 
   private selectedBranch = "";
   private branchData: SelectData[] = [
-    {
-      text: "U.S. Air Force",
-      value: "USAF",
-    },
-    {
-      text: "U.S. Army",
-      value: "ARMY",
-    },
-    {
-      text: "U.S. Coast Guard",
-      value: "USCG",
-    },
-    {
-      text: "U.S. Marine Corps",
-      value: "USMC",
-    },
-    {
-      text: "U.S. Navy",
-      value: "NAVY",
-    },
-    {
-      text: "U.S. Space Force",
-      value: "USSF",
-    },
+    { text: "U.S. Air Force", value: "USAF", },
+    { text: "U.S. Army", value: "ARMY", },
+    { text: "U.S. Coast Guard", value: "USCG", },
+    { text: "U.S. Marine Corps", value: "USMC", },
+    { text: "U.S. Navy", value: "NAVY", },
+    { text: "U.S. Space Force", value: "USSF", },
   ];
-
 
   private selectedContactAffiliation = "";
   private contactAffiliations: RadioButton[] = [
@@ -95,13 +76,46 @@ export default class ContactInfoForm extends Vue {
     },
   ];
 
+  private branchRanksData: unknown = [
+    {
+      "USAF": [
+        { rank: "AF Rank 1", value: "AF-R1", },
+        { rank: "AF Rank 2", value: "AF-R1", },
+        { rank: "AF Rank 3", value: "AF-R1", },
+      ],
+    }
+
+  ];
+
   // computed
   
   get corOrAcor(): string {
     return this.isACOR ? "ACOR" : "COR";
   }
 
+  // methods
+
+  private setShowAccessRadioButtons(): void {
+    this._showAccessRadioButtons = this.selectedContactAffiliation === "CIV" 
+      || this.selectedBranch !== "";
+  }
+
+  private setRankData(): void {
+
+  }
+
+  // watchers
+
+  @Watch("selectedBranch")
+  protected branchChange(): void {
+    this.setShowAccessRadioButtons();
+    this.setRankData();
+  }
+
+  @Watch("selectedContactAffiliation")
+  protected contactAffiliationChange(): void {
+    this.setShowAccessRadioButtons();
+  }
+
 }
 </script>
-
-           

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -1,6 +1,7 @@
 
 <template>
   <section class="mt-10">
+    <hr />
     <h2 class="form-section-heading">
       Your COR’s Contact Information
     </h2>
@@ -14,15 +15,92 @@
     />
 
     <ATATSelect
-      v-show="selectedContactAffiliation === 'MIL'"
       id="Branch"
-      class="input-max-width"
+      v-show="selectedContactAffiliation === 'MIL'"
+      class="input-max-width mb-10"
       label="Service Branch"
       placeholder=""
       :items="branchData"
       :selectedValue.sync="selectedBranch"
       :showAccessRadioButtons.sync="showAccessRadioButtons"
     />
+    <div v-show="selectedBranch || selectedContactAffiliation === 'CIV'">
+      <ATATAutoComplete
+        id="Rank"
+        v-show="selectedContactAffiliation === 'MIL'"
+        label="Rank"
+        titleKey="rank"
+        :items="selectedBranchRanks"
+        :searchFields="['rank', 'value']"
+        :selectedItem.sync="selectedRank"
+        class="input-max-width mb-7"
+        icon="arrow_drop_down"
+      />
+
+      <ATATSelect
+        v-show="selectedContactAffiliation === 'CIV'"
+        id="Salutation"
+        class="input-max-width mb-7"
+        label="Salutation"
+        :optional="true"
+        placeholder=""
+        :items="salutationData"
+        :selectedValue.sync="selectedSalutation"
+      />
+
+      <v-row class="form-section mb-7">
+        <v-col class="col-12 col-lg-3">
+          <ATATTextField label="First name" id="FirstName" class="input-max-width" />
+        </v-col>
+        <v-col class="col-12 col-lg-3">
+          <ATATTextField label="Middle name" id="MiddleName" :optional="true" class="input-max-width" />
+        </v-col>
+        <v-col class="col-12 col-lg-3">
+          <ATATTextField label="Last name" id="LastName" class="input-max-width" />
+        </v-col>
+        <v-col class="col-12 col-lg-3">
+          <ATATTextField
+            label="Suffix"
+            id="Suffix"
+            :optional="true"
+            width="80px"
+          />
+        </v-col>
+      </v-row>
+
+      <ATATTextField 
+        label="Email address" 
+        id="EmailAddress" 
+        class="input-max-width mb-10" 
+        helpText="Enter a .mil or .gov email address."
+      />
+
+      <div class="d-flex mb-10">
+        <ATATTextField 
+          label="Phone number" 
+          id="PhoneNumber" 
+          class="input-max-width width-100" 
+        />
+        <ATATTextField 
+          label="Extension" 
+          id="PhoneExtension" 
+          width="140px"
+          :optional="true"
+          class="ml-6"
+        />
+      </div>
+
+      <ATATTextField 
+        label="DoD Activity Address Code (DoDAAC)" 
+        id="DoDAAC" 
+        class="input-max-width"
+        tooltipText="A DoDAAC is a 6-character code that uniquely identifies a 
+          unit, activity, or organization that has the authority to requisition, 
+          contract for, or fund/pay bills for materials and services." 
+      />
+
+
+    </div>
 
   </section>
 </template>
@@ -31,15 +109,24 @@
 import Vue from "vue";
 import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
 
+import ATATAutoComplete from "@/components/ATATAutoComplete.vue"
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
 import ATATSelect from "@/components/ATATSelect.vue";
+import ATATTextField from "@/components/ATATTextField.vue";
 
-import { RadioButton, SelectData, AutoCompleteItem } from "../../../../types/Global";
+import { 
+  RadioButton, 
+  SelectData, 
+  AutoCompleteItem, 
+  AutoCompleteItemGroups 
+} from "../../../../types/Global";
 
 @Component({
   components: {
+    ATATAutoComplete,
     ATATRadioGroup,
     ATATSelect,
+    ATATTextField,
   }
 })
 
@@ -51,6 +138,15 @@ export default class ContactInfoForm extends Vue {
   @PropSync("showAccessRadioButtons") private _showAccessRadioButtons!: boolean;
 
   // data
+
+  private selectedSalutation = "";
+  private salutationData: SelectData[] = [
+    { text: "Mr.", value: "Mr.", },
+    { text: "Mrs.", value: "Mrs.", },
+    { text: "Miss", value: "Miss", },
+    { text: "Ms.", value: "Ms.", },
+    { text: "Dr.", value: "Dr.", },
+  ];
 
   private selectedBranch = "";
   private branchData: SelectData[] = [
@@ -76,16 +172,40 @@ export default class ContactInfoForm extends Vue {
     },
   ];
 
-  private branchRanksData: unknown = [
-    {
-      "USAF": [
-        { rank: "AF Rank 1", value: "AF-R1", },
-        { rank: "AF Rank 2", value: "AF-R1", },
-        { rank: "AF Rank 3", value: "AF-R1", },
-      ],
-    }
-
-  ];
+  private selectedRank = "";
+  private selectedBranchRanks: AutoCompleteItem[] = [];
+  private branchRanksData: AutoCompleteItemGroups = {
+    "USAF": [
+      { rank: "AF Rank 1", value: "AF-R1", },
+      { rank: "AF Rank 2", value: "AF-R2", },
+      { rank: "AF Rank 3", value: "AF-R3", },
+    ],
+    "ARMY": [
+      { rank: "ARMY Rank 1", value: "ARMY-R1", },
+      { rank: "ARMY Rank 2", value: "ARMY-R2", },
+      { rank: "ARMY Rank 3", value: "ARMY-R3", },
+    ],
+    "USCG": [
+      { rank: "USCG Rank 1", value: "USCG-R1", },
+      { rank: "USCG Rank 2", value: "USCG-R2", },
+      { rank: "USCG Rank 3", value: "USCG-R3", },
+    ],
+    "USMC": [
+      { rank: "USMC Rank 1", value: "USMC-R1", },
+      { rank: "USMC Rank 2", value: "USMC-R2", },
+      { rank: "USMC Rank 3", value: "USMC-R3", },
+    ],    
+    "NAVY": [
+      { rank: "NAVY Rank 1", value: "NAVY-R1", },
+      { rank: "NAVY Rank 2", value: "NAVY-R2", },
+      { rank: "NAVY Rank 3", value: "NAVY-R3", },
+    ],
+      "USSF": [
+      { rank: "USSF Rank 1", value: "USSF-R1", },
+      { rank: "USSF Rank 2", value: "USSF-R2", },
+      { rank: "USSF Rank 3", value: "USSF-R3", },
+    ],
+  };
 
   // computed
   
@@ -101,7 +221,7 @@ export default class ContactInfoForm extends Vue {
   }
 
   private setRankData(): void {
-
+    this.selectedBranchRanks = this.branchRanksData[this.selectedBranch];
   }
 
   // watchers

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -10,6 +10,17 @@
       id="ContactAffiliation"
       :items="contactAffiliations"
       :value.sync="selectedContactAffiliation"
+      class="mb-10"
+    />
+
+    <ATATSelect
+      v-show="selectedContactAffiliation === 'MIL'"
+      id="Branch"
+      class="input-max-width"
+      label="Service Branch"
+      placeholder=""
+      :items="branchData"
+      :selectedValue.sync="selectedBranch"
     />
 
 
@@ -22,12 +33,14 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
+import ATATSelect from "@/components/ATATSelect.vue";
 
 import { RadioButton, SelectData } from "../../../../types/Global";
 
 @Component({
   components: {
     ATATRadioGroup,
+    ATATSelect,
   }
 })
 
@@ -38,6 +51,35 @@ export default class ContactInfoForm extends Vue {
   @Prop({default: true}) private isACOR!: boolean;
 
   // data
+
+  private selectedBranch = "";
+  private branchData: SelectData[] = [
+    {
+      text: "U.S. Air Force",
+      value: "USAF",
+    },
+    {
+      text: "U.S. Army",
+      value: "ARMY",
+    },
+    {
+      text: "U.S. Coast Guard",
+      value: "USCG",
+    },
+    {
+      text: "U.S. Marine Corps",
+      value: "USMC",
+    },
+    {
+      text: "U.S. Navy",
+      value: "NAVY",
+    },
+    {
+      text: "U.S. Space Force",
+      value: "USSF",
+    },
+  ];
+
 
   private selectedContactAffiliation = "";
   private contactAffiliations: RadioButton[] = [

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -2,13 +2,13 @@
 <template>
   <section class="mt-10">
     <hr />
-    <h2 class="form-section-heading">
+    <h2 id="ContactInfoHeader" class="form-section-heading">
       Your COR’s Contact Information
     </h2>
 
     <ATATRadioGroup
-      legend="What role best describes your COR’s affiliation with the DoD?"
       id="ContactAffiliation"
+      legend="What role best describes your COR’s affiliation with the DoD?"
       :items="contactAffiliations"
       :value.sync="selectedContactAffiliation"
       class="mb-10"
@@ -39,8 +39,8 @@
       />
 
       <ATATSelect
-        v-show="selectedContactAffiliation === 'CIV'"
         id="Salutation"
+        v-show="selectedContactAffiliation === 'CIV'"
         class="input-max-width mb-7"
         label="Salutation"
         :optional="true"
@@ -70,21 +70,21 @@
       </v-row>
 
       <ATATTextField 
-        label="Email address" 
         id="EmailAddress" 
+        label="Email address" 
         class="input-max-width mb-10" 
         helpText="Enter a .mil or .gov email address."
       />
 
       <div class="d-flex mb-10">
         <ATATTextField 
-          label="Phone number" 
           id="PhoneNumber" 
+          label="Phone number" 
           class="input-max-width width-100" 
         />
         <ATATTextField 
-          label="Extension" 
           id="PhoneExtension" 
+          label="Extension" 
           width="140px"
           :optional="true"
           class="ml-6"
@@ -92,8 +92,8 @@
       </div>
 
       <ATATTextField 
-        label="DoD Activity Address Code (DoDAAC)" 
         id="DoDAAC" 
+        label="DoD Activity Address Code (DoDAAC)" 
         class="input-max-width"
         tooltipText="A DoDAAC is a 6-character code that uniquely identifies a 
           unit, activity, or organization that has the authority to requisition, 

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -24,6 +24,7 @@
       :selectedValue.sync="selectedBranch"
       :showAccessRadioButtons.sync="showAccessRadioButtons"
     />
+
     <div v-show="selectedBranch || selectedContactAffiliation === 'CIV'">
       <ATATAutoComplete
         id="Rank"
@@ -99,9 +100,7 @@
           contract for, or fund/pay bills for materials and services." 
       />
 
-
     </div>
-
   </section>
 </template>
 

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -1,16 +1,64 @@
 
 <template>
-  <v-flex class="mt-10">
-    Contact Info Form
-  </v-flex>
+  <section class="mt-10">
+    <h2 class="form-section-heading">
+      Your COR’s Contact Information
+    </h2>
+
+    <ATATRadioGroup
+      legend="What role best describes your COR’s affiliation with the DoD?"
+      id="ContactAffiliation"
+      :items="contactAffiliations"
+      :value.sync="selectedContactAffiliation"
+    />
+
+
+
+  </section>
 </template>
+
 <script lang="ts">
 import Vue from "vue";
-
 import { Component, Prop } from "vue-property-decorator";
-@Component({})
+
+import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
+
+import { RadioButton, SelectData } from "../../../../types/Global";
+
+@Component({
+  components: {
+    ATATRadioGroup,
+  }
+})
+
 export default class ContactInfoForm extends Vue {
+
+  //props
+
   @Prop({default: true}) private isACOR!: boolean;
+
+  // data
+
+  private selectedContactAffiliation = "";
+  private contactAffiliations: RadioButton[] = [
+    {
+      id: "Military",
+      label: "Military",
+      value: "MIL",
+    },
+    {
+      id: "Civilian",
+      label: "Civilian",
+      value: "CIV",
+    },
+  ];
+
+  // computed
+  
+  get corOrAcor(): string {
+    return this.isACOR ? "ACOR" : "COR";
+  }
+
 }
 </script>
 

--- a/src/steps/AcquisitionPackageDetails/ContactInfo.vue
+++ b/src/steps/AcquisitionPackageDetails/ContactInfo.vue
@@ -145,27 +145,13 @@ export default class ContactInfo extends Vue {
 
   private selectedSalutation = "";
   private salutationData: SelectData[] = [
-    {
-      text: "Mr.",
-      value: "Mr.",
-    },
-    {
-      text: "Mrs.",
-      value: "Mrs.",
-    },
-    {
-      text: "Miss",
-      value: "Miss",
-    },
-    {
-      text: "Ms.",
-      value: "Ms.",
-    },
-    {
-      text: "Dr.",
-      value: "Dr.",
-    },
+    { text: "Mr.", value: "Mr.", },
+    { text: "Mrs.", value: "Mrs.", },
+    { text: "Miss", value: "Miss", },
+    { text: "Ms.", value: "Ms.", },
+    { text: "Dr.", value: "Dr.", },
   ];
+  
   private selectedRank = "";
   private rankData: SelectData[] = [
     {

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -32,7 +32,7 @@
             />
           </div>
           <div class="d-flex align-start flex-column mt-10">
-           <ATATRadioGroup
+            <ATATRadioGroup
               id="emergency-declaration-support-requirement"
               legend="Is this requirement in support of an emergency declaration?"
               :value.sync="radioValue"

--- a/src/steps/AcquisitionPackageDetails/ProjectScope.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectScope.vue
@@ -4,7 +4,7 @@
       <v-row>
         <v-col class="col-12">
           <h1 class="page-header">Tell us more about the scope of your project</h1>
-       
+
           <ATATAlert type="info" :showIcon="false" class="copy-max-width mt-10">
             <template v-slot:content>
               <h2>Surge Capabilities</h2>
@@ -23,7 +23,7 @@
               </p>
             </template>
           </ATATAlert>
-           <p class="mt-8 mb-2">
+          <p class="mt-8 mb-2">
             If surge capabilities are required, what percentage of the contractor’s total proposed price will not be exceeded?
           </p>
           <ATATTextField 

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -29,7 +29,11 @@ export interface SelectData {
  * interface for autocomplete Items
  */
 export interface AutoCompleteItem {
-    [key: string]: string | number |  null | boolean
+    [ key: string ]: string | number | null | boolean
+}
+
+export interface AutoCompleteItemGroups {
+    [ key: string ]: AutoCompleteItem[];
 }
 
 /**


### PR DESCRIPTION
1. ‘Manually enter your COR’s contact information' accordion exists with:
    1. ‘Your COR’s Contact Information' header text with correct formatting.
    1. ‘What role best describes your COR’s affiliation with the DoD?' question with
        1. ‘Military’ radio button
        1. ‘Civilian’ radio button
    1. ‘Service Branch’ drop down with each of the 6 branches as options should be displayed if the user selects ‘Military’ above
    1. The following should only be displayed AFTER the user selects a role for their COR above (as well as Service Branch if ‘Military’ is selected):
        1. ‘Rank’ drop down should only be displayed for Military CORs.
        1. ‘Salutation’ drop down should only be displayed for Civilian CORs
        1. ‘First name’, ‘Middle name’, ‘Last name’, and ‘Suffix’ text boxes
        1. DoD Activity Address Code (DoDAAC) textbox with correct formatting and
            1. Tooltip that displays on hover.
        1. ‘Does this individual need access to help you create this acquisition package in ATAT?' question with
            1. ‘Yes. I would like to invite this individual to edit my acquisition’ and ‘No’ options.
1. Accordion should still expand/collapse as expected.