### PR TITLE
feature AT-7636 - Fixed back button text on summary page

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -391,7 +391,7 @@ export const OfferingDetailsPathResolver = (current: string, direction: string):
 }
 
 export const DowSummaryPathResolver = (current: string, direction: string): string =>{
-  DescriptionOfWork.setBackToContractDetails(false);
+  DescriptionOfWork.setBackToContractDetails(current === routeNames.PropertyDetails);
   Steps.clearAltBackButtonText();
 
   if(current === routeNames.PropertyDetails){

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -122,9 +122,9 @@
   </v-container>
 </template>
 <script lang="ts">
-import Vue from "vue";
 import { routeNames } from "../../../router/stepper"
-import { Component } from "vue-property-decorator";
+import { Component, Mixins } from "vue-property-decorator";
+import SaveOnLeave from "@/mixins/saveOnLeave";
 
 import classificationRequirements from "@/store/classificationRequirements";
 import ATATAlert from "@/components/ATATAlert.vue";
@@ -144,7 +144,8 @@ import { SystemChoiceDTO } from "@/api/models";
     DOWAlert,
   }
 })
-export default class Summary extends Vue {
+
+export default class Summary extends Mixins(SaveOnLeave) {
   private isPeriodsDataMissing = false;
   private isClassificationDataMissing = false;
   private showAlert = false;
@@ -352,5 +353,11 @@ export default class Summary extends Vue {
   public async mounted(): Promise<void> {
     await this.loadOnEnter();
   };
+
+  protected async saveOnLeave(): Promise<boolean> {
+    Steps.clearAltBackButtonText();
+    return true;
+  }
+
 };
 </script>


### PR DESCRIPTION
When user navigates from Summary page with back button text "Back to Contract Details" and clicks "Wrap up this section" button, back button text on GFE Property Details page remained "Back to Contract Details". Fixed to say "Back".

When on GFE Property Details page with back button text "Back" and user clicks back button, text on DOW Summary page remained as "Back" only. Should change to "Back to Contract Details"