### PR TITLE
Feature/at 7202 cor acor same error

### DIFF
--- a/cypress/integration/ATATDevSnow/AcquisitionPackageDetails.spec.js
+++ b/cypress/integration/ATATDevSnow/AcquisitionPackageDetails.spec.js
@@ -503,14 +503,14 @@ describe("Test suite: Acquisition Package ", () => {
             "mail test.adamson-civ@mail.mil ",
             "phone 333-333-3333",
             "pentagon HQ1234 - Corresponding Organization Name",
-            " To make any changes to your COR’s contact information, please send a request to our User Engagement Team. ",
-            " Request changes to COR’s contact information ",
+            " To update your COR’s contact information, please  submit a request to our User Engagement Team. ",
+            " submit a request to our User Engagement Team. ",
             "Remove COR info "
         );
         // click on Request Change Contact Information link
         cy.requestChangeContactInformation(
-            " Request changes to COR’s contact information ",
-            " Request change to COR's contact information ",
+            " submit a request to our User Engagement Team. ",
+            " Request change to COR’s contact information ",
             " Please let us know what information needs to be updated for this COR. ​",
             "Please change the contact info"
         );
@@ -637,15 +637,15 @@ describe("Test suite: Acquisition Package ", () => {
             "mail test.wentz@acusage.net ",
             "phone 444-444-4444",
             "pentagon HQ567 - Other Organization Name",
-            " To make any changes to your ACOR’s contact information, please send a request to our User Engagement Team. ",
-            " Request changes to ACOR’s contact information ",
+            " To update your ACOR’s contact information, please  submit a request to our User Engagement Team. ",
+            " submit a request to our User Engagement Team. ",
             "Remove ACOR info "
         );
         
         // click on Request Change Contact Information link
         cy.requestChangeContactInformation(
-            " Request changes to ACOR’s contact information ",
-            " Request change to ACOR's contact information ",
+            " submit a request to our User Engagement Team. ",
+            " Request change to ACOR’s contact information ",
             " Please let us know what information needs to be updated for this ACOR. ​",
             "Please change the contact info"
         );

--- a/src/components/ATATAlert.vue
+++ b/src/components/ATATAlert.vue
@@ -81,6 +81,7 @@ export default class ATATAlert extends Vue {
   @Prop({ default: true }) private show?: boolean;
   @Prop({ default: "Alert" }) private id?: string;
   @Prop({ default: "" }) private maxHeight?: string;
+  @Prop({ default: "" }) private attach?: string;
 
   /**
    * type: 1) info, 2) error, 3) warning, 4) success, 5) callout
@@ -106,6 +107,9 @@ export default class ATATAlert extends Vue {
     let alertClasses = "_" + this.type + "-alert";
     alertClasses = this.borderLeft ? alertClasses + " _border-left-thick " : alertClasses;
     alertClasses = this.maxHeight ? alertClasses + " py-0 pr-0 " : alertClasses;
+    alertClasses = this.attach === "bottom-of-card" 
+      ? alertClasses + " attach-to-bottom-of-card " 
+      : alertClasses;
     return alertClasses;
   }
 

--- a/src/components/ATATAlert.vue
+++ b/src/components/ATATAlert.vue
@@ -81,7 +81,6 @@ export default class ATATAlert extends Vue {
   @Prop({ default: true }) private show?: boolean;
   @Prop({ default: "Alert" }) private id?: string;
   @Prop({ default: "" }) private maxHeight?: string;
-  @Prop({ default: "" }) private attach?: string;
 
   /**
    * type: 1) info, 2) error, 3) warning, 4) success, 5) callout
@@ -107,9 +106,6 @@ export default class ATATAlert extends Vue {
     let alertClasses = "_" + this.type + "-alert";
     alertClasses = this.borderLeft ? alertClasses + " _border-left-thick " : alertClasses;
     alertClasses = this.maxHeight ? alertClasses + " py-0 pr-0 " : alertClasses;
-    alertClasses = this.attach === "bottom-of-card" 
-      ? alertClasses + " attach-to-bottom-of-card " 
-      : alertClasses;
     return alertClasses;
   }
 

--- a/src/sass/components/ATATAlert.scss
+++ b/src/sass/components/ATATAlert.scss
@@ -8,7 +8,7 @@
   padding: 16px 20px;
   position: relative;
 
-  &.attach-to-bottom-of-card {
+  &._attach-to-bottom-of-card {
     margin-top: 0 !important;
     border-radius: 8px;
     border-top-left-radius: 0;

--- a/src/sass/components/ATATAlert.scss
+++ b/src/sass/components/ATATAlert.scss
@@ -7,6 +7,13 @@
   border: 1px solid transparent;
   padding: 16px 20px;
   position: relative;
+
+  &.attach-to-bottom-of-card {
+    margin-top: 0 !important;
+    border-radius: 8px;
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
   
   &._scrollable {
     &:before, &:after {

--- a/src/sass/utils/base.scss
+++ b/src/sass/utils/base.scss
@@ -60,11 +60,11 @@ body {
   border-radius: 8px !important
 }
 
-.square-bottom {
+._square-bottom {
   border-bottom-left-radius: 0 !important;
   border-bottom-right-radius: 0 !important;
 }
 
-.no-border-bottom {
+._no-border-bottom {
   border-bottom: none !important;
 }

--- a/src/sass/utils/base.scss
+++ b/src/sass/utils/base.scss
@@ -59,3 +59,12 @@ body {
 .border-rounded-more {
   border-radius: 8px !important
 }
+
+.square-bottom {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+}
+
+.no-border-bottom {
+  border-bottom: none !important;
+}

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/Common.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/Common.vue
@@ -3,7 +3,7 @@
     <div class="max-width-640">
       <ATATAutoComplete
         id="SearchContact"
-        :class="haveSelectedContact ? 'mb-10' : 'mb-8'"
+        :class="haveSelectedContact ? 'mb-2' : 'mb-0'"
         :label-sr-only="true"
         :label="'Search for your ' + corOrAcor"
         titleKey="fullName"
@@ -161,7 +161,7 @@ export default class COR_ACOR extends Vue {
       id: "1",
       firstName: "Test0",
       lastName: "Adamson",
-      fullName: "Test Adamson",
+      fullName: "Test0 Adamson",
       email: "test.adamson-civ@mail.mil",
       phone: "333-333-3333",
       orgName: "HQ1234 - Corresponding Organization Name"

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -1,6 +1,12 @@
 <template>
   <div :id="id">
-    <div class="max-width-640 border1 border-base-lighter border-rounded-more pa-8 mb-5">
+    <div 
+      class="max-width-640 border1 border-base-lighter border-rounded-more pa-8"
+      :class="[
+        { 'square-bottom no-border-bottom mb-0' : isSameContact }, 
+        {'mb-5' :!isSameContact }
+      ]"
+    >
       <span class="font-size-20 mb-5 d-block" :id="id + '_Name'">
         {{ selectedContact.firstName }} {{ selectedContact.lastName }}
       </span>
@@ -12,19 +18,44 @@
         <v-icon class="mr-2 text-base-light">phone</v-icon> 
         {{ selectedContact.phone }}<br />
       </span>
-      <span class="ml-3 mb-10 d-block" :id="id + '_OrgName'">
+      <span 
+        class="ml-3 d-block" 
+        :class="{ 'mb-10' : !isSameContact }"
+        :id="id + '_OrgName'"
+      >
         <v-icon class="mr-2 text-base-light">pentagon</v-icon> 
         {{ selectedContact.orgName }}<br />
       </span>
-      <p class="mb-10 text-base" :id="id + '_Message'">
-        To make any changes to your {{ corOrAcor }}’s contact information, please send a 
-        request to our User Engagement Team.
+
+      <p 
+        class="mb-0 text-base" 
+        :id="id + '_Message'" 
+        v-show="!isSameContact"
+      >
+        To update your {{ corOrAcor }}’s contact information, please    
+        <a role="button" class="_text-link" id="RequestContactChange" @click="showDialog = true">
+          submit a request to our User Engagement Team.
+        </a>  
       </p>
 
-      <a role="button" class="_text-link" id="RequestContactChange" @click="showDialog = true">
-        Request changes to {{ corOrAcor }}’s contact information
-      </a>
     </div>
+
+    <ATATAlert
+      id="CorAcorSameErrorAlert"
+      type="error"
+      class="max-width-640 mb-5"
+      attach="bottom-of-card"
+      v-show="isSameContact"
+    >
+      <template v-slot:content>
+        <p class="mb-0">
+          This individual is set as your {{ isACOR ? 'primary' : 'alternate' }} COR. 
+          Please select a different {{ isACOR ? 'ACOR.' : 'primary COR,' }} 
+          <span v-if="!isACOR">or change your ACOR.</span>        
+        </p>
+      </template>
+    </ATATAlert>
+
     <v-icon class="text-primary mr-1" @click="removeCorInfo">delete</v-icon>
     <a 
       class="_text-link" 
@@ -60,11 +91,16 @@
 import Vue from "vue";
 import { Component, Prop, PropSync } from "vue-property-decorator";
 
+import ATATAlert from "@/components/ATATAlert.vue";
 import ATATDialog from "@/components/ATATDialog.vue";
 import ATATTextArea from "@/components/ATATTextArea.vue";
 
+import AcquisitionPackage from "@/store/acquisitionPackage";
+import { CorAcorSelectData } from "../../../../types/Global";
+
 @Component({
   components: {
+    ATATAlert,
     ATATDialog,
     ATATTextArea
   }
@@ -76,7 +112,7 @@ export default class PersonCard extends Vue {
   
   @Prop({ default: false }) private isACOR!: boolean;
   @Prop({ default: "PersonCard" }) private id!: boolean;
-  @PropSync("selectedContact") private _selectedContact!: unknown;
+  @PropSync("selectedContact") private _selectedContact!: CorAcorSelectData;
   @PropSync("showContactForm") private _showContactForm!: unknown;
 
   // data
@@ -85,14 +121,36 @@ export default class PersonCard extends Vue {
 
   // computed
 
-  get corOrAcor(): string {
+  private get corOrAcor(): string {
     return this.isACOR ? "ACOR" : "COR";
+  }
+
+  private get otherRepEmail(): string {
+    if (this.isACOR && AcquisitionPackage.corInfo) {
+      return AcquisitionPackage.corInfo.email;
+    } else if (!this.isACOR && AcquisitionPackage.acorInfo) {
+      return AcquisitionPackage.acorInfo.email;
+    }
+    return "";
+  }
+
+  private get isSameContact(): boolean {
+    return this.otherRepEmail === this._selectedContact.email;
   }
 
   // methods
   
   private removeCorInfo(): void {
-    this._selectedContact = null;
+    this._selectedContact = {
+      id: "",
+      firstName: "",
+      lastName: "",
+      fullName: "",
+      email: "",
+      phone: "",
+      orgName: "",
+    };
+
     this._showContactForm = false;
   }
 

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -51,6 +51,7 @@
           This individual is set as your {{ isACOR ? 'primary COR' : 'ACOR' }}. 
           Please select a different {{ isACOR ? 'ACOR' : 'primary COR' }}, or
           <router-link 
+            :id="'LinkTo' + (isACOR ? 'COR' : 'ACOR')"
             :to="{ name: isACOR 
               ? routeNames.Cor_Information 
               : routeNames.Acor_Information 

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -74,7 +74,7 @@
     </a>
     <ATATDialog
       :showDialog.sync="showDialog"
-      :title="'Request change to ' + corOrAcor + '\'s contact information'"
+      :title="'Request change to ' + corOrAcor + '’s contact information'"
       no-click-animation
       okText="Send Request"
       width="632"

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -3,7 +3,7 @@
     <div 
       class="max-width-640 border1 border-base-lighter border-rounded-more pa-8"
       :class="[
-        { 'square-bottom no-border-bottom mb-0' : isSameContact }, 
+        { '_square-bottom _no-border-bottom mb-0' : isSameContact }, 
         {'mb-5' :!isSameContact }
       ]"
     >
@@ -43,13 +43,12 @@
     <ATATAlert
       id="CorAcorSameErrorAlert"
       type="error"
-      class="max-width-640 mb-5"
-      attach="bottom-of-card"
+      class="max-width-640 mb-5 _attach-to-bottom-of-card"
       v-show="isSameContact"
     >
       <template v-slot:content>
         <p class="mb-0">
-          This individual is set as your {{ isACOR ? 'primary' : 'alternate' }} COR. 
+          This individual is set as your {{ isACOR ? 'primary COR' : 'ACOR' }}. 
           Please select a different {{ isACOR ? 'ACOR.' : 'primary COR,' }} 
           <span v-if="!isACOR">or change your ACOR.</span>        
         </p>

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -49,8 +49,15 @@
       <template v-slot:content>
         <p class="mb-0">
           This individual is set as your {{ isACOR ? 'primary COR' : 'ACOR' }}. 
-          Please select a different {{ isACOR ? 'ACOR.' : 'primary COR,' }} 
-          <span v-if="!isACOR">or change your ACOR.</span>        
+          Please select a different {{ isACOR ? 'ACOR' : 'primary COR' }}, or
+          <router-link 
+            :to="{ name: isACOR 
+              ? routeNames.Cor_Information 
+              : routeNames.Acor_Information 
+            }"
+          >
+            change your {{ isACOR ? 'COR' : 'ACOR' }}.
+          </router-link>
         </p>
       </template>
     </ATATAlert>
@@ -96,6 +103,7 @@ import ATATTextArea from "@/components/ATATTextArea.vue";
 
 import AcquisitionPackage from "@/store/acquisitionPackage";
 import { CorAcorSelectData } from "../../../../types/Global";
+import { routeNames } from "../../../router/stepper";
 
 @Component({
   components: {
@@ -117,7 +125,7 @@ export default class PersonCard extends Vue {
   // data
 
   private showDialog = false
-
+  private routeNames = routeNames;
   // computed
 
   private get corOrAcor(): string {

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/PersonCard.vue
@@ -4,7 +4,7 @@
       class="max-width-640 border1 border-base-lighter border-rounded-more pa-8"
       :class="[
         { '_square-bottom _no-border-bottom mb-0' : isSameContact }, 
-        {'mb-5' :!isSameContact }
+        {'mb-5' : !isSameContact }
       ]"
     >
       <span class="font-size-20 mb-5 d-block" :id="id + '_Name'">


### PR DESCRIPTION
1. Error messages are styled as in the Figma link in the description.
1. Error message is shown on ACOR page if selecting the same contact as selected on the COR page from the autocomplete dropdown.
    1. Error message is “This individual is set as your primary COR. Please select a different ACOR, or change your COR.”
    1. “change your COR” is a link to the COR page.
1. Error message is shown on COR page if user navigated back to COR page after selecting the same contact on the ACOR page.
    1. Error message is “This individual is set as your ACOR. Please select a different primary COR, or change your ACOR.”
    1. “change your ACOR” is a link to the ACOR page.