### PR TITLE
Fixed data populating on return to COR/ACOR page

### DIFF
--- a/src/components/ATATPhoneInput.vue
+++ b/src/components/ATATPhoneInput.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-container class="mb-10">
-    <v-row>
-      <v-col id="PhoneControl" class="_atat-phone-field pa-0">
+  <div id="PhoneControl" class="_atat-phone-field">
+    <div :class="wrapperClass">
+      <div>
         <div class="d-flex align-center" v-if="label">
           <label
             :id="id + '_TextFieldLabel'"
@@ -11,6 +11,7 @@
             {{ label }}
           </label>
         </div>
+
         <div class="d-flex">
           <v-select
             ref="atatPhoneDropdown"
@@ -98,12 +99,16 @@
           >
           </v-text-field>
         </div>
+        
         <ATATErrorValidation :errorMessages="errorMessages" />
-      </v-col>
-      <v-col
+
+      </div>
+
+      <div
         v-if="isPhoneExtensionVisible !== false"
         id="PhoneExtensionControl"
-        class="_atat-phone-extension-field pa-0"
+        class="_atat-phone-extension-field"
+        :class="extensionClass"
       >
         <div class="d-flex align-center">
           <label
@@ -128,10 +133,12 @@
           autocomplete="off"
         >
         </ATATTextField>
-      </v-col>
-    </v-row>
-  </v-container>
+      </div>
+    </div>
+  
+  </div>
 </template>
+
 <script lang="ts">
 import Vue from "vue";
 import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
@@ -396,7 +403,7 @@ export default class ATATPhoneInput extends Vue {
   @Prop({ default: "" }) private appendIcon!: string;
   @Prop({ default: "" }) private placeHolder!: string;
   @Prop({ default: "" }) private suffix!: string;
-  @Prop({ default: "" }) private optional!: boolean;
+  @Prop({ default: false }) private optional!: boolean;
   @Prop({ default: "351" }) private width!: string;
   @Prop({ default: () => [] }) private rules!: Array<unknown>;
   @Prop({ default: true }) private isPhoneExtensionVisible!: boolean;
@@ -561,8 +568,13 @@ export default class ATATPhoneInput extends Vue {
     }
   }
 
-  //data
+  get wrapperClass(): string {
+    return this.$vuetify.breakpoint.mdAndDown ? "d-block" : "d-flex";
+  }
 
+  get extensionClass(): string {
+    return this.$vuetify.breakpoint.mdAndDown ? "mt-6" : "ml-6";
+  }
   
 }
 </script>

--- a/src/sass/components/ATATPhoneInput.scss
+++ b/src/sass/components/ATATPhoneInput.scss
@@ -112,7 +112,7 @@
       color: $primary;
       border-bottom: 1px solid $base-lighter;
       .v-input__icon {
-        &.v-input__icon--append, {
+        &.v-input__icon--append {
           i.v-icon {
 
             padding-top: 8px;
@@ -156,7 +156,6 @@
 }
 
 ._atat-phone-extension-field {
-  margin-left: 24px;
   ._phone-extension-input {
     width: 140px;
   }

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -231,7 +231,6 @@ export default class ContactInfoForm extends Vue {
 
   private loaded = false;
   private contactTypeChange(): void {
-    debugger;
     if (this.loaded) {
       this.resetData();
     }

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -120,7 +120,7 @@
         <ATATPhoneInput
           id="PhoneNumber"
           label="Phone number"
-          class="width-100"
+          class="width-100 mb-10"
           :value.sync="_phone"
           :country.sync="_selectedPhoneCountry"
           :extensionValue.sync="_phoneExt"

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -231,10 +231,11 @@ export default class ContactInfoForm extends Vue {
 
   private loaded = false;
   private contactTypeChange(): void {
+    debugger;
     if (this.loaded) {
       this.resetData();
     }
-    this.loaded = false;
+    this.loaded = true;
   }
 
   public resetData(): void {

--- a/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
+++ b/src/steps/01-AcquisitionPackageDetails/COR_ACOR/ContactInfoForm.vue
@@ -229,15 +229,19 @@ export default class ContactInfoForm extends Vue {
     { text: "Dr.", value: "DR" },
   ];
 
+  private loaded = false;
   private contactTypeChange(): void {
-    this.resetData();
+    if (this.loaded) {
+      this.resetData();
+    }
+    this.loaded = false;
   }
 
   public resetData(): void {
     Vue.nextTick(() => {
       //iterate over the forms children ref manually set their 'errorMessages' array to empty
       const formChildren = this.$refs.CORACORContactForm.$children;
-     
+
       formChildren.forEach((ref)=> {
         ((ref as unknown) as {errorMessages:[], _value: string}).errorMessages = [];
       });

--- a/src/steps/01-AcquisitionPackageDetails/ContactInfo.vue
+++ b/src/steps/01-AcquisitionPackageDetails/ContactInfo.vue
@@ -112,7 +112,7 @@
           <ATATPhoneInput
             label="Your phone number"
             id="ContactPhone"
-            :class="{ 'mb-10': selectedRole === 'CIVILIAN' }"
+            class="mb-10"
             :value.sync="selectedPhoneNumber"
             :country.sync="selectedPhoneCountry"
             :extensionValue.sync="phoneExtension"


### PR DESCRIPTION
Made same changes to phone component as were done in ContactInfo.vue file.
Added a `loaded` boolean to prevent initial change of contact type from resetting the data.