### PR TITLE
Feature/at 7255 recurring requirement snow hookup

### DIFF
--- a/src/api/contractDetails/index.ts
+++ b/src/api/contractDetails/index.ts
@@ -1,0 +1,8 @@
+import { PeriodOfPerformanceDTO } from "../models";
+import { TableApiBase } from "../tableApiBase";
+const TABLENAME = "x_g_dis_atat_period_of_performance";
+export class PeriodOfPerformanceApi extends TableApiBase<PeriodOfPerformanceDTO> {
+  constructor() {
+    super(TABLENAME);
+  }
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ import { CurrentContractApi } from "./background";
 import { SensitiveInformationApi } from "./otherContractConsiderations";
 import { MilitaryRankApi } from "./militaryRanks";
 import { SystemChoicesApi } from "./systemChoices";
+import { PeriodOfPerformanceApi } from "./contractDetails";
 
 export default {
    systemChoices: new SystemChoicesApi(),
@@ -18,4 +19,5 @@ export default {
    currentContractTable: new CurrentContractApi(),
    sensitiveInformationTable: new SensitiveInformationApi(),
    militaryRankTable: new MilitaryRankApi(),
+   periodOfPerformanceTable: new PeriodOfPerformanceApi(),
 }

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -18,6 +18,7 @@ export interface AcquisitionPackageDTO extends BaseTableDTO {
   current_contract: string;
   docusign_envelope_id: string;
   sensitive_information: string;
+  period_of_performance: string;
 }
 
 export interface CurrentContractDTO extends BaseTableDTO {
@@ -76,21 +77,13 @@ export interface MilitaryRankDTO extends BaseTableDTO {
   branch: string;
 }
 
-export interface SystemChoiceDTO extends BaseTableDTO{
+export interface SystemChoiceDTO extends BaseTableDTO {
     name: string;
     label: string;
     value: string;
 }
 
-export interface SensitiveInformationDTO {
-  sys_mod_count?: string;
-  sys_updated_on?: string;
-  sys_tags?: string;
-  sys_id?: string;
-  sys_updated_by?: string;
-  sys_created_on?: string;
-  sys_created_by?: string;
-
+export interface SensitiveInformationDTO extends BaseTableDTO {
   pii_present?: string;
   system_of_record_name?: string;
   work_to_be_performed?: string;
@@ -108,4 +101,11 @@ export interface SensitiveInformationDTO {
   foia_state_province_state_code?: string;
   foia_zip_postal_code?: string;
   foia_country?: string;
+}
+
+export interface PeriodOfPerformanceDTO extends BaseTableDTO {
+  pop_start_request?: string;
+  requested_pop_start_date?: string;
+  time_frame?: string;
+  recurring_requirement?: string;
 }

--- a/src/steps/05-ContractDetails/RecurringRequirement.vue
+++ b/src/steps/05-ContractDetails/RecurringRequirement.vue
@@ -28,9 +28,14 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component } from "vue-property-decorator";
+import { Component, Mixins } from "vue-property-decorator";
 
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue"
+
+import AcquisitionPackage from "@/store/acquisitionPackage";
+import SaveOnLeave from "@/mixins/saveOnLeave";
+import { PeriodOfPerformanceDTO } from "@/api/models"
+import { hasChanges } from "@/helpers";
 
 import { RadioButton } from "../../../types/Global";
 
@@ -40,19 +45,64 @@ import { RadioButton } from "../../../types/Global";
   },
 })
 
-export default class RecurringRequirement extends Vue {
-  private selectedRecurringOption = "";
+export default class RecurringRequirement extends Mixins(SaveOnLeave) {
+
+  public selectedRecurringOption 
+    = AcquisitionPackage.periodOfPerformance?.recurring_requirement || "";
+
   private recurringOptions: RadioButton[] = [
     {
       id: "YesRecurring",
       label: "Yes. This requirement should be tracked for similar efforts in the future.",
-      value: "YesRecurring",
+      value: "true",
     },
     {
       id: "NoRecurring",
       label: "No. This is a temporary requirement.",
-      value: "NoRecurring",
+      value: "false",
     },
   ];
+  private get currentData(): PeriodOfPerformanceDTO {
+    return {
+      recurring_requirement: this.selectedRecurringOption,
+    };
+  }
+
+  private savedData: PeriodOfPerformanceDTO = { 
+    recurring_requirement: "" 
+  };
+
+  public async mounted(): Promise<void> {
+    await this.loadOnEnter();
+  }
+
+  public async loadOnEnter(): Promise<void> {
+    const storeData = await AcquisitionPackage.loadPeriodOfPerformance();
+    if (storeData) {
+      if (Object.prototype.hasOwnProperty.call(storeData, 'recurring_requirement')) {
+        this.savedData = {
+          recurring_requirement: storeData.recurring_requirement,
+        }
+      }
+    } else {
+      AcquisitionPackage.setPeriodOfPerformance(this.currentData);
+    }
+  }
+
+  private hasChanged(): boolean {
+    return hasChanges(this.currentData, this.savedData);
+  }
+
+  protected async saveOnLeave(): Promise<boolean> {
+    try {
+      if (this.hasChanged()) {
+        await AcquisitionPackage.savePeriodOfPerformance(this.currentData);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+
+    return true;
+  }
 }
 </script>

--- a/src/steps/05-ContractDetails/RecurringRequirement.vue
+++ b/src/steps/05-ContractDetails/RecurringRequirement.vue
@@ -27,7 +27,6 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
 import { Component, Mixins } from "vue-property-decorator";
 
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue"


### PR DESCRIPTION
All input fields from the ['Will this be a future recurring requirement?' ](https://www.figma.com/file/DhwLh5B4y6pFbeLgMY63Rp/ATAT-Prototype-MVP%2B-(Master)?node-id=11057%3A348402)screen are successfully stored in the Period of Performance SNOW Table [or equivalent, dependent on the implementer’s data structure decisions made in [AT-7227: Update and Create SNOW Data Tables for Recurring Information, Contract Type, PoP, and Section 508IN PROGRESS](https://ccpo.atlassian.net/browse/AT-7227)].