### PR TITLE
Stepper navigation update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,18 @@
 <template>
   <v-app>
-    <ATATSideStepper ref="sideStepper" :stepperData="stepperData"/>
+    <ATATSideStepper ref="sideStepper" :stepperData="stepperData" />
 
     <ATATSlideoutPanel v-if="hasSlideoutPanelComponent">
       <component :is="slideoutPanelComponent"></component>
     </ATATSlideoutPanel>
     <ATATToast />
 
-    <ATATPageHead :headline="projectTitle"/>
+    <ATATPageHead :headline="projectTitle" />
     <v-main id="app">
       <router-view></router-view>
 
-      <ATATStepperNavigation 
-        @next="navigate('next')" 
+      <ATATStepperNavigation
+        @next="navigate('next')"
         @previous="navigate('previous')"
         @additionalButtonClick="additionalButtonClick"
         :additionalButtons="additionalButtons"
@@ -20,7 +20,7 @@
         :noPrevious="noPrevious"
       />
 
-      <ATATFooter/>
+      <ATATFooter />
     </v-main>
   </v-app>
 </template>
@@ -34,7 +34,7 @@ import Vue from "vue";
 import { Component, Watch } from "vue-property-decorator";
 
 import ATATFooter from "./components/ATATFooter.vue";
-import ATATPageHead from "./components/ATATPageHead.vue"
+import ATATPageHead from "./components/ATATPageHead.vue";
 import ATATSideStepper from "./components/ATATSideStepper.vue";
 import ATATSlideoutPanel from "./components/ATATSlideoutPanel.vue";
 import ATATStepperNavigation from "./components/ATATStepperNavigation.vue";
@@ -44,9 +44,13 @@ import AcquisitionPackage from "@/store/acquisitionPackage";
 import SlideoutPanel from "@/store/slideoutPanel/index";
 import Steps from "@/store/steps";
 
-import { AdditionalButton, StepInfo } from "@/store/steps/types";
+import {
+  AdditionalButton,
+  StepInfo,
+  StepRouteResolver,
+} from "@/store/steps/types";
 import { buildStepperData } from "./router/stepper";
-import actionHandler from "./action-handlers/index"
+import actionHandler from "./action-handlers/index";
 
 @Component({
   components: {
@@ -56,9 +60,8 @@ import actionHandler from "./action-handlers/index"
     ATATSlideoutPanel,
     ATATStepperNavigation,
     ATATToast,
-  }
+  },
 })
