### PR TITLE
restore PoP validation

### DIFF
--- a/src/steps/04-ContractDetails/PeriodOfPerformance.vue
+++ b/src/steps/04-ContractDetails/PeriodOfPerformance.vue
@@ -227,13 +227,13 @@ export default class PeriodOfPerformance extends Mixins(SaveOnLeave) {
       if (optionPeriod.duration) {
         let multiplier = 1;
         switch (optionPeriod.unitOfTime) {
-        case "Week(s)":
+        case "WEEK":
           multiplier = 7;
           break;
-        case "Month(s)":
+        case "MONTH":
           multiplier = 30;
           break;
-        case "Year":
+        case "YEAR":
           multiplier = 365;
           break;
         default:


### PR DESCRIPTION
The POP error validation message, that alerts the user the base year and the options years have exceeded 5 years,  had stopped displaying, most likely when the units of time was pulled from SNOW.  The error validation message have been restored.  Pls see below. 

![image](https://user-images.githubusercontent.com/84856468/173129416-97866843-1563-40ad-9e62-672b2f51ceca.png)
