### PR TITLE
Feature/atat 7135 foreign and military addresses

### DIFF
--- a/src/components/ATATSelect.vue
+++ b/src/components/ATATSelect.vue
@@ -27,9 +27,6 @@
         :placeholder="placeholder"
         class="mt-2"
       >
-        <template v-slot:selection="{ item }">
-          {{ item.text }}
-        </template>
         <template v-slot:item="{ item, on }">
           <v-list-item v-on="on">
             <v-list-item-content

--- a/src/sass/components/ATATAutoComplete.scss
+++ b/src/sass/components/ATATAutoComplete.scss
@@ -18,4 +18,11 @@
     box-shadow: 0px 4px 10px rgba(194, 194, 194, 0.5);
     border-radius: 8px;
   }
+  
+  .v-select__slot {
+    input {
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }

--- a/src/sass/components/ATATSelect.scss
+++ b/src/sass/components/ATATSelect.scss
@@ -42,37 +42,3 @@
   box-shadow: 0px 4px 10px rgba(194, 194, 194, 0.5) !important;
   border-radius: 8px !important;
 }
-
-// accommodate selected text longer than the width of the input
-// keeps content on one line and fades out before the dropdown icon
-.v-select__selections {
-  white-space: nowrap;
-  overflow-x: hidden;
-  flex-wrap: unset;
-  max-height: 25px;
-  position: relative;
-  &:after {
-    position: absolute;
-    content: "";
-    right: 0;
-    height: 25px;
-    width: 20px;
-    display: block;
-    background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);   
-  }
-}
-
-// accommodate selected text longer than the width of the input on autocomplete
-// fades out text before the clear X icon
-.v-input__icon--clear {
-  position: relative;
-  &:after {
-    position: absolute;
-    content: "";
-    left: -24px;
-    height: 25px;
-    width: 20px;
-    display: block;
-    background: linear-gradient(90deg, rgba(255,255,255,0) 0%, rgba(255,255,255,1) 100%);   
-  }
-}


### PR DESCRIPTION
1. Military (APO or FPO) radio button functions as expected, displaying the following fields when selected:
    1. ‘Street address’ textbox with correct formatting.
    1. ‘Unit, suite, etc.' textbox with correct formatting.
    1. ‘APO/FPO’ drop down with
        1. ‘Army Post Office (APO)’ and ‘Fleet Post Office (FPO)’ as options.
    1. ‘State code’ drop down with
        1. ‘AA - Armed Forces Americas’, ‘AE - Armed Forces Europe’, and ‘AP - Armed Forces Pacific’ as options. 
    1. ‘ZIP code’ textbox with correct formatting.
9. Foreign address radio button functions as expected, displaying the following fields when selected:
    1. ‘Address’ textbox with correct formatting.
    1. ‘Unit, suite, etc.’ textbox with correct formatting.
    1. ‘City’ textbox with correct formatting.
    1. ‘State or Province’ textbox with correct formatting.
    1. ‘Postal code’ textbox with correct formatting.
    1. ‘Country’ drop down with options.
1. User should only be able to make one selection for the ‘Type of mailing address’ at any given time.