### PR TITLE
feature/AT-7364-validation-issue-found-in-testing

### DIFF
--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -27,7 +27,7 @@
           <div
             v-if="isFullSize"
             class="content d-flex flex-column align-center pt-9"
-            @click="fileUploadClicked"
+            @mousedown="fileUploadClicked"
           >
             <ATATSVGIcon name="uploadFile" :width="40" :height="50" />
             <h2 class="mt-5">Drag and Drop</h2>
@@ -42,12 +42,12 @@
                 browse to upload
               </a>
             </p>
-            <p class="mt-3 mb-9">Use a PDF file with a max size of 10 MB.</p>
+            <p class="mt-3 mb-9">Use a PDF file with a max size of 1 GB.</p>
           </div>
           <div
             v-else
             class="content-mini d-flex align-center width-100"
-            @click="fileUploadClicked"
+            @mousedown="fileUploadClicked"
           >
             <div>
               <ATATSVGIcon name="uploadFile" :width="40" :height="50" />
@@ -66,7 +66,7 @@
                 </a>
               </p>
             </div>
-            <p class="ml-auto mb-0">Use a PDF file with a max size of 10 MB.</p>
+            <p class="ml-auto mb-0">Use a PDF file with a max size of 1 GB.</p>
           </div>
         </template>
       </v-file-input>
@@ -149,6 +149,8 @@ export default class ATATFileUpload extends Vue {
    * triggers html file upload click
    */
   private fileUploadClicked(): void {
+    this.reset();
+    this.isFullSize = this.validFiles.length === 0;
     this.fileUploadControl.click();
   }
 
@@ -167,7 +169,9 @@ export default class ATATFileUpload extends Vue {
       if (vuetifyFileUploadStatus) {
         vuetifyFileUploadStatus.innerHTML = "";
       }
+      this.clearHTMLFileInput();
     });
+   
   }
 
   /**
@@ -181,6 +185,7 @@ export default class ATATFileUpload extends Vue {
     this.isHovering = true;
     this.isFullSize = this.validFiles.length === 0;
     this.reset();
+    this.clearHTMLFileInput();
   }
 
   /**
@@ -345,8 +350,6 @@ export default class ATATFileUpload extends Vue {
   private clearErrorMessages(): void {
     // if (this.errorMessages.length>0){
     Vue.nextTick(() => {
-      // const formChildren = this.$refs.atatFileUploadForm.$children;
-      // formChildren.forEach(ref=> ((ref as unknown) as {errorMessages:[]}).errorMessages = []);
       this.$refs.atatFileUploadForm.reset();
       Vue.nextTick(() => {
         this.$refs.atatFileUploadForm.resetValidation();
@@ -360,13 +363,15 @@ export default class ATATFileUpload extends Vue {
       this._invalidFiles = [];
       this.clearErrorMessages();
       this.errorMessages = [];
-
-      // clear out any files 'left over' in the
-      // HTML file input
-      (
-        document.getElementById("FundingPlanFileUpload") as HTMLInputElement
-      ).value = "";
     });
+  }
+
+  /**
+   * Clears out all files form HTML File Input
+   */
+  private clearHTMLFileInput():void{
+    const fileInput = document.getElementById("FundingPlanFileUpload") as HTMLInputElement;
+    fileInput.value = "";
   }
 
   //life cycle hooks

--- a/src/sass/components/ATATFileUpload.scss
+++ b/src/sass/components/ATATFileUpload.scss
@@ -34,6 +34,7 @@
         padding: 0px;
         transition: none !important;
         width: 100%;
+        color: $base-darkest;
         .content{
           cursor: pointer;
           width: 100%;


### PR DESCRIPTION
- [x] Invalid message disappears when user clicks the control to upload another file
- [x] `Use a PDF file with a max size of 10 MB` is standard text color, not error color
- [x]  Changed `10 MB` to `1 GB` text in `Use a PDF file with a max size of 1 GB`  (see both screencaps below)
- [x] Clicking browse to upload to upload the same file shows expected error message

![image](https://user-images.githubusercontent.com/84856468/170391875-f070b50b-1163-49cd-865f-88165e15ba36.png)

![image](https://user-images.githubusercontent.com/84856468/170391895-2d8beb5c-493b-4bb1-a2da-1b810142c5c0.png)
