### PR TITLE
Feature/at 7196 property custodian

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1,4 +1,6 @@
 import AcquisitionPackage from "@/store/acquisitionPackage";
+import GovtFurnishedEquipment from "@/store/govtFurnishedEquipment";
+
 import { routeNames } from "../stepper";
 
 export const AcorsRouteResolver = (current: string): string => {
@@ -6,10 +8,7 @@ export const AcorsRouteResolver = (current: string): string => {
 
   //routing from alternate cor and the user does not have
   //and alternatative contact rep
-  if (
-    current === routeNames.Alternate_Cor &&
-    hasAlternativeContactRep == false
-  ) {
+  if (current === routeNames.Alternate_Cor && hasAlternativeContactRep == false) {
     return routeNames.Summary;
   }
 
@@ -19,4 +18,18 @@ export const AcorsRouteResolver = (current: string): string => {
   }
 
   return routeNames.Acor_Information;
+};
+
+export const CustodianRouteResolver = (current: string): string => {
+  const needsPropertyCustodian = GovtFurnishedEquipment.needsPropertyCustodian;
+  // if government equipment will be furnished, route to Property Custodian page
+  if (current === routeNames.Will_Govt_Equip_Be_Furnished && needsPropertyCustodian) {
+    return routeNames.Property_Custodian;
+  }
+  // else stay on same page until next step after Property Custodian is completed
+  alert("Business rule is to skip Property Custodian page if answer is \"No\" (or unanswered) here. " +
+    "Navigation will temporarily stay on this page until the substep after Property " +
+    "Custodian has been completed. Select \"Yes\" to continue to Property Custodian page.");
+  // todo - change this routeName when page after Property Custodian is completed
+  return routeNames.Will_Govt_Equip_Be_Furnished; 
 };

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -22,10 +22,12 @@ export const AcorsRouteResolver = (current: string): string => {
 
 export const CustodianRouteResolver = (current: string): string => {
   const needsPropertyCustodian = GovtFurnishedEquipment.needsPropertyCustodian;
+  
   // if government equipment will be furnished, route to Property Custodian page
   if (current === routeNames.Will_Govt_Equip_Be_Furnished && needsPropertyCustodian) {
     return routeNames.Property_Custodian;
   }
+
   // else stay on same page until next step after Property Custodian is completed
   alert("Business rule is to skip Property Custodian page if answer is \"No\" (or unanswered) here. " +
     "Navigation will temporarily stay on this page until the substep after Property " +

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -227,7 +227,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         component: PropertyCustodian,
         routeResolver: CustodianRouteResolver,
       },
-
     ]
   },
   {

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -21,12 +21,13 @@ import PeriodOfPerformance from "../steps/ContractDetails/PeriodOfPerformance.vu
 import GovtFurnishedEquipment from "../steps/GovtFurnishedEquipment/Index.vue"
 import PropertyRequirements from "../steps/GovtFurnishedEquipment/PropertyRequirements.vue";
 import WillGovtEquipBeFurnished from "../steps/GovtFurnishedEquipment/WillGovtEquipBeFurnished.vue";
+import PropertyCustodian from "../steps/GovtFurnishedEquipment/PropertyCustodian.vue";
 
 // other
 import ValidatorsExample from "../validation/ValidatorsExample.vue";
 
 // route resolves
-import { AcorsRouteResolver } from "./resolvers";
+import { AcorsRouteResolver, CustodianRouteResolver } from "./resolvers";
 
 export const routeNames = {
   Project_Overview: "Project_Overview",
@@ -41,7 +42,8 @@ export const routeNames = {
   Fair_Opportunity_Exceptions: "Fair_Opportunity_Exceptions",
   Period_Of_Performance: "Period_Of_Performance",
   Property_Requirements: "Property_Requirements",
-  Will_Govt_Equip_Be_Furnished: "Will_Govt_Equip_Be_Furnished",  
+  Will_Govt_Equip_Be_Furnished: "Will_Govt_Equip_Be_Furnished",
+  Property_Custodian: "Property_Custodian", 
 };
 
 /**
@@ -217,6 +219,15 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         excludeFromMenu: true,
         component: WillGovtEquipBeFurnished,
       },
+      {
+        name: routeNames.Property_Custodian,
+        menuText: "Property Custodian",
+        path: "/property-custodian",
+        completePercentageWeight: 2,
+        component: PropertyCustodian,
+        routeResolver: CustodianRouteResolver,
+      },
+
     ]
   },
   {

--- a/src/steps/AcquisitionPackageDetails/COR_ACOR/AlternateCOR.vue
+++ b/src/steps/AcquisitionPackageDetails/COR_ACOR/AlternateCOR.vue
@@ -53,7 +53,7 @@ export default class AlternateCOR extends Vue {
 
   public get hasAlternateCOR(): string {
     const ACORValue = AcquisitionPackage.hasAlternativeContactRep;
-    if (ACORValue) {
+    if (ACORValue !== null) {
       return ACORValue.toString();
     }
     return "";

--- a/src/steps/GovtFurnishedEquipment/PropertyCustodian.vue
+++ b/src/steps/GovtFurnishedEquipment/PropertyCustodian.vue
@@ -26,7 +26,8 @@
               label="DPAS Custodian number" 
               id="DPASCustodianNumber" 
               class="input-max-width mb-10" 
-              tooltipText="This is a one-to-six character unique code used to identify an individual responsible for assigned assets in all property functions. "
+              tooltipText="This is a one-to-six character unique code used to identify an 
+                individual responsible for assigned assets in all property functions. "
             />
 
           </div>

--- a/src/steps/GovtFurnishedEquipment/PropertyCustodian.vue
+++ b/src/steps/GovtFurnishedEquipment/PropertyCustodian.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="mb-7">
+    <v-container fluid class="container-max-width">
+      <v-row>
+        <v-col class="col-12">
+          <h1 class="page-header">
+            Tell us about your property custodian
+          </h1>
+          <div class="copy-max-width">
+  
+            <ATATTextField 
+              label="Full name" 
+              id="FullName" 
+              class="input-max-width mb-10" 
+              helpText="Include rank, if applicable"  
+            />
+
+            <ATATTextField 
+              label="DPAS Unit Identification Code (UICs)" 
+              id="UICs" 
+              class="input-max-width mb-10" 
+              tooltipText="Lorem ipsum - awaiting tooltip text"
+            />
+            
+            <ATATTextField 
+              label="DPAS Custodian number" 
+              id="DPASCustodianNumber" 
+              class="input-max-width mb-10" 
+              tooltipText="This is a one-to-six character unique code used to identify an individual responsible for assigned assets in all property functions. "
+            />
+
+          </div>
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+import ATATTextField from "@/components/ATATTextField.vue"
+
+@Component({
+  components: {
+    ATATTextField,
+  },
+})
+
+export default class PropertyCustodian extends Vue {
+
+}
+</script>

--- a/src/steps/GovtFurnishedEquipment/WillGovtEquipBeFurnished.vue
+++ b/src/steps/GovtFurnishedEquipment/WillGovtEquipBeFurnished.vue
@@ -27,6 +27,8 @@ import { Component } from "vue-property-decorator";
 
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue"
 
+import GovtFurnishedEquipment from "@/store/govtFurnishedEquipment";
+
 import { RadioButton } from "../../../types/Global";
 
 @Component({
@@ -36,7 +38,7 @@ import { RadioButton } from "../../../types/Global";
 })
 
 export default class WillGovtEquipBeFurnished extends Vue {
-  private selectedEquipmentProvidedOption = "";
+  // private selectedEquipmentProvidedOption = "";
   private equipmentProvidedOptions: RadioButton[] = [
     {
       id: "Yes",
@@ -49,5 +51,18 @@ export default class WillGovtEquipBeFurnished extends Vue {
       value: "No",
     },
   ];
+
+  public get selectedEquipmentProvidedOption(): string {
+    const ifNeeded = GovtFurnishedEquipment.needsPropertyCustodian;
+    if (ifNeeded !== null) {
+      return ifNeeded ? "Yes" : "No";
+    }
+    return "";
+  }
+
+  public set selectedEquipmentProvidedOption(value: string) {
+    GovtFurnishedEquipment.setNeedsPropertyCustodian(value === "Yes" ? true : false);
+  }
+
 }
 </script>

--- a/src/steps/GovtFurnishedEquipment/WillGovtEquipBeFurnished.vue
+++ b/src/steps/GovtFurnishedEquipment/WillGovtEquipBeFurnished.vue
@@ -38,7 +38,6 @@ import { RadioButton } from "../../../types/Global";
 })
 
 export default class WillGovtEquipBeFurnished extends Vue {
-  // private selectedEquipmentProvidedOption = "";
   private equipmentProvidedOptions: RadioButton[] = [
     {
       id: "Yes",

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1,4 +1,4 @@
-import {Action, getModule, Module, Mutation, VuexModule} from "vuex-module-decorators";
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
 import rootStore from "../index";
 import api from "@/api";
 import { AcquisitionPackageDTO } from "@/models/AcquisitionPackageDTO";
@@ -37,7 +37,7 @@ export class AcquisitionPackageStore extends VuexModule {
   public setAcquisitionPackage(value: AcquisitionPackageDTO): void {
     this.acquisitionPackage = value;
   }
-
+ 
   @Mutation
   public setProjectTitle(value: string): void {
     this.projectTitle = value;
@@ -45,29 +45,24 @@ export class AcquisitionPackageStore extends VuexModule {
 
   @Action({ rawError: true })
   public async initialize(): Promise<void> {
-     
-       const storedAcquisitionPackageData = sessionStorage.getItem(ATAT_ACQUISTION_PACKAGE_KEY) as string;
-       
-      if(storedAcquisitionPackageData && storedAcquisitionPackageData.length > 0){
-           const parsedData = JSON.parse(storedAcquisitionPackageData) as AcquisitionPackageDTO;
-           this.setAcquisitionPackage(parsedData);
-      }
-      else{
+    const storedAcquisitionPackageData = sessionStorage.getItem(ATAT_ACQUISTION_PACKAGE_KEY) as string;
 
-           try {
-            const acquisitionPackage = await api.acquisitionPackages.create();
-             if(acquisitionPackage){
-               this.setAcquisitionPackage(acquisitionPackage);
-               sessionStorage.setItem(ATAT_ACQUISTION_PACKAGE_KEY, JSON.stringify(acquisitionPackage));
-             }
-             
-           } catch (error) {
-             
-              console.log(`error creating acquisition package ${error}`);
-           }
-
+    if (storedAcquisitionPackageData && storedAcquisitionPackageData.length > 0) {
+      const parsedData = JSON.parse(storedAcquisitionPackageData) as AcquisitionPackageDTO;
+      this.setAcquisitionPackage(parsedData);
+    } else {
+      try {
+        const acquisitionPackage = await api.acquisitionPackages.create();
+        if (acquisitionPackage) {
+          this.setAcquisitionPackage(acquisitionPackage);
+          sessionStorage.setItem(ATAT_ACQUISTION_PACKAGE_KEY, JSON.stringify(acquisitionPackage));
+        }
+      } catch (error) {
+        console.log(`error creating acquisition package ${error}`);
       }
+    }
   }
+
   // service or agency selected on Organiation page
   selectedServiceOrAgency: SelectData = { text: "", value: "" };
   public getSelectedServiceOrAgency(): SelectData {

--- a/src/store/govtFurnishedEquipment/index.ts
+++ b/src/store/govtFurnishedEquipment/index.ts
@@ -1,0 +1,28 @@
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
+import rootStore from "../index";
+
+@Module({
+  name: 'GovtFurnishedEquipment',
+  namespaced: true,
+  dynamic: true,
+  store: rootStore
+})
+
+export class GovtFurnishedEquipmentStore extends VuexModule {
+
+  needsPropertyCustodian: boolean | null = null;
+
+  // Step 6 
+  @Action
+  public setNeedsPropertyCustodian(isNeeded: boolean): void {
+    this.doSetNeedsPropertyCustodian(isNeeded);
+  }
+  @Mutation
+  public doSetNeedsPropertyCustodian(isNeeded: boolean): void {
+    this.needsPropertyCustodian = isNeeded;
+  }
+
+}
+
+const GovtFurnishedEquipment = getModule(GovtFurnishedEquipmentStore);
+export default GovtFurnishedEquipment;

--- a/src/store/govtFurnishedEquipment/index.ts
+++ b/src/store/govtFurnishedEquipment/index.ts
@@ -12,7 +12,6 @@ export class GovtFurnishedEquipmentStore extends VuexModule {
 
   needsPropertyCustodian: boolean | null = null;
 
-  // Step 6 
   @Action
   public setNeedsPropertyCustodian(isNeeded: boolean): void {
     this.doSetNeedsPropertyCustodian(isNeeded);


### PR DESCRIPTION
1. ‘Tell us about your property custodian' screen exists with
    1. ‘Full name’ textbox with correct formatting.
    1. ‘DPAS Unit Identification Code (UICs)’ textbox with
        1. DPAS Unit Identification Code (UICs) tooltip with correct verbiage.
    1. ‘DPAS Custodian number’ textbox with
        1. DPAS Custodian number tooltip with correct verbiage
1. The screen should be correctly navigated to when the user selects ‘Yes.’ on the ‘[Will government equipment be furnished, provided or acquired under this acquisition](https://www.figma.com/file/DhwLh5B4y6pFbeLgMY63Rp/ATAT-Prototype-MVP%2B-(Master)?node-id=11019%3A366173)’ screen and clicks the ‘continue’ button. 
1. If the user selects ‘No. GFP/GFE will NOT be furnished to the contractor.' on the ‘[Will government equipment be furnished, provided or acquired under this acquisition](https://www.figma.com/file/DhwLh5B4y6pFbeLgMY63Rp/ATAT-Prototype-MVP%2B-(Master)?node-id=11019%3A366173)’ screen and clicks the ‘continue’ button, this screen should be skipped entirely.