### PR TITLE
Feature/at 7101 toast

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,6 +5,7 @@
     <ATATSlideoutPanel v-if="hasSlideoutPanelComponent">
       <component :is="slideoutPanelComponent"></component>
     </ATATSlideoutPanel>
+    <ATATToast />
 
     <ATATPageHead :headline="projectTitle"/>
     <v-main id="app">
@@ -37,6 +38,7 @@ import ATATPageHead from "./components/ATATPageHead.vue"
 import ATATSideStepper from "./components/ATATSideStepper.vue";
 import ATATSlideoutPanel from "./components/ATATSlideoutPanel.vue";
 import ATATStepperNavigation from "./components/ATATStepperNavigation.vue";
+import ATATToast from "./components/ATATToast.vue";
 
 import AcquisitionPackage from "@/store/acquisitionPackage";
 import SlideoutPanel from "@/store/slideoutPanel/index";
@@ -53,6 +55,7 @@ import actionHandler from "./action-handlers/index"
     ATATSideStepper,
     ATATSlideoutPanel,
     ATATStepperNavigation,
+    ATATToast,
   }
 })
 

--- a/src/components/ATATToast.vue
+++ b/src/components/ATATToast.vue
@@ -7,7 +7,7 @@
     class="_atat-toast"
     :class="[
       '_toast-' + toast.type, 
-      {'_has-icon': toast.hasIcon}
+      { '_has-icon': toast.hasIcon }
     ]"
     light
     :timeout="getTimeout"
@@ -76,6 +76,5 @@ export default class ATATToast extends Vue {
 
     return timeout * 1000;
   }
-
 }
 </script>

--- a/src/components/ATATToast.vue
+++ b/src/components/ATATToast.vue
@@ -1,0 +1,81 @@
+<template>
+  <v-snackbar
+    v-model="isToastOpen"
+    top
+    right
+    transition="slide-x-reverse-transition"
+    class="_atat-toast"
+    :class="[
+      '_toast-' + toast.type, 
+      {'_has-icon': toast.hasIcon}
+    ]"
+    light
+    :timeout="getTimeout"
+  >
+    {{ toast.message }}
+    <template v-if="toast.hasUndo" v-slot:action="{ attrs }">
+      <v-btn
+        text
+        v-bind="attrs"
+        @click="onUndo"
+      >
+        Undo
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component, Watch } from "vue-property-decorator";
+
+import Toast from "@/store/toast"
+
+@Component({})
+
+export default class ATATToast extends Vue {
+  private toast = Toast.toast;
+
+  private isOpen = false;
+  set isToastOpen(isOpen: boolean) {
+    this.isOpen = isOpen;
+  }
+  get isToastOpen(): boolean {
+    return Toast.toast.isOpen;
+  }
+
+  public timeout = 0;
+
+  @Watch("isToastOpen")
+  public setToast(isOpen: boolean): void {
+    clearTimeout(this.timeout);
+    this.$nextTick(() => {
+      this.isOpen = isOpen;
+      this.timeout = setTimeout(() => {
+        Toast.doSetToastClosed();
+      }, this.getTimeout);
+    });
+  }
+
+  private onUndo(): void {
+    this.$emit("toast-undo");
+  }
+
+  get getTimeout(): number {
+    let timeout = 3;
+    
+    // add an extra second for every 120 chars
+    if (this.toast.message) {
+      const textLength = this.toast.message.length;
+      const extraTime: number = Math.floor(textLength / 120);
+      timeout += extraTime;
+    }
+    
+    // add 2 seconds if there is an "Undo" link
+    timeout += this.toast.hasUndo ? 2 : 0;
+
+    return timeout * 1000;
+  }
+
+}
+</script>

--- a/src/components/ATATToast.vue
+++ b/src/components/ATATToast.vue
@@ -7,7 +7,8 @@
     class="_atat-toast"
     :class="[
       '_toast-' + toast.type, 
-      { '_has-icon': toast.hasIcon }
+      { '_has-icon': toast.hasIcon },
+      { '_has-undo': toast.hasUndo },     
     ]"
     light
     :timeout="getTimeout"

--- a/src/sass/atat.scss
+++ b/src/sass/atat.scss
@@ -26,7 +26,5 @@
 @import "./components/ATATStepperNavigation";
 @import "./components/ATATTextArea";
 @import "./components/ATATTextField";
+@import "./components/ATATToast";
 @import "./components/ATATTooltip";
-
-
-

