### PR TITLE
Feature/at 7636 dow nav

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1,3 +1,4 @@
+import Vue from "vue";
 import AcquisitionPackage from "@/store/acquisitionPackage";
 import OtherContractConsiderations from "@/store/otherContractConsiderations";
 import { sanitizeOfferingName } from "@/helpers";
@@ -6,6 +7,8 @@ import { RouteDirection, StepPathResolver, StepRouteResolver } from "@/store/ste
 import DescriptionOfWork, { DescriptionOfWorkStore } from "@/store/descriptionOfWork";
 import ClassificationRequirements from "@/store/classificationRequirements";
 import Periods from "@/store/periods";
+import Steps from "@/store/steps";
+
 
 export const AcorsRouteResolver = (current: string): string => {
   const hasAlternativeContactRep = AcquisitionPackage.hasAlternativeContactRep;
@@ -160,6 +163,9 @@ export const OfferGroupOfferingsPathResolver = (
   current: string, direction: string
 ): string => {
   debugger;
+  DescriptionOfWork.setBackToContractDetails(false);
+  Steps.setBackButtonText("");
+
   DescriptionOfWork.setCurrentGroupRemoved(false);
   // if no options selected on category page, or if only "None apply" checkboxes checked, 
   // or if last group was removed, send to summary page
@@ -311,6 +317,15 @@ export const OfferGroupOfferingsPathResolver = (
 // When leaving service offering details page
 //this will always return the path for the current group and the current offering
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
+  debugger;
+  Steps.setBackButtonText("");
+
+  if (DescriptionOfWork.summaryBackToContractDetails) {
+    debugger;
+    DescriptionOfWork.setBackToContractDetails(false);
+    return "period-of-performance/period-of-performance";
+  }
+
   const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
 
   if ((missingDOWReqs && DescriptionOfWork.returnToDOWSummary) 
@@ -391,9 +406,13 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
   return descriptionOfWorkSummaryPath
 }
 
-// when leaving DOW Summary page
 export const DowSummaryPathResolver = (current: string, direction: string): string =>{
   debugger;
+  DescriptionOfWork.setBackToContractDetails(false);
+  Vue.nextTick(() => {
+    Steps.setBackButtonText("");
+  });
+
   if(current === routeNames.PropertyDetails){
     if(DescriptionOfWork.DOWObject.length > 0){
       DescriptionOfWork.setReturnToDOWSummary(false);

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -161,7 +161,7 @@ export const OfferGroupOfferingsPathResolver = (
   current: string, direction: string
 ): string => {
   DescriptionOfWork.setBackToContractDetails(false);
-  Steps.setBackButtonText("");
+  Steps.clearAltBackButtonText();
 
   DescriptionOfWork.setCurrentGroupRemoved(false);
   // if no options selected on category page, or if only "None apply" checkboxes checked, 
@@ -302,7 +302,7 @@ export const OfferGroupOfferingsPathResolver = (
 
 //this will always return the path for the current group and the current offering
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
-  Steps.setBackButtonText("");
+  Steps.clearAltBackButtonText();
 
   if (DescriptionOfWork.summaryBackToContractDetails) {
     DescriptionOfWork.setBackToContractDetails(false);
@@ -391,7 +391,7 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
 export const DowSummaryPathResolver = (current: string, direction: string): string =>{
   DescriptionOfWork.setBackToContractDetails(false);
   Vue.nextTick(() => {
-    Steps.setBackButtonText("");
+    Steps.clearAltBackButtonText();
   });
 
   if(current === routeNames.PropertyDetails){

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -157,7 +157,6 @@ export const RequirementsPathResolver = (current: string, direction: string): st
   return basePerformanceRequirementsPath;
 }
 
-// When leaving category service offerings checkbox list page
 export const OfferGroupOfferingsPathResolver = (
   current: string, direction: string
 ): string => {
@@ -312,7 +311,6 @@ export const OfferGroupOfferingsPathResolver = (
   return getOfferingGroupServicesPath(DescriptionOfWork.currentGroupId);
 }
 
-// When leaving service offering details page
 //this will always return the path for the current group and the current offering
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
   Steps.setBackButtonText("");
@@ -352,7 +350,6 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
       }
     }
   }
-
 
   if (!DescriptionOfWork.prevOfferingGroup && !DescriptionOfWork.currentGroupId) {
     // only "none apply" options selected.
@@ -430,7 +427,6 @@ export const DowSummaryPathResolver = (current: string, direction: string): stri
 
   // coming from service offering details step
   if(current === routeNames.ServiceOfferingDetails){
-
 
     //no more offerings or services to process go to summary
     if(atOfferingsEnd && atServicesEnd){

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -113,7 +113,6 @@ const getOfferingGroupServicesPath = (groupId: string)=>
 
 export const RequirementsPathResolver = (current: string, direction: string): string =>
 {
-  debugger;
   const atBeginningOfSericeOfferings = DescriptionOfWork.isAtBeginningOfServiceOfferings;
   const atBeginningOfOfferingGroups = DescriptionOfWork.isAtBeginningOfServiceGroups;
   const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
@@ -162,7 +161,6 @@ export const RequirementsPathResolver = (current: string, direction: string): st
 export const OfferGroupOfferingsPathResolver = (
   current: string, direction: string
 ): string => {
-  debugger;
   DescriptionOfWork.setBackToContractDetails(false);
   Steps.setBackButtonText("");
 
@@ -317,11 +315,9 @@ export const OfferGroupOfferingsPathResolver = (
 // When leaving service offering details page
 //this will always return the path for the current group and the current offering
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
-  debugger;
   Steps.setBackButtonText("");
 
   if (DescriptionOfWork.summaryBackToContractDetails) {
-    debugger;
     DescriptionOfWork.setBackToContractDetails(false);
     return "period-of-performance/period-of-performance";
   }
@@ -407,7 +403,6 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
 }
 
 export const DowSummaryPathResolver = (current: string, direction: string): string =>{
-  debugger;
   DescriptionOfWork.setBackToContractDetails(false);
   Vue.nextTick(() => {
     Steps.setBackButtonText("");

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -204,31 +204,28 @@ export const OfferGroupOfferingsPathResolver = (
 
   //handles moving backwards or forwards through service offerings
   if (current === routeNames.ServiceOfferingDetails &&
-    direction.toUpperCase() === RouteDirection.PREVIOUS)
-  {  
+    direction.toUpperCase() === RouteDirection.PREVIOUS) {  
     const atBeginningOfSericeOfferings = DescriptionOfWork.isAtBeginningOfServiceOfferings;
     const atBeginningOfOfferingGroups = DescriptionOfWork.isAtBeginningOfServiceGroups;
 
     //at the beginning of service offerings and offering groups
     // direct the user back to the performance requirements step
-    if(current === routeNames.ServiceOfferingDetails && 
+    if (current === routeNames.ServiceOfferingDetails && 
       atBeginningOfOfferingGroups && atBeginningOfSericeOfferings){
       return getOfferingGroupServicesPath(DescriptionOfWork.currentGroupId);
     }
 
-    if(atBeginningOfOfferingGroups && atBeginningOfSericeOfferings && 
-      current !== routeNames.ServiceOfferingDetails)
-    {
+    if (atBeginningOfOfferingGroups && atBeginningOfSericeOfferings && 
+      current !== routeNames.ServiceOfferingDetails) {
       return basePerformanceRequirementsPath;
     }
 
     //if we are at the beginning of offering groups but not at the beginning of service offerings
     //get the next service offering and display it in service offering details
-    if(atBeginningOfOfferingGroups && !atBeginningOfSericeOfferings){
+    if (atBeginningOfOfferingGroups && !atBeginningOfSericeOfferings){
       const previousServiceOffering = DescriptionOfWork.previousServiceOffering;
       const groupId = DescriptionOfWork.currentGroupId;
-      if(previousServiceOffering === undefined)
-      {
+      if (previousServiceOffering === undefined) {
         throw new Error('unable to get previous service offering group');
       }
       DescriptionOfWork.setCurrentOffering(previousServiceOffering);
@@ -237,26 +234,23 @@ export const OfferGroupOfferingsPathResolver = (
     }
 
     //at the beginning of service offerings for a given offering group
-    if(!atBeginningOfOfferingGroups && atBeginningOfSericeOfferings){
-
+    if (!atBeginningOfOfferingGroups && atBeginningOfSericeOfferings) {
       //if routing from service offering details
       //send the user to the step to select the Service Offerings (Service Offerings)
-      if(current === routeNames.ServiceOfferingDetails){
+      if (current === routeNames.ServiceOfferingDetails) {
         //display service offering group page
         return getOfferingGroupServicesPath(DescriptionOfWork.currentGroupId);
       }
 
       const previousGroup = DescriptionOfWork.prevOfferingGroup;
-      if(previousGroup === undefined)
-      {
+      if (previousGroup === undefined) {
         throw new Error('unable to get previous offering group');
       }
 
       DescriptionOfWork.setCurrentOfferingGroupId(previousGroup);
       const lastServiceOfferingForGroup = DescriptionOfWork.lastOfferingForGroup;
    
-      if(lastServiceOfferingForGroup === undefined)
-      {
+      if (lastServiceOfferingForGroup === undefined) {
         throw new Error(`unable to get last offering for group ${previousGroup}`);
       }
       DescriptionOfWork.setCurrentOffering(lastServiceOfferingForGroup);
@@ -265,28 +259,23 @@ export const OfferGroupOfferingsPathResolver = (
 
     //not at the beginning of service offerings or offering groups
     //get the next server offering and display in service offering details
-    if(!atBeginningOfOfferingGroups && !atBeginningOfSericeOfferings)
-    {
+    if (!atBeginningOfOfferingGroups && !atBeginningOfSericeOfferings) {
       const groupId = DescriptionOfWork.currentGroupId;
 
       //can we get the previous service offering for this group?
       const canGetPreviousOffering = DescriptionOfWork.canGetPreviousServiceOffering;
 
-      if(canGetPreviousOffering){
+      if (canGetPreviousOffering) {
         const serviceOffering = DescriptionOfWork.previousServiceOffering;
 
-        if(serviceOffering === undefined)
-        {
+        if (serviceOffering === undefined) {
           throw new Error('unable to get previous service offering');
         }
 
         DescriptionOfWork.setCurrentOffering(serviceOffering);
 
         return getServiceOfferingsDetailsPath(groupId, serviceOffering.name);
-
-      }
-      else{
-          
+      } else {
         //we couldn't get the previous offering so try to get the previous offering group
         const previousGroup = DescriptionOfWork.prevOfferingGroup;
         if(previousGroup === undefined)

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -110,9 +110,10 @@ const getOfferingGroupServicesPath = (groupId: string)=>
 
 export const RequirementsPathResolver = (current: string, direction: string): string =>
 {
+  debugger;
   const atBeginningOfSericeOfferings = DescriptionOfWork.isAtBeginningOfServiceOfferings;
   const atBeginningOfOfferingGroups = DescriptionOfWork.isAtBeginningOfServiceGroups;
-  const missingDOWReqs = DescriptionOfWork.missingDOWRequirements;
+  const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
 
   if (current === routeNames.ServiceOfferings && missingDOWReqs && !atBeginningOfOfferingGroups) {
     const group = direction === "next" 
@@ -154,9 +155,11 @@ export const RequirementsPathResolver = (current: string, direction: string): st
   return basePerformanceRequirementsPath;
 }
 
+// When leaving category service offerings checkbox list page
 export const OfferGroupOfferingsPathResolver = (
   current: string, direction: string
 ): string => {
+  debugger;
   DescriptionOfWork.setCurrentGroupRemoved(false);
   // if no options selected on category page, or if only "None apply" checkboxes checked, 
   // or if last group was removed, send to summary page
@@ -305,9 +308,10 @@ export const OfferGroupOfferingsPathResolver = (
   return getOfferingGroupServicesPath(DescriptionOfWork.currentGroupId);
 }
 
+// When leaving service offering details page
 //this will always return the path for the current group and the current offering
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
-  const missingDOWReqs = DescriptionOfWork.missingDOWRequirements;
+  const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
 
   if ((missingDOWReqs && DescriptionOfWork.returnToDOWSummary) 
     || (DescriptionOfWork.currentGroupRemovedForNav && DescriptionOfWork.lastGroupRemoved)) {
@@ -387,7 +391,9 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
   return descriptionOfWorkSummaryPath
 }
 
+// when leaving DOW Summary page
 export const DowSummaryPathResolver = (current: string, direction: string): string =>{
+  debugger;
   if(current === routeNames.PropertyDetails){
     if(DescriptionOfWork.DOWObject.length > 0){
       DescriptionOfWork.setReturnToDOWSummary(false);

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -115,9 +115,12 @@ export const RequirementsPathResolver = (current: string, direction: string): st
 {
   const atBeginningOfSericeOfferings = DescriptionOfWork.isAtBeginningOfServiceOfferings;
   const atBeginningOfOfferingGroups = DescriptionOfWork.isAtBeginningOfServiceGroups;
-  const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
+  const missingClassification = DescriptionOfWork.missingClassificationLevels;
 
-  if (current === routeNames.ServiceOfferings && missingDOWReqs && !atBeginningOfOfferingGroups) {
+  if (current === routeNames.ServiceOfferings 
+    && missingClassification 
+    && !atBeginningOfOfferingGroups
+  ) {
     const group = direction === "next" 
       ? DescriptionOfWork.nextOfferingGroup 
       : DescriptionOfWork.prevOfferingGroup;
@@ -309,9 +312,9 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
     return "period-of-performance/period-of-performance";
   }
 
-  const missingDOWReqs = DescriptionOfWork.missingClassificationLevels;
+  const missingClassification = DescriptionOfWork.missingClassificationLevels;
 
-  if ((missingDOWReqs && DescriptionOfWork.returnToDOWSummary) 
+  if ((missingClassification && DescriptionOfWork.returnToDOWSummary) 
     || (DescriptionOfWork.currentGroupRemovedForNav && DescriptionOfWork.lastGroupRemoved)) {
     // and no more groups after
     DescriptionOfWork.setReturnToDOWSummary(false);
@@ -331,7 +334,7 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
     if (DescriptionOfWork.currentOfferingName === ""){
       //get the last offering and display
       const offering = DescriptionOfWork.lastOfferingForGroup;
-      if (offering && !missingDOWReqs) {
+      if (offering && !missingClassification) {
         DescriptionOfWork.setCurrentOffering(offering);
       } else {
         const serviceOffering = routeNames.ServiceOfferings
@@ -363,7 +366,7 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
     DescriptionOfWork.setReturnToDOWSummary(false);
     return descriptionOfWorkSummaryPath;   
   } 
-  if (!missingDOWReqs) {
+  if (!missingClassification) {
     const offering = sanitizeOfferingName(DescriptionOfWork.currentOfferingName);
     return `${baseOfferingDetailsPath}${groupId.toLowerCase()}/${offering.toLowerCase()}`;  
   } 

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -309,10 +309,6 @@ export const OfferGroupOfferingsPathResolver = (
 export const OfferingDetailsPathResolver = (current: string, direction: string): string => {
   const missingDOWReqs = DescriptionOfWork.missingDOWRequirements;
 
-  const foo1 = DescriptionOfWork.lastGroupRemoved;
-  const bar2 = DescriptionOfWork.currentGroupRemovedForNav;
-  console.log(foo1, bar2);
-
   if ((missingDOWReqs && DescriptionOfWork.returnToDOWSummary) 
     || (DescriptionOfWork.currentGroupRemovedForNav && DescriptionOfWork.lastGroupRemoved)) {
     // and no more groups after

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -413,9 +413,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         completePercentageWeight: 1,
         component: DOWSummary,
         routeResolver: DowSummaryPathResolver,
-        backButtonText: DescriptionOfWork.summaryBackToContractDetails 
-          ? 'Back to Contract Details' 
-          : 'Back',
+        backButtonText: "Back",
         continueButtonText: 'Wrap up this section',
       },
     ],

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -1,5 +1,6 @@
 import {StepperRouteConfig, StepperStep} from "../../types/Global";
 
+import DescriptionOfWork from "@/store/descriptionOfWork";
 
 // Step 1 - Acquisition Package Details
 import AcquisitionPackageDetails from "../steps/01-AcquisitionPackageDetails/Index.vue";
@@ -410,7 +411,9 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         completePercentageWeight: 1,
         component: DOWSummary,
         routeResolver: DowSummaryPathResolver,
-        backButtonText: 'Back to Contract Details',
+        backButtonText: DescriptionOfWork.summaryBackToContractDetails 
+          ? 'Back to Contract Details' 
+          : 'Back',
         continueButtonText: 'Wrap up this section',
       },
     ],

--- a/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
@@ -76,7 +76,9 @@ import SlideoutPanel from "@/store/slideoutPanel/index";
 
 import { Checkbox, SlideoutPanelContent } from "../../../../types/Global";
 import { SystemChoiceDTO } from "@/api/models";
-import { routeNames } from "../../../router/stepper"
+import { routeNames } from "../../../router/stepper";
+import router from "@/router";
+
 import DescriptionOfWork from "@/store/descriptionOfWork";
 import { getIdText } from "@/helpers";
 import Periods from "@/store/periods";
@@ -103,6 +105,7 @@ export default class RequirementCategories extends Mixins(SaveOnLeave) {
   private isClassificationDataMissing = false
   private showAlert = false
   private routeNames = routeNames
+  private goToSummary = false;
 
   public openSlideoutPanel(e: Event): void {
     if (e && e.currentTarget) {
@@ -167,6 +170,14 @@ export default class RequirementCategories extends Mixins(SaveOnLeave) {
   };
 
   public async mounted(): Promise<void> {
+    this.goToSummary = DescriptionOfWork.DOWObject.length > 0;
+    debugger;
+    if (this.goToSummary) {
+      DescriptionOfWork.setBackToContractDetails(true);
+      router.push({
+        name: routeNames.DOWSummary,
+      }).catch(() => console.log("error navigating to DOW Summary"));
+    }    
     await this.loadOnEnter();
     const slideoutPanelContent: SlideoutPanelContent = {
       component: PerfReqLearnMore,
@@ -179,11 +190,13 @@ export default class RequirementCategories extends Mixins(SaveOnLeave) {
 
   protected async saveOnLeave(): Promise<boolean> {
     try {
-      // save to store
-      const selectedOfferingGroups
-        = this.selectedXaasOptions.concat(this.cloudSupportSelectedOptions);
+      if (!this.goToSummary) {
+        // save to store
+        const selectedOfferingGroups
+          = this.selectedXaasOptions.concat(this.cloudSupportSelectedOptions);
 
-      await DescriptionOfWork.setSelectedOfferingGroups(selectedOfferingGroups);
+        await DescriptionOfWork.setSelectedOfferingGroups(selectedOfferingGroups);
+      }
     } catch (error) {
       throw new Error('error saving requirement data');
     }

--- a/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
@@ -172,10 +172,8 @@ export default class RequirementCategories extends Mixins(SaveOnLeave) {
 
   public async mounted(): Promise<void> {
     this.goToSummary = DescriptionOfWork.DOWObject.length > 0;
-    debugger;
     if (this.goToSummary) {
       DescriptionOfWork.setBackToContractDetails(true);
-      debugger;
       this.$router.push({
         name: routeNames.DOWSummary,
       }).catch(() => console.log("error navigating to DOW Summary"));

--- a/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/RequirementCategories.vue
@@ -77,13 +77,14 @@ import SlideoutPanel from "@/store/slideoutPanel/index";
 import { Checkbox, SlideoutPanelContent } from "../../../../types/Global";
 import { SystemChoiceDTO } from "@/api/models";
 import { routeNames } from "../../../router/stepper";
-import router from "@/router";
+// import router from "@/router";
 
 import DescriptionOfWork from "@/store/descriptionOfWork";
 import { getIdText } from "@/helpers";
 import Periods from "@/store/periods";
 import classificationRequirements from "@/store/classificationRequirements";
 import DOWAlert from "@/steps/05-PerformanceRequirements/DOW/DOWAlert.vue";
+
 
 @Component({
   components: {
@@ -174,7 +175,8 @@ export default class RequirementCategories extends Mixins(SaveOnLeave) {
     debugger;
     if (this.goToSummary) {
       DescriptionOfWork.setBackToContractDetails(true);
-      router.push({
+      debugger;
+      this.$router.push({
         name: routeNames.DOWSummary,
       }).catch(() => console.log("error navigating to DOW Summary"));
     }    

--- a/src/steps/05-PerformanceRequirements/DOW/RequirementsForm.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/RequirementsForm.vue
@@ -143,8 +143,8 @@ export default class RequirementsForm extends Vue {
     
     const arr: Checkbox[] = [];
     periods.forEach((period, idx) => {
-      let label = idx === 0 ? `Base period` : `Option period ${idx}`
-      let option: Checkbox = {
+      const label = idx === 0 ? "Base period" : `Option period ${idx}`;
+      const option: Checkbox = {
         id: period.period_type,
         label,
         value: period.sys_id || "",

--- a/src/steps/05-PerformanceRequirements/DOW/RequirementsForm.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/RequirementsForm.vue
@@ -38,11 +38,11 @@
                 :items="requirementOptions"
                 :value.sync="instance.entireDuration"
                 :rules="[
-                  $validators.required('Please select an option to specify your requirement\'s.')
+                  $validators.required('Please select an option to specify your requirements.')
                 ]"
               />
               <div v-if="instance.entireDuration === 'NO'">
-                <p id="CloudSupportLabel" class="_checkbox-group-label">
+                <p id="CloudSupportLabel" class="_checkbox-group-label mb-3">
                   Which base and/or option periods do you need this requirement?
                 </p>
                 <ATATCheckboxGroup
@@ -54,7 +54,7 @@
                   :disabled="isDisabled"
                   :rules="[
                     $validators.required('Please select at least one base or option period' +
-                      ' to specify your requirement\'s duration level.')
+                      ' to specify your requirement’s duration level.')
                   ]"
                   class="copy-max-width"
                 />
@@ -119,9 +119,9 @@ export default class RequirementsForm extends Vue {
   @PropSync("instances") private _instances!: DOWClassificationInstance[];
   @Prop() private avlInstancesLength!: number;
 
-  private selectedOptions: string[] = []
-  private routeNames = routeNames
-  private isDisabled = true
+  private selectedOptions: string[] = [];
+  private routeNames = routeNames;
+  private isDisabled = true;
   private requirementOptions: RadioButton[] = [
     {
       id: "Yes",
@@ -143,9 +143,10 @@ export default class RequirementsForm extends Vue {
     
     const arr: Checkbox[] = [];
     periods.forEach((period, idx) => {
+      let label = idx === 0 ? `Base period` : `Option period ${idx}`
       let option: Checkbox = {
         id: period.period_type,
-        label: `${toTitleCase(period.period_type)} period ${idx + 1}`,
+        label,
         value: period.sys_id || "",
       }
       arr.push(option)
@@ -156,9 +157,17 @@ export default class RequirementsForm extends Vue {
   public async loadOnEnter(): Promise<void> {
     const periods = await Periods.loadPeriods();
     if (periods && periods.length > 0) {
-      this.isDisabled = false
-      this.availablePeriodCheckboxItems = this.createCheckboxItems(periods)
-      this.selectedOptions.push(this.availablePeriodCheckboxItems[0].value)
+      this.isDisabled = false;
+      this.availablePeriodCheckboxItems = this.createCheckboxItems(periods);
+      this.selectedOptions.push(this.availablePeriodCheckboxItems[0].value);
+    } else {
+      this.availablePeriodCheckboxItems = [
+        {
+          id: "BaseDisabled",
+          label: "Base period",
+          value: "",
+        }
+      ]
     }
   };
 

--- a/src/steps/05-PerformanceRequirements/DOW/ServiceOfferings.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ServiceOfferings.vue
@@ -116,18 +116,20 @@ export default class ServiceOfferings extends Mixins(SaveOnLeave) {
 
   protected async saveOnLeave(): Promise<boolean> {
     try {
-      if (this.selectedOptions.length === 0) {
-        await DescriptionOfWork.removeCurrentOfferingGroup();
-      } else {
-        // save to store if user hasn't clicked "I don't need these cloud resources" button
-        if (this.serviceGroupOnLoad === DescriptionOfWork.currentGroupId) {
-          await DescriptionOfWork.setSelectedOfferings(
-            { selectedOfferingSysIds: this.selectedOptions, otherValue: this.otherValueEntered }
-          );
+      if (this.serviceGroupOnLoad) {
+        if (this.selectedOptions.length === 0) {
+          await DescriptionOfWork.removeCurrentOfferingGroup();
+        } else {
+          // save to store if user hasn't clicked "I don't need these cloud resources" button
+          if (this.serviceGroupOnLoad === DescriptionOfWork.currentGroupId) {
+            await DescriptionOfWork.setSelectedOfferings(
+              { selectedOfferingSysIds: this.selectedOptions, otherValue: this.otherValueEntered }
+            );
+          }
         }
+        //save to backend
+        await DescriptionOfWork.saveUserSelectedServices();
       }
-      //save to backend
-      await DescriptionOfWork.saveUserSelectedServices();
     } catch (error) {
       throw new Error('error saving requirement data');
     }

--- a/src/steps/05-PerformanceRequirements/DOW/ServiceOfferings.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ServiceOfferings.vue
@@ -117,15 +117,11 @@ export default class ServiceOfferings extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.serviceGroupOnLoad) {
-        if (this.selectedOptions.length === 0) {
-          await DescriptionOfWork.removeCurrentOfferingGroup();
-        } else {
-          // save to store if user hasn't clicked "I don't need these cloud resources" button
-          if (this.serviceGroupOnLoad === DescriptionOfWork.currentGroupId) {
-            await DescriptionOfWork.setSelectedOfferings(
-              { selectedOfferingSysIds: this.selectedOptions, otherValue: this.otherValueEntered }
-            );
-          }
+        // save to store if user hasn't clicked "I don't need these cloud resources" button
+        if (this.serviceGroupOnLoad === DescriptionOfWork.currentGroupId) {
+          await DescriptionOfWork.setSelectedOfferings(
+            { selectedOfferingSysIds: this.selectedOptions, otherValue: this.otherValueEntered }
+          );
         }
         //save to backend
         await DescriptionOfWork.saveUserSelectedServices();

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -67,7 +67,7 @@
       <h2 class="mb-5">Other available categories</h2>
       <a
         id="ShowMoreLink"
-        class="expandable-content-opener mb-5 text-decoration-none"
+        class="expandable-content-opener mt-1 text-decoration-none"
         :class="[{ 'open' : showMore }]"
         v-show="availableServiceGroups.length > 4"
         @click="showMore = !showMore"

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -308,10 +308,8 @@ export default class Summary extends Vue {
 
   public async loadOnEnter(): Promise<void> {
     if (DescriptionOfWork.summaryBackToContractDetails) {
-      debugger;
       Steps.setBackButtonText("Back to Contract Details");
     } else {
-      debugger;
       Steps.setBackButtonText("");
     }
     DescriptionOfWork.setCurrentGroupRemoved(false);

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -147,7 +147,6 @@ import { SystemChoiceDTO } from "@/api/models";
 export default class Summary extends Vue {
   private isPeriodsDataMissing = false;
   private isClassificationDataMissing = false;
-  private isMissingRequirements = this.isPeriodsDataMissing || this.isClassificationDataMissing;
   private showAlert = false;
   private routeNames = routeNames;
   public serviceGroupsMissingData: string[] =[]
@@ -275,7 +274,7 @@ export default class Summary extends Vue {
     let outputArr :string[] = [];
     value.forEach((obj)=>{
       let id = obj.serviceOfferingGroupId;
-      if (this.isMissingRequirements || obj.serviceOfferings.length === 0) {
+      if (this.isClassificationDataMissing || obj.serviceOfferings.length === 0) {
         outputArr.push(id);
       } else {
         obj.serviceOfferings.forEach((offering)=>{

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -133,6 +133,7 @@ import DOWAlert from "@/steps/05-PerformanceRequirements/DOW/DOWAlert.vue";
 import { DOWServiceOffering, DOWServiceOfferingGroup } from "../../../../types/Global";
 import Periods from "@/store/periods";
 import DescriptionOfWork from "@/store/descriptionOfWork";
+import Steps from "@/store/steps";
 import { SystemChoiceDTO } from "@/api/models";
 // import router from "@/router";
 
@@ -306,6 +307,13 @@ export default class Summary extends Vue {
   };
 
   public async loadOnEnter(): Promise<void> {
+    if (DescriptionOfWork.summaryBackToContractDetails) {
+      debugger;
+      Steps.setBackButtonText("Back to Contract Details");
+    } else {
+      debugger;
+      Steps.setBackButtonText("");
+    }
     DescriptionOfWork.setCurrentGroupRemoved(false);
     DescriptionOfWork.setCurrentGroupRemovedForNav(false);
     DescriptionOfWork.setReturnToDOWSummary(false);

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -21,7 +21,7 @@
           />
         </div>
         <div class="container-max-width"
-              v-for="(item) in selectedServiceGroups"
+              v-for="(item, index) in selectedServiceGroups"
               :key="item.serviceOfferingGroupId">
           <div class=" d-flex justify-space-between">
             <div>
@@ -55,12 +55,15 @@
               </div>
             </div>
           </div>
-          <hr />
+          <hr v-if="index !== allServiceGroups.length - 1" />
         </div>
       </v-col>
     </v-row>
 
-    <div class="d-flex justify-space-between align-flex-end">
+    <div 
+      v-if="availableServiceGroups.length > 0" 
+      class="d-flex justify-space-between align-flex-end"
+    >
       <h2 class="mb-5">Other available categories</h2>
       <a
         id="ShowMoreLink"
@@ -75,7 +78,7 @@
       </a>
     </div>
 
-    <v-row>
+    <v-row v-if="availableServiceGroups.length > 0">
       <v-col
         cols="3"
         style="padding: 10px; !important"

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -308,9 +308,9 @@ export default class Summary extends Vue {
 
   public async loadOnEnter(): Promise<void> {
     if (DescriptionOfWork.summaryBackToContractDetails) {
-      Steps.setBackButtonText("Back to Contract Details");
+      Steps.setAltBackButtonText("Back to Contract Details");
     } else {
-      Steps.setBackButtonText("");
+      Steps.clearAltBackButtonText();
     }
     DescriptionOfWork.setCurrentGroupRemoved(false);
     DescriptionOfWork.setCurrentGroupRemovedForNav(false);

--- a/src/store/descriptionOfWork/index.ts
+++ b/src/store/descriptionOfWork/index.ts
@@ -294,16 +294,12 @@ export class DescriptionOfWorkStore extends VuexModule {
   }
 
   public get canGetPreviousServiceOffering(): boolean {
-
     const currentOfferingIndex = this.currentOfferingIndex;
-
     return currentOfferingIndex >=0;
-    
   }
-  public get missingDOWRequirements(): boolean {
-    const selectedClassifications = ClassificationRequirements.selectedClassificationLevels;
-    const periods = Periods.periods;
-    return selectedClassifications.length === 0 || periods === null;
+
+  public get missingClassificationLevels(): boolean {
+    return ClassificationRequirements.selectedClassificationLevels.length === 0;;
   }
 
   public get selectedServiceOfferingGroups(): string[] {
@@ -328,6 +324,14 @@ export class DescriptionOfWorkStore extends VuexModule {
   public get currentOfferingGroupHasOfferings(): boolean {
     return this.serviceOfferingsForGroup.length > 0;
   }
+
+  public summaryBackToContractDetails = false;
+
+  @Mutation
+  public setBackToContractDetails(bool: boolean): void {
+    this.summaryBackToContractDetails = bool;
+  }
+
 
   @Mutation
   private setInitialized(value: boolean) {

--- a/src/store/steps/index.ts
+++ b/src/store/steps/index.ts
@@ -41,10 +41,10 @@ export class StepsStore extends VuexModule implements StepsState {
       if (step) {
         this.currentStep = step;
       }
-      if (this.altBackButtonText && this.currentStep) {
-        this.currentStep.backButtonText = this.altBackButtonText;
-      } else if (this.currentStep) {
-        this.currentStep.backButtonText = "Back";
+      if (this.currentStep) {
+        this.currentStep.backButtonText = this.altBackButtonText 
+          ? this.altBackButtonText 
+          : "Back";
       }
     }
 

--- a/src/store/steps/index.ts
+++ b/src/store/steps/index.ts
@@ -23,11 +23,23 @@ export class StepsStore extends VuexModule implements StepsState {
     
     stepMap: Map<string, StepInfo> = mapStepConfigs(stepperRoutes);
 
+    altBackButtonText = "";
+
+    @Mutation
+    public setBackButtonText(text: string): void {
+      this.altBackButtonText = text;
+    }
+
     @Mutation
     [Mutations.SET_CURRENT_STEP](stepName: string): void {
       const step = this.stepMap.get(stepName);
       if (step) {
         this.currentStep = step;
+      }
+      if (this.altBackButtonText && this.currentStep) {
+        this.currentStep.backButtonText = this.altBackButtonText;
+      } else if (this.currentStep) {
+        this.currentStep.backButtonText = "Back";
       }
     }
 

--- a/src/store/steps/index.ts
+++ b/src/store/steps/index.ts
@@ -26,8 +26,13 @@ export class StepsStore extends VuexModule implements StepsState {
     altBackButtonText = "";
 
     @Mutation
-    public setBackButtonText(text: string): void {
+    public setAltBackButtonText(text: string): void {
       this.altBackButtonText = text;
+    }
+
+    @Mutation
+    public clearAltBackButtonText(): void {
+      this.altBackButtonText = "";
     }
 
     @Mutation


### PR DESCRIPTION
1. If Classification Level missing:
    1. Clicking "Continue" from Service Offerings page goes to next selected Service Offerings page, or Summary page if at last Service Offerings page. 
    1. Clicking "Back" button from Summary page navigates to last Service Offerings page.  
    1. Clicking "Back" button from Service Offerings page navigates to previous selected service offerings page, or to Category page if at first Service Offering page. 
1. If PoP missing:  
    1. Clicking "Continue" from Service Offerings page with selection(s) made navigates to the Offering Details page. 
    1. If user selects "No" for "Is this requirement for the entire duration of your task order?" a disabled "Base period" checkbox is present with the existing alert with message and link to Contract Details. 
1. If no offerings checked on Service Offerings page and user clicks "Continue" button:
    1. The category remains in the list of selected categories. 
    1. Category is listed on the summary page with no description (list of selected offerings) with the "Missing info" alert and button "Review" 
1. If all service categories are selected, "Other available categories" header and rule below last category are not displayed on page. 	
1. If any category selected, user clicks main "Performance Requirements" link in stepper from another step:
    1. User goes to summary page 
    1. "Back" button text is "Back to Contract Details" which navigates to step 4 Contract Details.
    1. If user reviews/views/adds any category, "Back" button on Summary page text is "Back" and navigates back to either selected service offering (checkbox list) page if no offerings previously selected, or to the last service offering selected.