### PR TITLE
Fixed tooltip position

### DIFF
--- a/src/components/ATATTooltip.vue
+++ b/src/components/ATATTooltip.vue
@@ -5,7 +5,6 @@
     max-width="250px"
     :open-delay="500"
     top
-    attach
     eager
     v-if="tooltipText"
   >


### PR DESCRIPTION
Including `attach` attribute caused improper positioning of the tooltip. Removing it displays properly
![Screen Shot 2022-05-02 at 9 44 29 AM](https://user-images.githubusercontent.com/90333349/166248853-097eb58e-a469-4dd2-8e2b-0d322c6c7842.png)
.