### PR TITLE
feature at 7419 fix modal alert

### DIFF
--- a/src/steps/05-PerformanceRequirements/DOW/ServiceOfferingDetails.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ServiceOfferingDetails.vue
@@ -336,6 +336,9 @@ export default class ServiceOfferingDetails extends Mixins(SaveOnLeave) {
       if (e.sys_id) {
         this.avlClassificationLevelSysIds.push(e.sys_id);
       }
+      if (e.impact_level === "IL6") {
+        this.isIL6Selected = "true";
+      }
     });
     this.headerCheckboxItems 
       = this.createCheckboxItems(this.avlClassificationLevelObjects);


### PR DESCRIPTION
Fixed issue where the IL6 alert wasn't showing on initial opening of modal if IL6 was selected in step 4. It was only showing if user selected IL6 in the modal.