-
 export default class App extends Vue {
   $refs!: {
     sideStepper: ATATSideStepper;
@@ -82,12 +85,12 @@ export default class App extends Vue {
     const routeName = this.$route.name;
     const step = await Steps.findRoute(routeName || "");
     if (routeName && step) {
-      const {stepName} = step;
+      const { stepName } = step;
       Steps.setCurrentStep(stepName);
       this.setNavButtons(step);
     }
     await AcquisitionPackage.initialize();
-    
+
     this.slideoutPanelComponent = SlideoutPanel.slideoutPanelComponent;
   }
 
@@ -97,11 +100,11 @@ export default class App extends Vue {
     const step = await Steps.findRoute(routeName || "");
 
     if (routeName && step) {
-      const {stepName, stepNumber} = step;
+      const { stepName, stepNumber } = step;
       Steps.setCurrentStep(stepName);
       this.setNavButtons(step);
       this.$refs.sideStepper.setCurrentStep(stepNumber);
-      
+
       SlideoutPanel.closeSlideoutPanel();
       this.slideoutPanelComponent = SlideoutPanel.slideoutPanelComponent;
     }
@@ -109,12 +112,23 @@ export default class App extends Vue {
 
   async navigate(direction: string): Promise<void> {
     const nextStepName =
-      direction === "next" 
-        ? await Steps.getNext() 
-        : await Steps.getPrevious();
+      direction === "next" ? await Steps.getNext() : await Steps.getPrevious();
 
     if (nextStepName) {
-      this.$router.push({name: nextStepName});
+      const isRouteResolver =
+        (nextStepName as StepRouteResolver).name != undefined;
+
+      if (isRouteResolver) {
+        const routeResolver = nextStepName as StepRouteResolver;
+        this.$router.push({
+          name: "resolver",
+          params: {
+            resolver: routeResolver.name,
+          },
+        });
+      } else {
+        this.$router.push({ name: nextStepName as string });
+      }
     }
   }
 
@@ -134,15 +148,14 @@ export default class App extends Vue {
 
   private async additionalButtonClick(button: AdditionalButton) {
     if (button.emitText) {
-      this.$emit('AdditionalButtonClicked', button.emitText);
+      this.$emit("AdditionalButtonClicked", button.emitText);
     }
     if (button.actionName) {
       const actionArgs = button.actionArgs || [];
       await actionHandler(button.actionName, actionArgs);
     }
 
-    this.$router.push({name: button.name})
+    this.$router.push({ name: button.name });
   }
-
 }
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,7 +116,7 @@ export default class App extends Vue {
 
     if (nextStepName) {
       const isRouteResolver =
-        (nextStepName as StepRouteResolver).name != undefined;
+        (nextStepName as StepRouteResolver).name !== undefined;
 
       if (isRouteResolver) {
         const routeResolver = nextStepName as StepRouteResolver;

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,8 +1,14 @@
 import VueRouter from "vue-router";
 import {stepperRoutes} from "./stepper";
+import Resolver from "./resolvers/Resolver.vue";
 
 const routes = [
    ...stepperRoutes,
+   {
+     name: 'resolver',
+     component: Resolver,
+     path: '/resolver'
+   },
 ];
 
 const router = new VueRouter({

--- a/src/router/resolvers/Resolver.vue
+++ b/src/router/resolvers/Resolver.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { Route } from "vue-router";
+
+// route resolvers
+import {
+    InvokeResolver
+  } from "./index";
+
+Component.registerHooks(["beforeRouteEnter"]);
+@Component({
+    template:'<div></div>'
+})
+export default class Resolver extends Vue {
+
+  
+
+  private resolveRoute(current: string): void{
+
+         const routeResolver = this.$route.params.resolver;
+
+         if(!routeResolver){
+             throw new Error("could not obtain step and resolver");
+         }
+
+         const routeName = InvokeResolver(routeResolver,current);
+         this.$router.push({name: routeName});
+
+  }
+
+  public async beforeRouteEnter(
+    to: Route,
+    from: Route,
+    next: (n: unknown) => void
+  ): Promise<void> {
+    next(async (vm: {resolveRoute: (current:string)=> void} ) => {
+          const current = from.name;
+          if(!current){
+              throw new Error('from route name undefined');
+          }
+
+          vm.resolveRoute(current);
+    });
+  }
+}
+</script>

--- a/src/router/resolvers/Resolver.vue
+++ b/src/router/resolvers/Resolver.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-  </div>
+  <div></div>
 </template>
 
 <script lang="ts">
@@ -8,30 +7,21 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import { Route } from "vue-router";
 
-// route resolvers
-import {
-    InvokeResolver
-  } from "./index";
+// route resolver invoker
+import { InvokeResolver } from "./index";
 
 Component.registerHooks(["beforeRouteEnter"]);
-@Component({
-    template:'<div></div>'
-})
+@Component({})
 export default class Resolver extends Vue {
+  private resolveRoute(current: string): void {
+    const routeResolver = this.$route.params.resolver;
 
-  
+    if (!routeResolver) {
+      throw new Error("could not obtain step resolver");
+    }
 
-  private resolveRoute(current: string): void{
-
-         const routeResolver = this.$route.params.resolver;
-
-         if(!routeResolver){
-             throw new Error("could not obtain step and resolver");
-         }
-
-         const routeName = InvokeResolver(routeResolver,current);
-         this.$router.push({name: routeName});
-
+    const routeName = InvokeResolver(routeResolver, current);
+    this.$router.push({ name: routeName });
   }
 
   public async beforeRouteEnter(
@@ -39,13 +29,13 @@ export default class Resolver extends Vue {
     from: Route,
     next: (n: unknown) => void
   ): Promise<void> {
-    next(async (vm: {resolveRoute: (current:string)=> void} ) => {
-          const current = from.name;
-          if(!current){
-              throw new Error('from route name undefined');
-          }
+    next(async (vm: { resolveRoute: (current: string) => void }) => {
+      const current = from.name;
+      if (!current) {
+        throw new Error("from route name undefined");
+      }
 
-          vm.resolveRoute(current);
+      vm.resolveRoute(current);
     });
   }
 }

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -11,7 +11,10 @@ export const AcorsRouteResolver = (current: string): string => {
 
   //routing from alternate cor and the user does not have
   //and alternatative contact rep
-  if (current === routeNames.Alternate_Cor && hasAlternativeContactRep === false) {
+  if (
+    current === routeNames.Alternate_Cor &&
+    hasAlternativeContactRep === false
+  ) {
     return routeNames.Summary;
   }
 
@@ -25,18 +28,23 @@ export const AcorsRouteResolver = (current: string): string => {
 
 export const CustodianRouteResolver = (current: string): string => {
   const needsPropertyCustodian = GovtFurnishedEquipment.needsPropertyCustodian;
-  
+
   // if government equipment will be furnished, route to Property Custodian page
-  if (current === routeNames.Will_Govt_Equip_Be_Furnished && needsPropertyCustodian) {
+  if (
+    current === routeNames.Will_Govt_Equip_Be_Furnished &&
+    needsPropertyCustodian
+  ) {
     return routeNames.Property_Custodian;
   }
 
   // else stay on same page until next step after Property Custodian is completed
-  alert("Business rule is to skip Property Custodian page if answer is \"No\" (or unanswered) here. " +
-    "Navigation will temporarily stay on this page until the substep after Property " +
-    "Custodian has been completed. Select \"Yes\" to continue to Property Custodian page.");
+  alert(
+    'Business rule is to skip Property Custodian page if answer is "No" (or unanswered) here. ' +
+      "Navigation will temporarily stay on this page until the substep after Property " +
+      'Custodian has been completed. Select "Yes" to continue to Property Custodian page.'
+  );
   // todo - change this routeName when page after Property Custodian is completed
-  return routeNames.Will_Govt_Equip_Be_Furnished; 
+  return routeNames.Will_Govt_Equip_Be_Furnished;
 };
 
 export const CurrentContractRouteResolver = (current: string): string => {
@@ -45,8 +53,8 @@ export const CurrentContractRouteResolver = (current: string): string => {
   if (hasCurrentContract) {
     return routeNames.Current_Contract_Details;
   }
-  return current === routeNames.Current_Contract 
-    ? routeNames.Performance_Requirements 
+  return current === routeNames.Current_Contract
+    ? routeNames.Performance_Requirements
     : routeNames.Current_Contract;
 };
 
@@ -66,22 +74,20 @@ export const FOIARecordResolver = (current: string): string => {
   if (needsFOIACoordinator) {
     return routeNames.FOIA_Coordinator;
   }
-  return current === routeNames.FOIA 
-    ? routeNames.Public_Disclosure_of_Information 
+  return current === routeNames.FOIA
+    ? routeNames.Public_Disclosure_of_Information
     : routeNames.FOIA;
 };
 
+const resolvers: Record<string, StepRouteResolver> = {
+  AcorsRouteResolver,
+  CurrentContractRouteResolver,
+  CustodianRouteResolver,
+  PIIRecordResolver,
+  FOIARecordResolver,
+};
 
-const resolvers: Record<string,  StepRouteResolver> = {
- 
-  "AcorsRouteResolver": AcorsRouteResolver,
-  "CurrentContractRouteResolver":CurrentContractRouteResolver,
-  "CustodianRouteResolver": CustodianRouteResolver,
-  "PIIRecordResolver": PIIRecordResolver,
-  "FOIARecordResolver": FOIARecordResolver
-    
-}
-
-export const InvokeResolver = (resolverName: string, currentStep: string): string => resolvers[resolverName](currentStep);
-
-
+export const InvokeResolver = (
+  resolverName: string,
+  currentStep: string
+): string => resolvers[resolverName](currentStep);

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -4,6 +4,7 @@ import OtherContractConsiderations from "@/store/otherContractConsiderations";
 import Background from "@/store/background";
 
 import { routeNames } from "../stepper";
+import { StepRouteResolver } from "@/store/steps/types";
 
 export const AcorsRouteResolver = (current: string): string => {
   const hasAlternativeContactRep = AcquisitionPackage.hasAlternativeContactRep;
@@ -69,3 +70,18 @@ export const FOIARecordResolver = (current: string): string => {
     ? routeNames.Public_Disclosure_of_Information 
     : routeNames.FOIA;
 };
+
+
+const resolvers: Record<string,  StepRouteResolver> = {
+ 
+  "AcorsRouteResolver": AcorsRouteResolver,
+  "CurrentContractRouteResolver":CurrentContractRouteResolver,
+  "CustodianRouteResolver": CustodianRouteResolver,
+  "PIIRecordResolver": PIIRecordResolver,
+  "FOIARecordResolver": FOIARecordResolver
+    
+}
+
+export const InvokeResolver = (resolverName: string, currentStep: string): string => resolvers[resolverName](currentStep);
+
+

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -79,6 +79,8 @@ export const FOIARecordResolver = (current: string): string => {
     : routeNames.FOIA;
 };
 
+
+// add resolver here so that it can be found by invoker
 const resolvers: Record<string, StepRouteResolver> = {
   AcorsRouteResolver,
   CurrentContractRouteResolver,

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -187,7 +187,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
     stepNumber: "03",
     menuText: "Background",
     path: "/current-contract",
-    name: routeNames.Current_Contract,
     completePercentageWeight: 10,
     component: Background,
     completed: false,
@@ -231,7 +230,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
   {
     stepNumber: "05",
     completePercentageWeight: 7,
-    name: routeNames.Period_Of_Performance,
     menuText: "Contract Details",
     path: "/period-of-performance",
     component: PeriodOfPerformance,
@@ -248,7 +246,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
   {
     stepNumber: "06",
     completePercentageWeight: 7,
-    name: routeNames.Property_Requirements,
     menuText: "Government Furnished Equipment",
     path: "/property-requirements",
     component: GovtFurnishedEquipment,
@@ -281,7 +278,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
   {
     stepNumber: "07",
     completePercentageWeight: 7,
-    name: routeNames.PII,
     menuText: "Other Contract Considerations",
     path: "/personally-identifiable-information",
     component: OtherContractConsiderations,
@@ -346,7 +342,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
   {
     stepNumber: "10",
     completePercentageWeight: 7,
-    name: routeNames.Project_Scope,
     menuText: "Financial Details",
     path: "/project-scope",
     component: FinancialDetails,
@@ -362,7 +357,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
   },
   {
     stepNumber: "11",
-
     completePercentageWeight: 7,
     name: "Government_Furnished_Equipment",
     menuText: "Government Furnished Equipment",

--- a/src/store/steps/helpers/index.ts
+++ b/src/store/steps/helpers/index.ts
@@ -26,7 +26,7 @@ export const mapStepConfigs = (
     }
         
     //we use step name for dynamic routing
-    //sense by convention the parent route configs
+    //since by convention the parent route configs
     //don't have a name we will fall through to child routes
     if(stepInfo.stepName.length > 0){
       map?.set(stepInfo.stepName, stepInfo);

--- a/src/store/steps/helpers/index.ts
+++ b/src/store/steps/helpers/index.ts
@@ -24,9 +24,14 @@ export const mapStepConfigs = (
       lastStep.next = stepInfo.stepName;
       stepInfo.prev = lastStep.stepName;
     }
-
-    map?.set(stepInfo.stepName, stepInfo);
-    last = stepInfo.stepName;
+        
+    //we use step name for dynamic routing
+    //sense by convention the parent route configs
+    //don't have a name we will fall through to child routes
+    if(stepInfo.stepName.length > 0){
+      map?.set(stepInfo.stepName, stepInfo);
+      last = stepInfo.stepName;
+    }
 
     routeConfig.children?.forEach((childConfig) =>
       mapStep({

--- a/src/store/steps/index.ts
+++ b/src/store/steps/index.ts
@@ -1,9 +1,10 @@
 import { VuexModule, Module, Action, Mutation, getModule } from "vuex-module-decorators";
 import rootStore from "../index";
-import { Mutations, RouteDirection, StepInfo, StepsState } from "./types";
+import { Mutations, RouteDirection, StepInfo, StepRouteResolver, StepsState } from "./types";
 import { mapStepConfigs } from "./helpers";
 import { stepperRoutes } from "@/router/stepper";
 import { StepperRouteConfig } from "types/Global";
+import VueRouter from "vue-router";
 
 @Module({ name: 'Steps', namespaced: true, dynamic: true, store: rootStore })
 export class StepsStore extends VuexModule implements StepsState {
@@ -45,7 +46,7 @@ export class StepsStore extends VuexModule implements StepsState {
     }
 
     @Action({ rawError: true })
-    public async resolveRoute(direction: RouteDirection): Promise<string | undefined> {
+    public async resolveRoute(direction: RouteDirection): Promise<string | StepRouteResolver | undefined> {
 
         const nextStepName = direction === RouteDirection.NEXT 
             ? (this.currentStep?.next || '') 
@@ -61,19 +62,19 @@ export class StepsStore extends VuexModule implements StepsState {
         const stepResolver = nextStep?.resolver;
 
         if (stepResolver) {
-            return stepResolver(currentStepName);
+            return stepResolver;
         }
 
         return nextStep?.stepName;
     }
 
     @Action({ rawError: true })
-    public async getNext(): Promise<string | undefined> {
+    public async getNext(): Promise<string | StepRouteResolver | undefined> {
         return this.resolveRoute(RouteDirection.NEXT);
     }
 
     @Action({ rawError: true })
-    public async getPrevious(): Promise<string | undefined> {
+    public async getPrevious(): Promise<string | StepRouteResolver | undefined> {
         return this.resolveRoute(RouteDirection.PREVIOUS)
     }
 }


### PR DESCRIPTION
I updated the stepper mapping for navigation so that nameless parent routes are not mapped
I updated the route resolver functionality so that route resolution is performed in a component called Resolver. This should allow any data persistence that occurs in 'SaveOnLeave' to be finalized before moving on to the next route. The Resolver component is never actually rendered because the Resolver component routes the UI to the correct stepper by calling the route resolver function BeforeRouteEnter, invoking the resolver and navigating to the desired route. 