### PR TITLE
Address Form validation updates

### DIFF
--- a/src/components/ATATAddressForm.vue
+++ b/src/components/ATATAddressForm.vue
@@ -15,6 +15,7 @@
       <v-row>
       <v-col class="col-12 col-lg-8">
         <ATATTextField
+          
           id="StreetAddress"
           label="Street address"
           :class="inputClass"
@@ -200,6 +201,8 @@ export default class ATATAddressForm extends Vue {
         addressType === this.addressTypes?.FOR
           ? { text: "", value: "" }
           : { text: "United States of America", value: "US" };
+
+    this.resetData();
   }
 
   private getRules(inputID: string): ((v:string)=> string | true | undefined)[] {
@@ -247,6 +250,10 @@ export default class ATATAddressForm extends Vue {
 
   public resetData(): void {
     Vue.nextTick(() => {
+     
+      //iterate over the forms children ref manually set their 'errorMessages' array to empty
+      const formChildren = this.$refs.atatAddressForm.$children;
+      formChildren.forEach(ref=> ((ref as unknown) as {errorMessages:[]}).errorMessages = []);
       this.$refs.atatAddressForm.reset();
       Vue.nextTick(() => {
         this.$refs.atatAddressForm.resetValidation();

--- a/src/components/ATATAddressForm.vue
+++ b/src/components/ATATAddressForm.vue
@@ -11,7 +11,8 @@
       @radioButtonSelected="addressTypeChange"
     />
 
-    <v-row>
+    <v-form ref="atatAddressForm" lazy-validation>
+      <v-row>
       <v-col class="col-12 col-lg-8">
         <ATATTextField
           id="StreetAddress"
@@ -133,7 +134,7 @@
         />
       </v-col>
     </v-row> 
-  
+    </v-form>
   </div>
 </template>
 
@@ -162,6 +163,13 @@ import { isValidObj, RadioButton, SelectData, stringObj } from "types/Global";
 })
 
 export default class ATATAddressForm extends Vue {
+   $refs!: {
+    atatAddressForm: Vue & {
+      resetValidation: () => void;
+      reset: () => void;
+    };
+  };
+
   @PropSync("selectedAddressType") public _selectedAddressType?: string;
   @PropSync("streetAddress1") public _streetAddress1?: string;
   @PropSync("streetAddress2") public _streetAddress2?: string;
@@ -181,6 +189,8 @@ export default class ATATAddressForm extends Vue {
   @Prop() public countryListData?: SelectData[];
   @Prop() public requiredFields?: stringObj[];
   @Prop() public isValidRules?: isValidObj[];
+
+  
 
 
   // methods
@@ -234,6 +244,15 @@ export default class ATATAddressForm extends Vue {
 
     })
   }
+
+  public resetData(): void {
+    Vue.nextTick(() => {
+      this.$refs.atatAddressForm.reset();
+      Vue.nextTick(() => {
+        this.$refs.atatAddressForm.resetValidation();
+      });
+    });
+  }
   // computed
 
   get inputClass(): string {
@@ -252,6 +271,8 @@ export default class ATATAddressForm extends Vue {
       ? "ZIPCode"
       : "PostalCode";
   }
+
+
 
 }
 

--- a/src/components/ATATTextField.vue
+++ b/src/components/ATATTextField.vue
@@ -54,12 +54,16 @@ import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
   components: {
     ATATTooltip,
     ATATErrorValidation
-  }
+  },
 })
-export default class ATATTextField extends Vue {
+export default class ATATTextField extends Vue  {
   // refs
   $refs!: {
-    atatTextField: Vue & { errorBucket: string[]; errorCount: number };
+    atatTextField: Vue & { 
+      errorBucket: string[]; 
+      errorCount: number 
+      resetValidation(): void
+  };
   }; 
 
   // props
@@ -98,6 +102,13 @@ export default class ATATTextField extends Vue {
     const input = e.target as HTMLInputElement;
     this.setErrorMessage();
     this.$emit('blur', input.value, this.extraEmitVal);
+  }
+
+  
+  public resetValidation(): void {
+    debugger;
+    this.$refs.atatTextField.errorBucket = [];
+    this.$refs.atatTextField.resetValidation();
   }
 }
 </script>

--- a/src/plugins/validation.ts
+++ b/src/plugins/validation.ts
@@ -57,7 +57,7 @@ export class ValidationPlugin {
     message = message || "This field is required.";
     return (v: string) => {
       if (typeof(v)==="object"){ // if typeof 'selectData(dropdown)' or string[]
-        return Object.values(v).every((val)=> val !=="") || message;
+        return v && Object.values(v).every((val)=> val !=="") || message;
       } else if (typeof(v) === "string"){ // else if typeof 'string'
         return (v!=="")|| message;
       }

--- a/src/steps/01-AcquisitionPackageDetails/Organization.vue
+++ b/src/steps/01-AcquisitionPackageDetails/Organization.vue
@@ -93,7 +93,34 @@
               :stateOrProvince.sync="stateOrProvince"
               :zipCode.sync="zipCode"
               :selectedCountry.sync="selectedCountry"
-
+              :requiredFields='[
+              {field:"StreetAddress", message: "Please enter an address."},
+              {field:"City", message:  "Please enter a city."},
+             {field:"State" , message: "Please select a state."},
+             {field:"ZIPCode" , message: "Please enter a ZIP code."},
+             {
+               field:"APO_FPO_DPO",
+               message: "Please select a military post office (APO or FPO)."
+               },
+             {field:"StateCode", message:  "Please select a state code."},
+             {field:"StateProvince", message: "Please enter a state/province."},
+             {field:"Country", message: "Please select a country."},
+             {field:"PostalCode" , message: "Please enter a postal code."},
+            ]'
+            :isValidRules='[
+              {
+                field:"ZIPCode",
+                message: "Your ZIP code must be 5 or 9 digits.",
+                mask:["99999", "99999-9999"],
+                },
+              {
+                field:"PostalCode",
+                message: "Your postal code must be 10 characters or " +
+                "less and may include spaces and hyphens.",
+                mask:["^[A-Za-z0-9- ]{0,10}$"],
+                isMaskRegex: true
+              }
+            ]'
               :addressTypeOptions="addressTypeOptions"
               :addressTypes="addressTypes"
               :militaryPostOfficeOptions="militaryPostOfficeOptions"


### PR DESCRIPTION
updates to Address Form's reset functionality. When the form's reset method is called, all of the forms children's error messages are reset. For instance, when the form changes between address types (e.g.  U.S., Military, Foreign) 