--- a/src/sass/components/ATATToast.scss
+++ b/src/sass/components/ATATToast.scss
@@ -1,0 +1,61 @@
+._atat-toast {
+  .v-snack__content {
+    @extend .body;
+  }
+
+  &._has-icon {
+    .v-snack__content {
+      color: $base-darkest;
+      margin-left: 30px;
+      position: relative;
+      &:after {
+        position: absolute;
+        left: -16px;
+        top: 26px;
+        content: "check_circle_outline";
+        font-family: "Material Icons";
+        -webkit-font-feature-settings: "liga";
+        font-size: 24px;
+        font-weight: normal;
+        display: inline-block;
+        height: 9px;
+        line-height: 0;
+        text-decoration: none !important;
+      }
+    }
+  }
+
+  .v-snack__wrapper {
+    border: 1px solid;
+    min-width: unset;
+  }
+
+  &._toast-success {
+    .v-snack__wrapper {
+      background-color: $success-lighter;
+      border-color: $success !important;
+    }
+    .v-snack__content::after {
+      color: $success;
+    }
+  }
+
+  &._toast-info {
+    .v-snack__wrapper {
+      background-color: $info-lighter;
+      border-color: $info !important;
+    }
+
+    .v-snack__content::after {
+      color: $info;
+    }
+  }
+  
+  .v-btn {
+    .v-btn__content {
+      font-weight: normal;
+      color: $primary;
+      text-decoration: underline;
+    }    
+  }
+}

--- a/src/sass/components/ATATToast.scss
+++ b/src/sass/components/ATATToast.scss
@@ -3,6 +3,13 @@
     @extend .body;
   }
 
