### PR TITLE
Fix Cypress test failures on GFE

### DIFF
--- a/cypress/integration/ATATDevSnow/GovernmentFurnishedEquipment.spec.js
+++ b/cypress/integration/ATATDevSnow/GovernmentFurnishedEquipment.spec.js
@@ -84,7 +84,7 @@ describe("Test suite: Government Furnished Equipment", () => {
       common.header,
       " Will government equipment be furnished, provided or acquired under this acquisition? ");
     //No radio button option is selected
-    cy.radioBtn(govFurEquip.yesRadioOption, "true").focus().tab().blur().then(() => {
+    cy.radioBtn(govFurEquip.yesRadioOption, "true").focus().tab().tab().then(() => {
       cy.checkErrorMessage(govFurEquip.govEquipRadioError, "Please select an option");
     });
       

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -338,7 +338,7 @@ Cypress.Commands.add("enterOrganizationAddress", (orgAddress)    => {
 });
 
 Cypress.Commands.add("contactRoleRadioBtnOption", (selector,value) => {
-  cy.radioBtn(selector, value).click({ force: true });
+  cy.radioBtn(selector, value).click({ force: true }, { timeout: 1000 }).should("be.checked");
   cy.findElement(contact.contactRadioBtnActive)
     .then(($radioBtn) => {
       cy.log($radioBtn.text());


### PR DESCRIPTION
Fixed the test that is failing on DISA instance
Added a assertion to make sure the radio button is checked when the button is selected .