### PR TITLE
Feature/at 7249 section 508

### DIFF
--- a/src/components/ATATAlert.vue
+++ b/src/components/ATATAlert.vue
@@ -5,7 +5,11 @@
     class="_atat-alert"
     :class="getClasses"
   >
-    <div class="d-flex">
+    <div 
+      class="_content d-flex"
+      :style="{ 'max-height': maxHeight + 'px' }"
+      :class="{ 'pt-6 pr-6': maxHeight }"
+    >
       <div
         v-if="type !== 'callout'"
         class="pr-4"
@@ -22,6 +26,11 @@
       </div>
       <div>
         <slot name="content"></slot>
+        <div 
+          v-if="maxHeight"
+          style="height: 60px; display: block; width: 100%"
+        >
+        </div>
       </div>
       <div
         v-if="closeButton"
@@ -71,6 +80,7 @@ export default class ATATAlert extends Vue {
   @Prop({ default: "presentation" }) private role?: string;
   @Prop({ default: true }) private show?: boolean;
   @Prop({ default: "Alert" }) private id?: string;
+  @Prop({ default: "" }) private maxHeight?: string;
 
   /**
    * type: 1) info, 2) error, 3) warning, 4) success, 5) callout
@@ -89,12 +99,13 @@ export default class ATATAlert extends Vue {
   @Prop({ default: false }) private borderLeft?: boolean;
   @Prop({ default: false }) private closeButton?: boolean;
 
-  get getClasses(): string {
+  public get getClasses(): string {
     if (this.type === "callout") {
-      return "_callout";
+      return this.maxHeight ? "_callout py-0 pr-0 " : "_callout";
     }
     let alertClasses = "_" + this.type + "-alert";
     alertClasses = this.borderLeft ? alertClasses + " _border-left-thick " : alertClasses;
+    alertClasses = this.maxHeight ? alertClasses + " py-0 pr-0 " : alertClasses;
     return alertClasses;
   }
 

--- a/src/sass/components/ATATAlert.scss
+++ b/src/sass/components/ATATAlert.scss
@@ -1,4 +1,4 @@
-._atat-alert{
+._atat-alert {
   display: block;
   color: $base-darkest;
   border-radius: 4px;
@@ -6,6 +6,25 @@
   padding: 24px;
   border: 1px solid transparent;
   padding: 16px 20px;
+  position: relative;
+  
+  &:after {
+    content: "";
+    position: absolute;
+    z-index: 1;
+    pointer-events: none;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 60px;
+    background: rgb(230,245,252);
+    background: linear-gradient(180deg, rgba(230,245,252,0) 0%, rgba(230,245,252,1) 100%);    
+  }
+  ._content {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    position: relative;
+  }
 
   a {
     text-decoration: underline;

--- a/src/sass/components/ATATAlert.scss
+++ b/src/sass/components/ATATAlert.scss
@@ -8,18 +8,27 @@
   padding: 16px 20px;
   position: relative;
   
-  &:after {
+  &:before, &:after {
     content: "";
     position: absolute;
     z-index: 1;
-    pointer-events: none;
     left: 0;
     right: 0;
+    background: rgb(230,245,252);
+  }
+
+  &:before {
+    top: 0;
+    height: 24px;
+    background: linear-gradient(180deg, rgba(230,245,252,1) 0%, rgba(230,245,252,0) 100%);    
+  }
+  
+  &:after {
     bottom: 0;
     height: 60px;
-    background: rgb(230,245,252);
     background: linear-gradient(180deg, rgba(230,245,252,0) 0%, rgba(230,245,252,1) 100%);    
   }
+  
   ._content {
     overflow-x: hidden;
     overflow-y: scroll;

--- a/src/sass/utils/typography.scss
+++ b/src/sass/utils/typography.scss
@@ -248,3 +248,9 @@ $sizes: 16, 18, 20, 22, 24, 26, 28, 32, 200;
   font-weight: 500 !important;
 }
 
+ul._atat-ul {
+  padding-bottom: 12px;
+  li {
+    padding-bottom: 8px;
+  }
+}

--- a/src/sass/utils/typography.scss
+++ b/src/sass/utils/typography.scss
@@ -265,5 +265,20 @@ ul._atat-ul {
   padding-bottom: 12px;
   li {
     padding-bottom: 8px;
+    ul {
+      li {
+        position: relative;
+        &::marker {
+          content: "";
+        }
+        &:before {
+          content: "•";
+          font-size: 2.5rem;
+          position: absolute;
+          left: -18px;
+          top: 0;
+        }
+      }
+    }
   }
 }

--- a/src/steps/07-OtherContractConsiderations/BAA.vue
+++ b/src/steps/07-OtherContractConsiderations/BAA.vue
@@ -120,8 +120,8 @@ import { RadioButton, SlideoutPanelContent } from "../../../types/Global";
 @Component({
   components: {
     ATATAlert,
-    ATATRadioGroup,
     ATATExpandableLink,
+    ATATRadioGroup,
     BAALearnMore,
   },
 })

--- a/src/steps/07-OtherContractConsiderations/Section508Standards.vue
+++ b/src/steps/07-OtherContractConsiderations/Section508Standards.vue
@@ -3,11 +3,11 @@
     <v-container fluid class="container-max-width">
       <v-row>
         <v-col class="col-12">
-          <h1 class="page-header">
+          <h1 class="page-header mb-3">
             Let’s look into your Section 508 Accessibility requirements
           </h1>
           <div class="copy-max-width">
-            <p>
+            <p id="IntroP" class="mb-10">
               The overarching JWCC Contract provides the following language to
               ensure CSPs comply with the government’s Section 508 Accessibility
               Standards for Cloud Computing. If your project requires different
@@ -18,6 +18,7 @@
               id="Section508Callout" 
               type="callout"
               maxHeight="460"
+              class="mb-10"
             >
               <template slot="content">
                 <h2>
@@ -28,43 +29,43 @@
                   Requirements Statement per the Revised Section 508 of the
                   Rehabiliation Act
                 </p>
-                <h3 class="mb-3">Electronic Content Technical Criteria:</h3>
+
+                <span class="font-size-20 _semibold mb-4 d-block">
+                  Electronic Content Technical Criteria:
+                </span>
                 <ul class="_atat-ul">
                   <li>
-                    <span class="_semibold">E205.1 General</span> - Electronic
+                    <strong>E205.1 General</strong> - Electronic
                     content shall comply with E205.
                   </li>
                   <li>
-                    <span class="_semibold">E205.2 Public Facing</span> -
+                    <strong>E205.2 Public Facing</strong> -
                     Electronic content that is public facing shall conform to
                     the accessibility requirements specified in E205.4.
                   </li>
                   <li>
-                    <span class="_semibold">602 Support Documentation</span>
+                    <strong>602 Support Documentation</strong>
                   </li>
                   <li>
-                    <span class="_semibold">603 Support Services</span>
+                    <strong>603 Support Services</strong>
                   </li>
                   <li>
-                    <span class="_semibold"
-                      >302 Functional Performance Criteria</span
-                    >
+                    <strong>302 Functional Performance Criteria</strong>
                   </li>
                 </ul>
 
-                <span class="font-size-16 _semibold mb-3">Software Exceptions:</span>
+                <span class="font-size-20 _semibold mb-4 d-block">
+                  Software Exceptions:
+                </span>
                 <ul class="_atat-ul">
                   <li>
-                    <span class="_semibold">E207.1 General</span> - Software
+                    <strong>E207.1 General</strong> - Software
                     that is assistive technology and that supports the
                     accessibility services of the platform shall not be required
                     to conform to the requirements in Chapter 5.
                   </li>
                   <li>
-                    <span class="_semibold">E207.2 WCAG Conformance -</span>
-                  </li>
-
-                  <li>
+                    <strong class="mb-2 d-block">E207.2 WCAG Conformance -</strong>
                     <ul class="_atat-ul">
                       <li>
                         Software that is assistive technology and that supports
@@ -77,7 +78,7 @@
                         Bypass Blocks; 2.4.5 Multiple Ways; 3.2.3 Consistent
                         Navigation; and 3.2.4 Consistent Identification.
                       </li>
-                      <li>
+                      <li class="pb-0">
                         Non-Web software shall not be required to conform to
                         Conformance Requirement 3 Complete Processes in WCAG
                         2.0.
@@ -86,10 +87,12 @@
                   </li>
                 </ul>
 
-                <h3 class="mb-3">Functional Performance Criteria:</h3>
+                <span class="font-size-20 _semibold mb-4 d-block">
+                  Functional Performance Criteria:
+                </span>
                 <ul class="_atat-ul">
                   <li>
-                    <span class="_semibold">301.1 Scope</span> - The
+                    <strong>301.1 Scope</strong> - The
                     requirements of Chapter 3 shall apply to ICT where required
                     by 508 Chapter 2 (Scoping Requirements), 255 Chapter 2
                     (Scoping Requirements), and where otherwise referenced in
@@ -97,56 +100,56 @@
                     255 Guidelines.
                   </li>
                   <li>
-                    <span class="_semibold">302.1 Without Vision</span> - Where
+                    <strong>302.1 Without Vision</strong> - Where
                     a visual mode of operation is provided, ICT shall provide at
                     least one mode of operation that does not require user
                     vision.
                   </li>
                   <li>
-                    <span class="_semibold">302.2 With Limited Vision</span> -
+                    <strong>302.2 With Limited Vision</strong> -
                     Where a visual mode of operation is provided, ICT shall
                     provide at least one mode of operation that enables users to
                     make use of limited vision.
                   </li>
                   <li>
-                    <span class="_semibold">302.3 Without Perception of Color</span> 
+                    <strong>302.3 Without Perception of Color</strong> 
                     - Where a visual mode of operation is provided, ICT shall
                     provide at least one visual mode of operation that does not
                     require user perception of color.
                   </li>
                   <li>
-                    <span class="_semibold">302.4 Without Hearing</span> - Where
+                    <strong>302.4 Without Hearing</strong> - Where
                     an audible mode of operation is provided, ICT shall provide
                     at least one mode of operation that does not require user
                     hearing.
                   </li>
                   <li>
-                    <span class="_semibold">302.5 With Limited Hearing</span> -
+                    <strong>302.5 With Limited Hearing</strong> -
                     Where an audible mode of operation is provided, ICT shall
                     provide at least one mode of operation that enables users to
                     make use of limited hearing.
                   </li>
                   <li>
-                    <span class="_semibold">302.6 Without Speech</span> - Where
+                    <strong>302.6 Without Speech</strong> - Where
                     speech is used for input, control, or operation, ICT shall
                     provide at least one mode of operation that does not require
                     user speech.
                   </li>
                   <li>
-                    <span class="_semibold">302.7 With Limited Manipulation</span>
+                    <strong>302.7 With Limited Manipulation</strong>
                     - Where a manual mode of operation is provided, ICT shall
                     provide at least one mode of operation that does not require
                     fine motor control or simultaneous manual operations.
                   </li>
                   <li>
-                    <span class="_semibold">302.8 With Limited Reach and Strength</span>
+                    <strong>302.8 With Limited Reach and Strength</strong>
                     - Where a manual mode of operation is provided, ICT shall
                     provide at least one mode of operation that is operable with
                     limited reach and limited strength.
                   </li>
                   <li>
-                    <span class="_semibold">302.9 With Limited Language, Cognitive, 
-                    and Learning Abilities</span> - ICT shall provide features 
+                    <strong>302.9 With Limited Language, Cognitive, 
+                    and Learning Abilities</strong> - ICT shall provide features 
                     making its use by individuals with limited cognitive, language, 
                     and learning abilities simpler and easier.
                   </li>

--- a/src/steps/07-OtherContractConsiderations/Section508Standards.vue
+++ b/src/steps/07-OtherContractConsiderations/Section508Standards.vue
@@ -1,16 +1,218 @@
-
 <template>
-  <div>
-    Future 508 Standards page
+  <div class="mb-7">
+    <v-container fluid class="container-max-width">
+      <v-row>
+        <v-col class="col-12">
+          <h1 class="page-header">
+            Let’s look into your Section 508 Accessibility requirements
+          </h1>
+          <div class="copy-max-width">
+            <p>
+              The overarching JWCC Contract provides the following language to
+              ensure CSPs comply with the government’s Section 508 Accessibility
+              Standards for Cloud Computing. If your project requires different
+              compliance standards, we’ll gather that info next. Learn more
+              about Section 508.
+            </p>
+            <ATATAlert 
+              id="Section508Callout" 
+              type="callout"
+              maxHeight="460"
+            >
+              <template slot="content">
+                <h2>
+                  Section 508 Accessibility Standards for Cloud Computing
+                </h2>
+                <p>
+                  Information and Communication Technology (ICT) Accessibility
+                  Requirements Statement per the Revised Section 508 of the
+                  Rehabiliation Act
+                </p>
+                <h3 class="mb-3">Electronic Content Technical Criteria:</h3>
+                <ul class="_atat-ul">
+                  <li>
+                    <span class="_semibold">E205.1 General</span> - Electronic
+                    content shall comply with E205.
+                  </li>
+                  <li>
+                    <span class="_semibold">E205.2 Public Facing</span> -
+                    Electronic content that is public facing shall conform to
+                    the accessibility requirements specified in E205.4.
+                  </li>
+                  <li>
+                    <span class="_semibold">602 Support Documentation</span>
+                  </li>
+                  <li>
+                    <span class="_semibold">603 Support Services</span>
+                  </li>
+                  <li>
+                    <span class="_semibold"
+                      >302 Functional Performance Criteria</span
+                    >
+                  </li>
+                </ul>
+
+                <span class="font-size-16 _semibold mb-3">Software Exceptions:</span>
+                <ul class="_atat-ul">
+                  <li>
+                    <span class="_semibold">E207.1 General</span> - Software
+                    that is assistive technology and that supports the
+                    accessibility services of the platform shall not be required
+                    to conform to the requirements in Chapter 5.
+                  </li>
+                  <li>
+                    <span class="_semibold">E207.2 WCAG Conformance -</span>
+                  </li>
+
+                  <li>
+                    <ul class="_atat-ul">
+                      <li>
+                        Software that is assistive technology and that supports
+                        the accessibility services of the platform shall not be
+                        required to conform to E207.2.
+                      </li>
+                      <li>
+                        Non-web software shall not be required to conform to the
+                        following four Success Criteria in WCAG 2.0: 2.4.1
+                        Bypass Blocks; 2.4.5 Multiple Ways; 3.2.3 Consistent
+                        Navigation; and 3.2.4 Consistent Identification.
+                      </li>
+                      <li>
+                        Non-Web software shall not be required to conform to
+                        Conformance Requirement 3 Complete Processes in WCAG
+                        2.0.
+                      </li>
+                    </ul>
+                  </li>
+                </ul>
+
+                <h3 class="mb-3">Functional Performance Criteria:</h3>
+                <ul class="_atat-ul">
+                  <li>
+                    <span class="_semibold">301.1 Scope</span> - The
+                    requirements of Chapter 3 shall apply to ICT where required
+                    by 508 Chapter 2 (Scoping Requirements), 255 Chapter 2
+                    (Scoping Requirements), and where otherwise referenced in
+                    any other chapter of the Revised 508 Standards or Revised
+                    255 Guidelines.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.1 Without Vision</span> - Where
+                    a visual mode of operation is provided, ICT shall provide at
+                    least one mode of operation that does not require user
+                    vision.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.2 With Limited Vision</span> -
+                    Where a visual mode of operation is provided, ICT shall
+                    provide at least one mode of operation that enables users to
+                    make use of limited vision.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.3 Without Perception of Color</span> 
+                    - Where a visual mode of operation is provided, ICT shall
+                    provide at least one visual mode of operation that does not
+                    require user perception of color.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.4 Without Hearing</span> - Where
+                    an audible mode of operation is provided, ICT shall provide
+                    at least one mode of operation that does not require user
+                    hearing.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.5 With Limited Hearing</span> -
+                    Where an audible mode of operation is provided, ICT shall
+                    provide at least one mode of operation that enables users to
+                    make use of limited hearing.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.6 Without Speech</span> - Where
+                    speech is used for input, control, or operation, ICT shall
+                    provide at least one mode of operation that does not require
+                    user speech.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.7 With Limited Manipulation</span>
+                    - Where a manual mode of operation is provided, ICT shall
+                    provide at least one mode of operation that does not require
+                    fine motor control or simultaneous manual operations.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.8 With Limited Reach and Strength</span>
+                    - Where a manual mode of operation is provided, ICT shall
+                    provide at least one mode of operation that is operable with
+                    limited reach and limited strength.
+                  </li>
+                  <li>
+                    <span class="_semibold">302.9 With Limited Language, Cognitive, 
+                    and Learning Abilities</span> - ICT shall provide features 
+                    making its use by individuals with limited cognitive, language, 
+                    and learning abilities simpler and easier.
+                  </li>
+                </ul>
+              </template>
+            </ATATAlert>
+
+            <ATATRadioGroup
+              id="Section508RadioGroup"
+              legend="Are the above Section 508 requirements sufficient for this acquisition?"
+              :value.sync="selected508Response"
+              :items="section508Options"
+              name="Section508RadioGroup"
+              class="mt-3 mb-8"
+            />
+
+            <ATATExpandableLink aria-id="AboutBusinessAssociates">
+            <template v-slot:header>
+              How do I determine which Section 508 accessibility requirements apply 
+              to my acquisition?
+            </template>
+            <template v-slot:content>
+              <p>
+                (To be completed in next milestone)
+              </p>
+            </template>
+          </ATATExpandableLink>
+
+          </div>
+        </v-col>
+      </v-row>
+    </v-container>
   </div>
 </template>
+
 <script lang="ts">
 import Vue from "vue";
-
 import { Component } from "vue-property-decorator";
+
+import ATATAlert from "@/components/ATATAlert.vue";
+import ATATExpandableLink from "@/components/ATATExpandableLink.vue"
+import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
+
+import { RadioButton } from "../../../types/Global";
+
 @Component({
+  components: {
+    ATATAlert,
+    ATATExpandableLink,
+    ATATRadioGroup,
+  },
 })
 export default class Section508Standards extends Vue {
+  private selected508Response = "";
+  private section508Options: RadioButton[] = [
+    {
+      id: "Yes",
+      label: "Yes.",
+      value: "true",
+    },
+    {
+      id: "No",
+      label: `No. I need to customize the Section 508 Accessibility Standards 
+        in my Description of Work.`,
+      value: "false",
+    },
+  ];
 }
 </script>
-


### PR DESCRIPTION
1. ‘Let’s look into your Section 508 Accessibility requirements’ screen exists in the correct location within the ‘Section 508 Standards’ sub step of step 7 with
    1. Header text with correct formatting.
    1. Description text with correct formatting.
    1. Blue ‘Section 508 Accessibility Standards for Cloud Computing’ info box exists with scrolling functionality and correct content.
    1. Are the above Section 508 requirements sufficient for this acquisition?' radio button question with
        1. ‘Yes.' option.
        1. ‘No. I need to customize the Section 508 Accessibility Standards in my Description of Work.’ option.
    1. ‘How do I determine what Section 508 Accessibility requirements apply to my acquisition?’ accordion [accordion word content should not be implemented in this ticket].