### PR TITLE
saving data from a11y requirement input

### DIFF
--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -107,6 +107,8 @@ export interface SensitiveInformationDTO extends BaseTableDTO {
   foia_zip_postal_code?: string;
   foia_country?: string;
   section_508_sufficient?: string;
+  accessibility_reqs_508?: string;
+
 }
 
 export interface PeriodOfPerformanceDTO extends BaseTableDTO {


### PR DESCRIPTION
Additional accessibility requirements might be required. If so, the user needs to be able to add these requirements, and

save these requirements to the DISA SNOW instance as the user leaves the page

retrieve these requirements from the DISA SNOW instance when the user revisits the page.

Please add the code necessary for these additional requirements to be stored and retrieved as necessary.