### PR TITLE
 508 a11y page and input validation

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -57,6 +57,18 @@ export const FOIARecordResolver = (current: string): string => {
     ? routeNames.Section508Standards
     : routeNames.FOIA;
 };
+export const A11yRequirementResolver = (current: string): string => {
+  const needsA11yReqs
+      = AcquisitionPackage.sensitiveInformation?.section_508_sufficient === "false";
+  // if user selects "Yes" on FOIA (Public Disclosure of Information) page,
+  // then need to collect information about the FOIA Coordinator
+  if (needsA11yReqs) {
+    return routeNames.Section508AccessibilityRequirements;
+  }
+  return current === routeNames.Section508Standards
+    ? routeNames.EvaluationCriteriaStepOne
+    : routeNames.Section508Standards;
+};
 
 
 // add resolver here so that it can be found by invoker
@@ -65,6 +77,7 @@ const resolvers: Record<string, StepRouteResolver> = {
   CurrentContractRouteResolver,
   PIIRecordResolver,
   FOIARecordResolver,
+  A11yRequirementResolver,
 };
 
 export const InvokeResolver = (

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -60,8 +60,8 @@ export const FOIARecordResolver = (current: string): string => {
 export const A11yRequirementResolver = (current: string): string => {
   const needsA11yReqs
       = AcquisitionPackage.sensitiveInformation?.section_508_sufficient === "false";
-  // if user selects "Yes" on FOIA (Public Disclosure of Information) page,
-  // then need to collect information about the FOIA Coordinator
+  // if user selects "No" on Section 508 standards page,
+  // then need to collect information about 508 accessibility requirements
   if (needsA11yReqs) {
     return routeNames.Section508AccessibilityRequirements;
   }

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -56,6 +56,8 @@ import PIIRecord from "../steps/07-OtherContractConsiderations/PIIRecord.vue";
 import FOIA from "../steps/07-OtherContractConsiderations/FOIA.vue";
 import FOIACoordinator from "../steps/07-OtherContractConsiderations/FOIACoordinator.vue";
 import Section508Standards from "../steps/07-OtherContractConsiderations/Section508Standards.vue";
+import Section508AccessibilityRequirements
+  from "../steps/07-OtherContractConsiderations/Section508AccessibilityRequirements.vue"
 
 // step 8 - Evaluation Criteria
 import EvaluationCriteria from "../steps/08-EvaluationCriteria/Index.vue"
@@ -82,6 +84,7 @@ import {
   CurrentContractRouteResolver,
   PIIRecordResolver,
   FOIARecordResolver,
+  A11yRequirementResolver,
 } from "./resolvers";
 
 export const routeNames = {
@@ -130,6 +133,7 @@ export const routeNames = {
   ReviewRequiredForms: "Review_Required_Forms",
   ReviewRequiredFormsStepOne: "Review_Required_Forms_Step_One",
   POPStart: "POP_Start",
+  Section508AccessibilityRequirements: "Section_508_Accessibility_Requirements"
 };
 
 /**
@@ -462,7 +466,16 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         completePercentageWeight: 2,
         component: Section508Standards,
       },
-      
+      {
+        menuText: "Section 508 Accessibility Requirements",
+        path: "/508-accessibility-reqs",
+        name: routeNames.Section508AccessibilityRequirements,
+        excludeFromMenu: true,
+        completePercentageWeight: 2,
+        component: Section508AccessibilityRequirements,
+        routeResolver: A11yRequirementResolver
+      },
+
     ]
   },
   {

--- a/src/steps/07-OtherContractConsiderations/Section508AccessibilityRequirements.vue
+++ b/src/steps/07-OtherContractConsiderations/Section508AccessibilityRequirements.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="mb-7">
+    <v-container fluid class="container-max-width">
+      <v-row>
+        <v-col class="col-12">
+          <h1 class="page-header">
+            Tell us more about your Section 508 Accessibility requirements
+          </h1>
+          <ATATAlert
+            id="FairOpportunityAlert"
+            type="callout"
+            :showIcon="false"
+            class="copy-max-width my-10"
+          >
+            <template v-slot:content>
+              <h2>Determining your accessibility requirements</h2>
+              <p class="mt-2 mb-0">
+                The <a
+                href="https://app.buyaccessible.gov/art/home"
+                target="_blank"
+                class="_text-link"
+                id="508AccessibilityExternalLink"
+              >
+                <span class="_external-link">Accessibility Requirements Tool (ART)</span>
+              </a> is a step-by-step guide that helps you
+                determine and properly document IT accessibility requirements in contracting
+                documents. From the ART website, you can
+                <span class="h6">choose from pre-packaged sample procurements</span>
+                for standard ICT products and services or
+                <span class="h6">start a new procurement</span>
+                to identify your relevant accessibility requirements.
+                ART will guide you through a series of questions about your procurement, beginning
+                with potential exceptions. If no exceptions apply, the tool will walk you through
+                the criteria for each item in your procurement, then produce a comprehensive
+                report
+                detailing all the applicable standards and exceptions that apply to your
+                procurement. <span class="h6">Copy and paste the ICT procurement language</span>
+                from this report into the
+                field below, and we will customize the Section 508 requirements in your Description
+                of Work.
+              </p>
+            </template>
+          </ATATAlert>
+          <ATATTextArea
+            id="OperationToBePerformed"
+            label="What accessibility requirements do you need to include in your solicitation?"
+            helpText="Copy/paste the procurement language from your
+            custom ART report or from one of the sample procurements."
+            class="width-100 copy-max-width"
+            :rows="10"
+            :value.sync="accessibilityReqs"
+            :rules="[
+                $validators.required(
+                  'Please enter your accessibility requirements.'
+                ),
+              ]"
+          />
+
+        </v-col>
+      </v-row>
+    </v-container>
+  </div>
+</template>
+
+<script lang="ts">
+/* eslint-disable camelcase */
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import ATATAlert from "@/components/ATATAlert.vue";
+import SaveOnLeave from "@/mixins/saveOnLeave";
+import ATATTextArea from "@/components/ATATTextArea.vue";
+
+@Component({
+  components: {
+    ATATTextArea,
+    ATATAlert,
+  },
+})
+
+export default class AccessibilityReq extends Vue {
+  private accessibilityReqs = "";
+
+}
+</script>


### PR DESCRIPTION
Additional accessibility requirements might be required. If so, the user needs to be able to add these requirements.

User navigates to new page by clicking 08 Standards and Compliance step, then Section 508 Standards substep, then clicking the no.  I need to customize the Section 508 Accessibility Standards in my Description of Work. radio button option.  Next, click the Continue button to view new page. 