+  .v-snack__action  {
+    margin-right: 0;
+    .v-btn {
+      padding-left: 0 !important;
+    }
+  }
+
   &._has-icon {
     .v-snack__content {
       color: $base-darkest;

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -1,0 +1,49 @@
+import { Action, getModule, Module, Mutation, VuexModule } from "vuex-module-decorators";
+import rootStore from "./index";
+import { ToastObj } from "types/Global";
+
+@Module({
+  name: 'Toast',
+  namespaced: true,
+  dynamic: true,
+  store: rootStore
+})
+
+export class ToastStore extends VuexModule {
+
+  toast: ToastObj = {
+    isOpen: false,
+    type: "success",
+    message: "",
+    hasUndo: false,
+    hasIcon: false,  
+  }
+
+  @Action
+  public setToast(toast: ToastObj): void {
+    this.doSetToast(toast);
+  }
+
+  @Mutation
+  public doSetToast(toast: ToastObj): void {
+    this.toast.isOpen = toast.isOpen;
+    this.toast.type = toast.type;
+    this.toast.message = toast.message;
+    this.toast.hasUndo = toast.hasUndo;
+    this.toast.hasIcon = toast.hasIcon;
+  }
+
+  @Action
+  setToastClosed(): void {
+    this.doSetToastClosed();
+  }
+
+  @Mutation
+  doSetToastClosed(): void {
+    this.toast.isOpen = false;
+  }
+
+}
+
+const Toast = getModule(ToastStore);
+export default Toast;

--- a/src/store/toast.ts
+++ b/src/store/toast.ts
@@ -26,11 +26,7 @@ export class ToastStore extends VuexModule {
 
   @Mutation
   public doSetToast(toast: ToastObj): void {
-    this.toast.isOpen = toast.isOpen;
-    this.toast.type = toast.type;
-    this.toast.message = toast.message;
-    this.toast.hasUndo = toast.hasUndo;
-    this.toast.hasIcon = toast.hasIcon;
+    Object.assign(this.toast, toast);
   }
 
   @Action
@@ -42,7 +38,6 @@ export class ToastStore extends VuexModule {
   doSetToastClosed(): void {
     this.toast.isOpen = false;
   }
-
 }
 
 const Toast = getModule(ToastStore);

--- a/src/validation/ValidatorsExample.vue
+++ b/src/validation/ValidatorsExample.vue
@@ -1,16 +1,27 @@
 <template>
   <v-form ref="form" lazy-validation>
+    
+    <a 
+      class="d-block mb-10" 
+      role="button" 
+      id="SlideoutPanelOpener" 
+      tabindex="0"
+      @click="openSlideoutPanel"
+      aria-label="Example slideout panel trigger"
+    >
+      Open slideout panel
+    </a>
 
-      <a 
-        class="d-block mb-10" 
-        role="button" 
-        id="SlideoutPanelOpener" 
-        tabindex="0" 
-        @click="openSlideoutPanel"
-        aria-label="Example slideout panel trigger"
-      >
-        Open slideout panel
-      </a>
+    <a 
+      class="d-block mb-10" 
+      role="button" 
+      id="ToastOpener" 
+      tabindex="0" 
+      @click="setToast"
+      aria-label="Example toast trigger"
+    >
+      Open toast
+    </a>
 
     <v-row>
       <v-col cols="7"
@@ -59,7 +70,9 @@ import ATATTextField from "@/components/ATATTextField.vue";
 
 import SampleLearnMore from "./SampleLearnMore.vue";
 import SlideoutPanel from "@/store/slideoutPanel/index";
-import { SlideoutPanelContent } from "types/Global";
+import Toast from "@/store/toast";
+
+import { SlideoutPanelContent, ToastObj } from "types/Global";
 
 @Component({
   components: {
@@ -74,6 +87,17 @@ export default class ValidatatorsExample extends Vue {
   private maxValue = "12345678910";
   private requiredValue = "";
   private integerValue = "y";
+
+  private setToast(): void {
+    const toast: ToastObj = {
+      type: "info",
+      message: "My toast message " + Math.floor(Math.random() * 100),
+      isOpen: true,
+      hasUndo: false,
+      hasIcon: true,
+    }
+    Toast.setToast(toast);
+  }
 
   get Form(): Vue & { validate: () => boolean } {
     return this.$refs.form as Vue & { validate: () => boolean };
@@ -97,6 +121,14 @@ export default class ValidatatorsExample extends Vue {
       title: "Learn More 1",
     }
     await SlideoutPanel.setSlideoutPanelComponent(slideoutPanelContent);
+
+    // const toast: ToastObj = {
+    //   type: "success",
+    //   message: "My default toast message",
+    //   isOpen: false,
+    // }
+    // await Toast.setToast(toast);
+
   }
 
   public openSlideoutPanel(e: Event): void {

--- a/src/validation/ValidatorsExample.vue
+++ b/src/validation/ValidatorsExample.vue
@@ -13,15 +13,44 @@
     </a>
 
     <a 
-      class="d-block mb-10" 
-      role="button" 
-      id="ToastOpener" 
-      tabindex="0" 
-      @click="setToast"
-      aria-label="Example toast trigger"
+      class="d-block mb-2" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('success', false, false, false)"
     >
-      Open toast
+      Open toast: success, no icon, no undo, short message
     </a>
+    <a 
+      class="d-block mb-2" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('success', true, true, false)"
+    >
+      Open toast: success, has icon, has undo, short message
+    </a>
+    <a 
+      class="d-block mb-6" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('success', false, true, true)"
+    >
+      Open toast: success, no icon, has undo, long message
+    </a>
+
+    <a 
+      class="d-block mb-2" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('info', false, false, false)"
+    >
+      Open toast: info, no icon, no undo, short message
+    </a>
+    <a 
+      class="d-block mb-2" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('info', true, true, false)"
+    >
+      Open toast: info, has icon, has undo, short message
+    </a>
+    <a 
+      class="d-block mb-10" role="button" id="ToastOpener" tabindex="0" 
+      @click="setToast('info', false, true, true)"
+    >
+      Open toast: info, no icon, has undo, long message
+    </a>
+
+
 
     <v-row>
       <v-col cols="7"
@@ -88,15 +117,25 @@ export default class ValidatatorsExample extends Vue {
   private requiredValue = "";
   private integerValue = "y";
 
-  private setToast(): void {
+  private setToast(
+    type: "success" | "info", 
+    hasIcon: boolean, 
+    hasUndo: boolean, 
+    longMessage: boolean,
+  ): void {
+    let message = longMessage 
+      ? `My toast with a long message to check the timing of the toast - one extra 
+        second for every 120 characters so this message should add one second. `
+      : "My toast message ";
+
     const toast: ToastObj = {
-      type: "info",
-      message: "My toast message " + Math.floor(Math.random() * 100),
+      type,
+      message,
       isOpen: true,
-      hasUndo: false,
-      hasIcon: true,
+      hasUndo,
+      hasIcon,
     }
-    
+
     Toast.setToast(toast);
   }
 

--- a/src/validation/ValidatorsExample.vue
+++ b/src/validation/ValidatorsExample.vue
@@ -161,14 +161,6 @@ export default class ValidatatorsExample extends Vue {
       title: "Learn More 1",
     }
     await SlideoutPanel.setSlideoutPanelComponent(slideoutPanelContent);
-
-    // const toast: ToastObj = {
-    //   type: "success",
-    //   message: "My default toast message",
-    //   isOpen: false,
-    // }
-    // await Toast.setToast(toast);
-
   }
 
   public openSlideoutPanel(e: Event): void {

--- a/src/validation/ValidatorsExample.vue
+++ b/src/validation/ValidatorsExample.vue
@@ -96,6 +96,7 @@ export default class ValidatatorsExample extends Vue {
       hasUndo: false,
       hasIcon: true,
     }
+    
     Toast.setToast(toast);
   }
 

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -111,3 +111,11 @@ export interface CountryObj {
   active: boolean;
   suggested?: boolean;
 }
+
+export interface ToastObj {
+  isOpen: boolean;
+  type: string;
+  message: string;
+  hasUndo?: boolean;
+  hasIcon?: boolean;
+}

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -114,7 +114,7 @@ export interface CountryObj {
 
 export interface ToastObj {
   isOpen: boolean;
-  type: string;
+  type: "success" | "info";
   message: string;
   hasUndo?: boolean;
   hasIcon?: boolean;


### PR DESCRIPTION
1. The toast component exists in ServiceNow, is functional, and styled properly.
2. Toast will be positioned in top-right corner of the window.
3. Toast transition will fade in and slide from the left when opening, slide right and fade out when closing.
4. Has option of including a circle-check icon.
5. Has option of being colored for success (green) or info (blue).
6. Has option for an “Undo” link.
7. Timing - how long to show the toast.
    1. Default to 3 seconds.
    1. Add 1 second for every extra 120 characters in message.
    1. Add 2 seconds if includes an “Undo” link.