### PR TITLE
feature/AT-7296-datepicker-updates

### DIFF
--- a/src/components/ATATDatePicker.vue
+++ b/src/components/ATATDatePicker.vue
@@ -72,7 +72,8 @@
         v-model="date"
         :show-adjacent-months="showAdjacentMonths"
         no-title
-        active-picker="date"
+        :active-picker.sync="activePicker"
+        type="date"
         :min="min"
         :max="max"
         @click:date="datePickerClicked"
@@ -87,7 +88,7 @@
 import { Component, Prop, Watch } from "vue-property-decorator";
 import Vue from "vue";
 import Inputmask from "inputmask";
-import { add, format, isAfter, isBefore, isValid } from "date-fns";
+import { add, format, isValid } from "date-fns";
 import ATATTooltip from "@/components/ATATTooltip.vue";
 import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
 
@@ -113,6 +114,7 @@ export default class ATATDatePicker extends Vue {
   private dateFormatted = "";
   private menu = false;
   private errorMessages: string[] = [];
+  private activePicker = '';
 
   // Flash of red border on date text field when validateOnBlur is true and user
   // clicks a date in the picker to be addressed in future milestone.
@@ -135,12 +137,25 @@ export default class ATATDatePicker extends Vue {
   @Prop({ default: ()=>[] }) private rules!: Array<unknown>;
   @Prop({ default: false }) private isRequired!: boolean;
 
+
   /**
    * WATCHERS
    */
   @Watch("date")
   protected formatDateWatcher(): void {
     this.dateFormatted = this.reformatDate(this.date);
+  }
+
+  /**
+   * restores standar calendar view when popup menu is displayed 
+   * if previous view was month or year view
+   */
+
+  @Watch("menu")
+  protected showStandardCalendar(val: boolean): void {
+    if (val){
+      setTimeout(()=> this.activePicker = 'DATE')
+    }
   }
 
   /**

--- a/src/sass/components/ATATDatePicker.scss
+++ b/src/sass/components/ATATDatePicker.scss
@@ -34,8 +34,6 @@
               color: $base-darkest !important;
             }
             button{
-              pointer-events: none;
-              user-select: none;
               color: $base_darkest;
               &:hover{
                 color: $base_darkest;

--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
@@ -1,56 +1,62 @@
 
 <template>
-    <v-container fluid class="container-max-width">
-      <v-row>
-        <v-col class="col-12">
-          <h1 class="page-header">
-            Let’s gather some details about your current contract
-          </h1>
-          <div class="copy-max-width">
-  
-            <ATATTextField 
-              label="Incumbent contractor name" 
-              id="IncumbentContractorName" 
-              class="_input-max-width mb-10" 
-              :value.sync="incumbentContractorName"
-              :rules="[
-                $validators.required('Please enter the incumbent contractor’s name.')
-              ]"            
-            />
+  <v-container fluid class="container-max-width">
+    <v-row>
+      <v-col class="col-12">
+        <h1 class="page-header">
+          Let’s gather some details about your current contract
+        </h1>
+        <div class="copy-max-width">
+          <ATATTextField
+            label="Incumbent contractor name"
+            id="IncumbentContractorName"
+            class="_input-max-width mb-10"
+            :value.sync="incumbentContractorName"
+            :rules="[
+              $validators.required(
+                'Please enter the incumbent contractor’s name.'
+              ),
+            ]"
+          />
 
-            <ATATTextField 
-              label="Contract number" 
-              id="ContractNumber" 
-              class="_input-max-width mb-10" 
-              :value.sync="contractNumber"
-              :rules="[
-                $validators.required('Please enter your contract number.')
-              ]"            
-            />
-            
-            <ATATTextField 
-              label="Task/Delivery order number" 
-              id="TaskDeliveryOrderNumber" 
-              class="_input-max-width mb-10" 
-              :value.sync="taskDeliveryOrderNumber"
-            />
+          <ATATTextField
+            label="Contract number"
+            id="ContractNumber"
+            class="_input-max-width mb-10"
+            :value.sync="contractNumber"
+            :rules="[
+              $validators.required('Please enter your contract number.'),
+            ]"
+          />
 
-            <!-- NOTE: max date to be determined -->
-            <ATATDatePicker id="Expiration" 
-              label="Contract/Order expiration date"
-              placeHolder="MM/DD/YYYY"
-              :value.sync="contractOrderExpirationDate" 
-              :min="minDate"
-              max="2024-01-01"
-              :rules="[
-                $validators.required('Please enter your contract/order expiration date.'),
-                $validators.isDateValid('Please enter a valid date.')
-              ]" />
+          <ATATTextField
+            label="Task/Delivery order number"
+            id="TaskDeliveryOrderNumber"
+            class="_input-max-width mb-10"
+            :value.sync="taskDeliveryOrderNumber"
+          />
 
-          </div>
-        </v-col>
-      </v-row>
-    </v-container>
+          <!-- NOTE: max date to be determined -->
+          <ATATDatePicker
+            id="Expiration"
+            label="Contract/Order expiration date"
+            placeHolder="MM/DD/YYYY"
+            :value.sync="contractOrderExpirationDate"
+            :min="minDate"
+            tooltipText="Use the period of performance end date for your task order. If you 
+                do not have an order number, use your contract expiration date."
+            max="2024-01-01"
+            :rules="[
+              $validators.required(
+                'Please enter your contract/order expiration date.'
+              ),
+              $validators.isDateValid('Please enter a valid date.'),
+            ]"
+          />
+        </div>
+      </v-col>
+    </v-row>
+  </v-container>
 </template>
 
 <script lang="ts">
@@ -60,7 +66,9 @@ import { Component, Mixins } from "vue-property-decorator";
 import ATATDatePicker from "@/components/ATATDatePicker.vue";
 import ATATTextField from "@/components/ATATTextField.vue";
 
-import AcquisitionPackage, { StoreProperties } from "@/store/acquisitionPackage";
+import AcquisitionPackage, {
+  StoreProperties,
+} from "@/store/acquisitionPackage";
 import SaveOnLeave from "@/mixins/saveOnLeave";
 import { CurrentContractDTO } from "@/api/models";
 import { hasChanges } from "@/helpers";
@@ -72,19 +80,18 @@ import { add, format } from "date-fns";
     ATATTextField,
   },
 })
-
 export default class CurrentContract extends Mixins(SaveOnLeave) {
-  private incumbentContractorName 
-    = AcquisitionPackage.currentContract?.incumbent_contractor_name || "";
-  
-  private contractNumber 
-    = AcquisitionPackage.currentContract?.contract_number || "";
-  
-  private taskDeliveryOrderNumber 
-    = AcquisitionPackage.currentContract?.task_delivery_order_number || "";
-  
-  private contractOrderExpirationDate 
-    = AcquisitionPackage.currentContract?.contract_order_expiration_date || "";
+  private incumbentContractorName =
+    AcquisitionPackage.currentContract?.incumbent_contractor_name || "";
+
+  private contractNumber =
+    AcquisitionPackage.currentContract?.contract_number || "";
+
+  private taskDeliveryOrderNumber =
+    AcquisitionPackage.currentContract?.task_delivery_order_number || "";
+
+  private contractOrderExpirationDate =
+    AcquisitionPackage.currentContract?.contract_order_expiration_date || "";
 
   private minDate: string = format(add(new Date(), { days: 1 }), "yyyy-MM-dd");
 
@@ -97,7 +104,7 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
     };
   }
 
-  private savedData = { 
+  private savedData = {
     incumbent_contractor_name: "",
     contract_number: "",
     task_delivery_order_number: "",
@@ -109,16 +116,16 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   }
 
   public async loadOnEnter(): Promise<void> {
-    const storeData = await AcquisitionPackage
-      .loadData<CurrentContractDTO>({storeProperty: 
-      StoreProperties.CurrentContract}) as Record<string, string>;
+    const storeData = (await AcquisitionPackage.loadData<CurrentContractDTO>({
+      storeProperty: StoreProperties.CurrentContract,
+    })) as Record<string, string>;
 
     if (storeData) {
       const keys: string[] = [
         "incumbent_contractor_name",
         "contract_number",
         "task_delivery_order_number",
-        "contract_order_expiration_date"
+        "contract_order_expiration_date",
       ];
       keys.forEach((key: string) => {
         if (Object.prototype.hasOwnProperty.call(storeData, key)) {
@@ -137,9 +144,10 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.hasChanged()) {
-        await AcquisitionPackage
-          .saveData<CurrentContractDTO>({data: this.currentData, 
-            storeProperty: StoreProperties.CurrentContract });
+        await AcquisitionPackage.saveData<CurrentContractDTO>({
+          data: this.currentData,
+          storeProperty: StoreProperties.CurrentContract,
+        });
       }
     } catch (error) {
       console.log(error);
@@ -147,6 +155,5 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
 
     return true;
   }
-
 }
 </script>


### PR DESCRIPTION
- [x] 1. Today’s date doesn’t allow hover or select
- [x] 2. Enable user to click on the Month/Year text (consistent for mouse and keyboard users).  Currently this only works for mouse click and keyboard navigation.
     Solution: remove .v-date-picker-header__value button{  user-select: none; }from \src\sass\components\ATATDatePicker.scss
- [x] 3. Always have the calendar view displayed when user opens the modal (Currently, if the modal is closed with the Month/Year selection option displayed, then it will open to the same view, instead of going to the calendar view) 
- [x] 4. The component is to have a tooltip that will toggle via tooltip property passed to the component
     Tooltip is displayed at by viewing Step 03 - Background > Current Contract, then click  Yes, there is a current contract for this effort.  The tooltip is on the Contract/Order expiration date datepicker with the following text:  Use the period of performance end date for  your task order. If you do not have an order number, use your contract expiration date.