### PR TITLE
Feature/at 7118

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <ATATSideStepper ref="sideStepper" :stepperData="stepperData"/>
-    <ATATPageHead  :headline="getCurrentStepMenuText()"/>
+    <ATATPageHead  :headline="projectTitle"/>
     <v-main id="app">
       <router-view></router-view>
       <ATATStepperNavigation @next="navigate('next')" @previous="navigate('previous')" />
@@ -24,6 +24,9 @@ import ATATFooter from "./components/ATATFooter.vue";
 import ATATPageHead from "./components/ATATPageHead.vue"
 import { Component, Watch } from "vue-property-decorator";
 import { buildStepperData } from "./router/stepper";
+
+import AcquisitionPackage from "@/store/acquisitionPackage";
+
 
 @Component({
   components: {
@@ -85,5 +88,10 @@ export default class App extends Vue {
 
       return label;
    }
+  public get projectTitle(): string {
+    return AcquisitionPackage.projectTitle !== ""
+      ? AcquisitionPackage.projectTitle
+      : "New Acquisition";
+  }
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,11 @@
 <template>
   <v-app>
     <ATATSideStepper ref="sideStepper" :stepperData="stepperData"/>
-    <ATATPageHead  :headline="projectTitle"/>
+    <ATATPageHead :headline="projectTitle"/>
     <v-main id="app">
       <router-view></router-view>
-      <ATATStepperNavigation @next="navigate('next')" @previous="navigate('previous')" />
-      <ATATFooter />
+      <ATATStepperNavigation @next="navigate('next')" @previous="navigate('previous')"/>
+      <ATATFooter/>
     </v-main>
   </v-app>
 </template>
@@ -22,8 +22,8 @@ import ATATSideStepper from "./components/ATATSideStepper.vue";
 import ATATStepperNavigation from "./components/ATATStepperNavigation.vue";
 import ATATFooter from "./components/ATATFooter.vue";
 import ATATPageHead from "./components/ATATPageHead.vue"
-import { Component, Watch } from "vue-property-decorator";
-import { buildStepperData } from "./router/stepper";
+import {Component, Watch} from "vue-property-decorator";
+import {buildStepperData} from "./router/stepper";
 
 import AcquisitionPackage from "@/store/acquisitionPackage";
 
@@ -37,11 +37,11 @@ import AcquisitionPackage from "@/store/acquisitionPackage";
   }
 })
 export default class App extends Vue {
-   $refs!: {
+  $refs!: {
     sideStepper: ATATSideStepper;
   };
 
-   private stepperData = buildStepperData();
+  private stepperData = buildStepperData();
 
   async mounted(): Promise<void> {
     //get first step and intitialize store to first step;
@@ -49,18 +49,18 @@ export default class App extends Vue {
     const step = await Steps.findRoute(routeName || "");
 
     if (routeName && step) {
-      const { stepName} = step;
+      const {stepName} = step;
       Steps.setCurrentStep(stepName);
     }
   }
 
-   @Watch("$route")
+  @Watch("$route")
   async onRouteChanged(): Promise<void> {
     const routeName = this.$route.name;
     const step = await Steps.findRoute(routeName || "");
 
     if (routeName && step) {
-      const { stepName, stepNumber } = step;
+      const {stepName, stepNumber} = step;
       Steps.setCurrentStep(stepName);
       this.$refs.sideStepper.setCurrentStep(stepNumber);
     }
@@ -68,26 +68,27 @@ export default class App extends Vue {
 
   async navigate(direction: string): Promise<void> {
     const nextStepName =
-      direction === "next" ? await Steps.getNext(): 
-      await Steps.getPrevious();
+      direction === "next" ? await Steps.getNext() :
+        await Steps.getPrevious();
 
     if (nextStepName) {
-      this.$router.push({ name: nextStepName});
+      this.$router.push({name: nextStepName});
     }
   }
 
-   getCurrentStepMenuText(): string | undefined {
-      let label = Steps.currentStep?.stepLabel;
-      // temporarily transform the 'project overview' and 'project scope' 
-      // titles to 'demo package'
-      let demoPackage = ["project overview", "project scope"];
-      
-      if (demoPackage.some((dp)=> dp=== (label && label.toLowerCase()) )){
-        label = "Demo Package";
-      }
+  getCurrentStepMenuText(): string | undefined {
+    let label = Steps.currentStep?.stepLabel;
+    // temporarily transform the 'project overview' and 'project scope'
+    // titles to 'demo package'
+    let demoPackage = ["project overview", "project scope"];
 
-      return label;
-   }
+    if (demoPackage.some((dp) => dp === (label && label.toLowerCase()))) {
+      label = "Demo Package";
+    }
+
+    return label;
+  }
+
   public get projectTitle(): string {
     return AcquisitionPackage.projectTitle !== ""
       ? AcquisitionPackage.projectTitle

--- a/src/components/ATATTextField.vue
+++ b/src/components/ATATTextField.vue
@@ -31,6 +31,7 @@
         class="text-primary"
         :suffix="suffix"
         :rules="rules"
+        @blur="$emit('blur', $event)"
       >
         <template v-slot:message="{ message }">
         <div class="d-flex justify-start align-center atat-text-field-error">

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -59,8 +59,8 @@ import ATATRadioGroup from "../../components/ATATRadioGroup.vue";
 
 import Vue from "vue";
 
-import { Component } from "vue-property-decorator";
-import { RadioButton } from "types/Global";
+import {Component} from "vue-property-decorator";
+import {RadioButton} from "types/Global";
 
 import AcquisitionPackage from "@/store/acquisitionPackage";
 
@@ -88,15 +88,15 @@ export default class ProjectOverview extends Vue {
 
   private currentTitle = "";
 
-  public get projectTitle() {
-   return AcquisitionPackage.getTitle()
+  public get projectTitle(): string {
+    return AcquisitionPackage.getTitle()
   }
 
   public set projectTitle(value: string) {
     AcquisitionPackage.setProjectTitle(value);
   }
 
-  public onTitleChanged():void {
+  public onTitleChanged(): void {
     this.projectTitle = this.currentTitle;
   }
 }

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -4,7 +4,7 @@
       <v-row>
         <v-col>
           <h1 class="page-header">
-            Let’s start with basic info about your {{ projectTitle }}
+            Let’s start with basic info about your new acquisition
           </h1>
           <p class="page-intro">
             In this section, we will gather some overarching details about your
@@ -99,11 +99,6 @@ export default class ProjectOverview extends Vue {
   }
 
   public onTitleChanged():void {
-
-    if(this.currentTitle === "" || this.currentTitle == this.projectTitle){
-        return;
-    }
-
     this.projectTitle = this.currentTitle;
       
   }

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -88,12 +88,6 @@ export default class ProjectOverview extends Vue {
 
   private currentTitle = "";
 
-  public get projectTitle(): string {
-    return AcquisitionPackage.projectTitle !== ""
-      ? AcquisitionPackage.projectTitle
-      : "new acquisition";
-  }
-
   public set projectTitle(value: string) {
     AcquisitionPackage.setProjectTitle(value);
   }

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -88,13 +88,16 @@ export default class ProjectOverview extends Vue {
 
   private currentTitle = "";
 
+  public get projectTitle() {
+   return AcquisitionPackage.getTitle()
+  }
+
   public set projectTitle(value: string) {
     AcquisitionPackage.setProjectTitle(value);
   }
 
   public onTitleChanged():void {
     this.projectTitle = this.currentTitle;
-      
   }
 }
 </script>

--- a/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
+++ b/src/steps/AcquisitionPackageDetails/ProjectOverview.vue
@@ -3,7 +3,9 @@
     <v-container fluid class="container-max-width">
       <v-row>
         <v-col>
-          <h1 class="page-header">Let’s start with basic info about your new acquisition</h1>
+          <h1 class="page-header">
+            Let’s start with basic info about your {{ projectTitle }}
+          </h1>
           <p class="page-intro">
             In this section, we will gather some overarching details about your
             project requirements, organization, and points of contact. This
@@ -17,6 +19,8 @@
               label="Project/Requirement Title"
               class="input-max-width"
               tooltipText="Provide a short, descriptive title of the work to be performed. This will be used to refer to this project within ATAT and across all acquisition forms."
+              :value.sync="currentTitle"
+              @blur="onTitleChanged"
             />
           </div>
           <div class="d-flex align-start flex-column mt-10 textarea-max-width">
@@ -24,7 +28,7 @@
               id="ProjectScope"
               label="What is the scope of your requirement?"
               class="width-100"
-              :rows=7
+              :rows="7"
               helpText="Briefly describe the type of resources and services to be
               acquired, and what is necessary to achieve mission specific
               outcomes for this particular requirement (e.g., move DITCO’s contract
@@ -39,8 +43,8 @@
               :items="radioGroupItems"
               name="emergency-declaration-support-requirement-radio-group"
               class="mt-3"
-          >
-          </ATATRadioGroup>
+            >
+            </ATATRadioGroup>
           </div>
         </v-col>
       </v-row>
@@ -51,23 +55,25 @@
 <script lang="ts">
 import ATATTextField from "../../components/ATATTextField.vue";
 import ATATTextArea from "../../components/ATATTextArea.vue";
-import ATATRadioGroup from "../../components/ATATRadioGroup.vue"
+import ATATRadioGroup from "../../components/ATATRadioGroup.vue";
 
 import Vue from "vue";
 
 import { Component } from "vue-property-decorator";
 import { RadioButton } from "types/Global";
 
+import AcquisitionPackage from "@/store/acquisitionPackage";
+
 @Component({
   components: {
     ATATTextField,
     ATATTextArea,
-    ATATRadioGroup
+    ATATRadioGroup,
   },
 })
 export default class ProjectOverview extends Vue {
-  private radioValue = '';
-  private radioGroupItems:RadioButton[] = [
+  private radioValue = "";
+  private radioGroupItems: RadioButton[] = [
     {
       id: "Yes",
       label: "Yes",
@@ -77,8 +83,29 @@ export default class ProjectOverview extends Vue {
       id: "No",
       label: "No",
       value: "no",
+    },
+  ];
+
+  private currentTitle = "";
+
+  public get projectTitle(): string {
+    return AcquisitionPackage.projectTitle !== ""
+      ? AcquisitionPackage.projectTitle
+      : "new acquisition";
+  }
+
+  public set projectTitle(value: string) {
+    AcquisitionPackage.setProjectTitle(value);
+  }
+
+  public onTitleChanged():void {
+
+    if(this.currentTitle === "" || this.currentTitle == this.projectTitle){
+        return;
     }
-  ] 
+
+    this.projectTitle = this.currentTitle;
+      
+  }
 }
 </script>
-

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1,13 +1,19 @@
-import {  VuexModule, Module, getModule, Action, Mutation} from "vuex-module-decorators";
+import {  VuexModule, Module, getModule, Mutation} from "vuex-module-decorators";
 import rootStore from "../index";
 
 @Module({ name: 'AcquisitionPackage',  namespaced: true, dynamic: true, store: rootStore})
 export class AcquisitionPackageStore extends VuexModule  {
+   projectTitle = "";
    hasAlternativeContactRep: boolean | null = null;
 
    @Mutation
    public setHasAlternateCOR(value: boolean): void{
       this.hasAlternativeContactRep = value;
+   }
+
+   @Mutation
+   public setProjectTitle(value: string) : void {
+      this.projectTitle = value;
    }
 
 }

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1,10 +1,20 @@
 import {getModule, Module, Mutation, VuexModule} from "vuex-module-decorators";
 import rootStore from "../index";
 
-@Module({name: 'AcquisitionPackage', namespaced: true, dynamic: true, store: rootStore})
+@Module({
+  name: 'AcquisitionPackage',
+  namespaced: true,
+  dynamic: true,
+  store: rootStore
+})
+
 export class AcquisitionPackageStore extends VuexModule {
   projectTitle = "";
   hasAlternativeContactRep: boolean | null = null;
+
+  public getTitle(): string {
+    return this.projectTitle;
+  }
 
   @Mutation
   public setHasAlternateCOR(value: boolean): void {

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1,20 +1,20 @@
-import {  VuexModule, Module, getModule, Mutation} from "vuex-module-decorators";
+import {getModule, Module, Mutation, VuexModule} from "vuex-module-decorators";
 import rootStore from "../index";
 
-@Module({ name: 'AcquisitionPackage',  namespaced: true, dynamic: true, store: rootStore})
-export class AcquisitionPackageStore extends VuexModule  {
-   projectTitle = "";
-   hasAlternativeContactRep: boolean | null = null;
+@Module({name: 'AcquisitionPackage', namespaced: true, dynamic: true, store: rootStore})
+export class AcquisitionPackageStore extends VuexModule {
+  projectTitle = "";
+  hasAlternativeContactRep: boolean | null = null;
 
-   @Mutation
-   public setHasAlternateCOR(value: boolean): void{
-      this.hasAlternativeContactRep = value;
-   }
+  @Mutation
+  public setHasAlternateCOR(value: boolean): void {
+    this.hasAlternativeContactRep = value;
+  }
 
-   @Mutation
-   public setProjectTitle(value: string) : void {
-      this.projectTitle = value;
-   }
+  @Mutation
+  public setProjectTitle(value: string): void {
+    this.projectTitle = value;
+  }
 
 }
 


### PR DESCRIPTION
Package name in header that changes based on user input as follows:
If no input has been provided in the ‘Project/Requirements Title’ textbox field in the ‘Project Overview’ sub step of the ‘Acquisition Package Details’ step, header should display 'New Acquisition.
If the user has provided input in the ‘Project/Requirements Title’ textbox field in the ‘Project Overview’ sub step of the ‘Acquisition Package Details’ step, header should display the name the user inputted.
Headline should change when input field loses focus
Package name should be consistently displayed following these rules on all relevant screens.