### PR TITLE
made file upload more bulletproof

### DIFF
--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -60,7 +60,7 @@
                   role="button"
                   id="BrowseToUpload"
                   class="_text-link ml-1"
-                  @mousedown="fileUploadClicked"
+                  @click="fileUploadClicked"
                 >
                   browse to upload
                 </a>
@@ -148,7 +148,12 @@ export default class ATATFileUpload extends Vue {
   /**
    * triggers html file upload click
    */
-  private fileUploadClicked(): void {
+  private fileUploadClicked(event: Event): void {
+    const eventSrc = event.target as HTMLElement;
+    if (eventSrc.classList.contains("_text-link")) {
+      event.preventDefault();
+      event.stopPropagation();}
+
     (document.getElementById("FundingPlanFileUpload") as HTMLInputElement).click();
     this.reset();
     this.isFullSize = this.validFiles.length === 0;

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -149,11 +149,11 @@ export default class ATATFileUpload extends Vue {
    * triggers html file upload click
    */
   private fileUploadClicked(): void {
+    (document.getElementById("FundingPlanFileUpload") as HTMLInputElement).click();
     this.reset();
     this.isFullSize = this.validFiles.length === 0;
-    this.fileUploadControl.click();
   }
-
+  // 
   /**
    * 1. sets uploadedFiles data
    * 2. removes unnecessary vuetify status msg
@@ -169,9 +169,10 @@ export default class ATATFileUpload extends Vue {
       if (vuetifyFileUploadStatus) {
         vuetifyFileUploadStatus.innerHTML = "";
       }
-      this.clearHTMLFileInput();
+      Vue.nextTick(()=>{
+        this.clearHTMLFileInput();
+      })
     });
-   
   }
 
   /**


### PR DESCRIPTION
File upload `browse to upload` link was still failing in test.  Have bulletproofed the file upload process even more.  

**Please test the following scenarios**

```
click 'browse to upload' 
  upload single valid file (pdf or Excel file)
  upload single invalid file (Word/notepad file)
  upload multiple valid files (pdf or Excel files)
  upload multiple valid and invalid files (pdf, Excel and Word/notepad file)


drag and drop 
  upload single valid file (pdf or Excel file)
  upload single invalid file (Word/notepad file)
  upload multiple valid files (pdf or Excel files)
  upload multiple valid and invalid files (pdf, Excel and Word/notepad file)
```