### PR TITLE
Test - DOW - Navigation Workflows-Classification levels ,PoP details missing

### DIFF
--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoClassLevel.spec.js
@@ -1,0 +1,221 @@
+import { 
+  bootstrapMockApis,  
+  getCheckboxIds,   
+  getServiceOfferingNames,
+  getCheckboxId, 
+  getObjectFromArrayByKey, 
+  randomAlphaNumeric
+} from "../../../helpers";
+import common from "../../../selectors/common.sel";
+import contractDetails from "../../../selectors/contractDetails.sel";
+import performanceReqs from "../../../selectors/performanceReqs.sel";
+
+
+describe("Test suite: No Classification Levels Workflow Scenarios ", () => {
+  let serviceOfferingGroups; 
+  let periodCount=2
+  beforeEach(() => {
+    bootstrapMockApis();
+
+    cy.fixture("serviceOfferingGroups").then((data) => {
+      serviceOfferingGroups = data;
+    });
+    
+    cy.launchATAT();
+    cy.clickSideStepper(common.stepContractDetailsLink, " Contract Details ");
+    cy.verifyPageHeader(" Let’s gather some details about the duration of your task order ");  
+    
+    //Enter the Value for Base
+    cy.findElement(contractDetails.baseInputTxtBox).type("5");
+    cy.dropDownClick(contractDetails.baseDropdownIcon);
+    cy.findElement(contractDetails.baseDropdownMonth).click({ force: true });
+    //click on Add Option year 
+    cy.textExists(
+      contractDetails.addOptionLink,
+      "Add an option period"
+    ).click();
+    cy.findElement(contractDetails.optionalTextBox).type("4");   
+    cy.dropDownClick(contractDetails.optionDropdownIcon);
+    cy.findElement(contractDetails.optionDropdownMonth).click({ force: true });
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader("Do you want to request a PoP start date?");
+    cy.clickSideStepper(common.stepPerformanceReqText, " Performance Requirements ");
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");   
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  classification requirements are  missing. ");
+  });
+  const alertTxt = "You can continue to add cloud resources and" +
+      " support packages, but we won't be able to gather details about" +
+      " your unique requirements until we have this missing info." +
+      " We recommend updating your classification requirements in the" +
+      " Contract Details section before proceeding."
+  
+    
+  it("TC1: Click on Contract Details Link in Summary page", () => { 
+    let periodCount=2
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, alertTxt);
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const securityObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "SECURITY" 
+    );
+    
+    const secCheckBoxId = getCheckboxId(securityObj.value);      
+    cy.selectServiceOfferingGroup([secCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + securityObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]', securityObj.serviceOfferingCypressLabels);
+    
+    const labels = getServiceOfferingNames(securityObj);
+    const checkboxIds = getCheckboxIds(securityObj); 
+    const selectedServiceOffering = [labels[0], labels[1]]    
+    cy.selectCheckBoxes([checkboxIds[0],checkboxIds[1]]);
+    cy.btnClick(common.continueBtn, " Continue ");   
+    //Navigates directly to Summary page.
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  classification requirements are  missing. "
+    );
+    const alertInfo = "We cannot gather some details about your unique requirements at this time." +
+      " In order to finalize your performance requirements, you need to tell us about" +
+      " your classification requirements in the Contract Details section first."
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, alertInfo); 
+    cy.verifyTextMatches(performanceReqs.categoryNameHeader, securityObj.label);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, selectedServiceOffering);
+    cy.textExists(performanceReqs.missingInfo, "Missing info").should("exist");
+    cy.btnExists(performanceReqs.reviewbtn, " Review ");
+    cy.textExists(performanceReqs.otherCategories, "Other available categories");
+    cy.notAvailableCategory(securityObj.label);
+    cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
+    cy.verifyPageHeader(
+      "What classification level(s) will be required for your cloud resources and/or services?"
+    );
+    const selectedClassLevelsLabels = ["Unclassified / Impact Level 5 (IL5)"];  
+    cy.selectCheckBoxes([contractDetails.level5]);      
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    cy.findElement(performanceReqs.categoryAlertInfoTxt).should("not.exist");
+    cy.btnExists(performanceReqs.reviewbtn, " Review ").click();
+    cy.verifyPageHeader("What type of " + securityObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels(
+      'input[type=checkbox]:checked',
+      selectedServiceOffering
+    );
+    cy.btnClick(common.continueBtn, " Continue ");
+    //Navigates to Gather Requirements screen for selected Offering checkboxIds[0]
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[0]
+    ); 
+    const anticipatedReqText = randomAlphaNumeric(10)
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    cy.durationPeriodExists(
+      performanceReqs.durationYesRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "YES");      
+    cy.btnClick(common.continueBtn, " Continue "); 
+    //Navigates to gather screen for next offering selected
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[1]
+    );
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    cy.durationPeriodExists(
+      performanceReqs.durationNoRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "NO");
+    cy.periodCount(periodCount, performanceReqs.periodCheckboxRow1);
+    cy.selectCheckBoxes([performanceReqs.checkBoxBase]);    
+    cy.btnClick(common.continueBtn, " Continue "); 
+    //navigate to Summary page
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    ); 
+    cy.findElement(performanceReqs.missingInfo).should("not.exist");    
+  });
+
+  it("TC2: Click on ContractDetails Link in Performance Requirement page", () => {   
+    cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
+    const selectedClassLevelsLabels = [
+      "Unclassified / Impact Level 5 (IL5)",
+      "Secret / Impact Level 6 (IL6)"
+    ];
+    cy.selectCheckBoxes([contractDetails.level5,contractDetails.level6]);     
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    cy.btnClick(common.continueBtn, " Continue ");    
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");
+    cy.findElement(performanceReqs.categoryAlertheading).should("not.exist");    
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const trainingObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "TRAINING" 
+    );
+    
+    const trainCheckBoxId = getCheckboxId(trainingObj.value);    
+    cy.selectServiceOfferingGroup([trainCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + trainingObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',trainingObj.serviceOfferingCypressLabels);
+    
+    const labels = getServiceOfferingNames(trainingObj);
+    const checkboxIds = getCheckboxIds(trainingObj);
+    const selectedServiceOffering = [labels[2]]
+    cy.selectCheckBoxes([checkboxIds[2]]);
+    cy.btnClick(common.continueBtn, " Continue ");
+    //Navigates to the Gather your requirement screen
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[2]
+    );     
+    
+    cy.selectCheckBoxes([contractDetails.level5])
+      .then(() => {
+        cy.findElement(performanceReqs.offeringDetailform).scrollIntoView().should("be.visible");
+        
+      });
+    //enter the exist in the text box
+    const anticipatedReqText = randomAlphaNumeric()
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    
+    cy.durationPeriodExists(performanceReqs.durationNoRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "NO");
+    cy.periodCount(periodCount, performanceReqs.periodCheckboxRow1);
+    cy.selectCheckBoxes([performanceReqs.checkBoxBase]);
+    cy.btnClick(common.continueBtn, " Continue "); 
+    //navigate to Summary page
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    ); 
+    cy.verifyTextMatches(
+      performanceReqs.categoryNameHeader,
+      trainingObj.label);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, selectedServiceOffering);
+    
+  });
+  
+});

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoClassLevel.spec.js
@@ -151,7 +151,7 @@ describe("Test suite: No Classification Levels Workflow Scenarios ", () => {
     cy.findElement(performanceReqs.missingInfo).should("not.exist");    
   });
 
-  it("TC2: Click on ContractDetails Link in Performance Requirement page", () => {   
+  it("TC2: Click on Contract Details Link in Performance Requirement page", () => {   
     cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
     const selectedClassLevelsLabels = [
       "Unclassified / Impact Level 5 (IL5)",

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoPoP.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoPoP.spec.js
@@ -1,0 +1,312 @@
+import { 
+  bootstrapMockApis,  
+  getCheckboxIds,   
+  getServiceOfferingNames,
+  getCheckboxId, 
+  getObjectFromArrayByKey, 
+  randomAlphaNumeric
+} from "../../../helpers";
+import common from "../../../selectors/common.sel";
+import contractDetails from "../../../selectors/contractDetails.sel";
+import performanceReqs from "../../../selectors/performanceReqs.sel";
+
+
+describe("Test suite: No PoP Workflow Scenarios ", () => {
+  let serviceOfferingGroups;   
+
+  beforeEach(() => {
+    bootstrapMockApis();
+
+    cy.fixture("serviceOfferingGroups").then((data) => {
+      serviceOfferingGroups = data;
+    });
+    
+    cy.launchATAT();
+    cy.clickSideStepper(common.stepContractDetailsLink, " Contract Details ");
+    cy.verifyPageHeader(" Let’s gather some details about the duration of your task order "); 
+    cy.textExists(common.subStepClassReqsLink, " Classification Requirements ").click();
+  });
+    
+  it("TC1: Click on PoP link in GatherRequirement page", () => {    
+    
+    const selectedClassLevelsLabels = [
+      "Unclassified / Impact Level 5 (IL5)",
+      "Secret / Impact Level 6 (IL6)"     
+    ];    
+    
+    cy.selectCheckBoxes([contractDetails.level5,contractDetails.level6]);    
+    
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    
+    cy.btnClick(common.continueBtn, " Continue ");    
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");         
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance is  missing. "
+    );
+    const alertInfo = "You can continue to add cloud resources" +
+      " and support packages, but we won't be able to gather details" +
+      " about your unique requirements until we have this missing info." +
+      " We recommend updating your PoP in the Contract Details" +
+      " section before proceeding.";
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, alertInfo); 
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const networkObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "NETWORKING" 
+    );
+    
+    const networkCheckBoxId = getCheckboxId(networkObj.value);    
+    cy.selectServiceOfferingGroup([networkCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + networkObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',networkObj.serviceOfferingCypressLabels);
+    
+    const labels = getServiceOfferingNames(networkObj);
+    const checkboxIds = getCheckboxIds(networkObj);
+    
+    cy.selectCheckBoxes([checkboxIds[1]]);
+    cy.btnClick(common.continueBtn, " Continue ");
+    //Navigates to the Gather your requirement screen
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[1]
+    );
+    const selectedClassBox = ["Unclassified/IL5 instance"]
+    cy.selectCheckBoxes([contractDetails.level5])
+      .then(() => {
+        cy.findElement(performanceReqs.offeringDetailform).scrollIntoView().should("be.visible");
+        
+      });
+    cy.verifyTextMatches(
+      performanceReqs.requirmentHeading1,
+      "1. Tell us about the "  + selectedClassBox);
+
+    //enter the exist in the text box
+    const anticipatedReqText = randomAlphaNumeric(10)
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    
+    cy.durationPeriodExists(performanceReqs.durationNoRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "NO");
+    cy.findElement(performanceReqs.baseCheckbox1Disabled).should("exist")
+      .and("be.disabled");
+    cy.findElement(performanceReqs.alertPeriod1Text).should("be.visible");
+    const alertText = "Your period of performance details are missing." +
+      " To select specific base or option periods for this requirement," +
+      " revisit the Contract Details section"
+    cy.verifyTextMatches(performanceReqs.alertPeriod1Text,
+      alertText);
+      
+    cy.textExists(performanceReqs.contractDtailsLink, "revisit the Contract Details section ")
+      .click();
+    cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
+    cy.findElement(contractDetails.baseInputTxtBox).type("12");
+    cy.dropDownClick(contractDetails.baseDropdownIcon);
+    cy.findElement(contractDetails.baseDropdownMonth).click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader("Do you want to request a PoP start date?");
+    cy.radioBtn(contractDetails.popStartDateNoRadioOption, "NO").click({ force: true });
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(" Will this be a future recurring requirement? ");
+    cy.radioBtn(contractDetails.yesRadioOption,  "YES").not("[disabled]").click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader( " Which contract type(s) apply to this acquisition? ");
+    cy.findCheckBox(contractDetails.ffpCheckBox, "FFP").should("not.be.checked")
+      .check({ force: true });
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(
+      " What classification level(s) will be required for your cloud resources and/or services? "
+    );
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    cy.btnExists(common.backBtn, "Back to Contract Details");
+  });
+
+  it("TC2: Click on PoP link in Performance Requirement page", () => {
+  
+    const selectedClassLevelsLabels = [
+      "Unclassified / Impact Level 4 (IL4)",      
+    ];    
+    
+    cy.selectCheckBoxes([contractDetails.level4]);    
+    
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    
+    cy.btnClick(common.continueBtn, " Continue ");    
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");         
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance is  missing. "
+    );
+    
+    cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
+    cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
+    cy.findElement(contractDetails.baseInputTxtBox).type("12");
+    cy.dropDownClick(contractDetails.baseDropdownIcon);
+    cy.findElement(contractDetails.baseDropdownMonth).click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader("Do you want to request a PoP start date?");
+    cy.clickSideStepper(common.stepPerformanceReqText, " Performance Requirements ");
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const trainingObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "TRAINING" 
+    );
+    
+    const trainCheckBoxId = getCheckboxId(trainingObj.value);    
+    cy.selectServiceOfferingGroup([trainCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + trainingObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',trainingObj.serviceOfferingCypressLabels);
+    
+    const labels = getServiceOfferingNames(trainingObj);
+    const checkboxIds = getCheckboxIds(trainingObj);
+    const selectedServiceOffering = [labels[0]]
+    cy.selectCheckBoxes([checkboxIds[0]]);
+    cy.btnClick(common.continueBtn, " Continue ");
+    //Navigates to the Gather your requirement screen
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[0]
+    );     
+
+    //enter the exist in the text box
+    const anticipatedReqText = randomAlphaNumeric()
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    
+    cy.durationPeriodExists(performanceReqs.durationNoRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "NO");
+    cy.findElement(performanceReqs.checkBoxBase).should("exist")
+      .and("not.be.disabled");
+    cy.selectCheckBoxes([performanceReqs.checkBoxBase]);    
+    cy.btnClick(common.continueBtn, " Continue "); 
+    //navigate to Summary page
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    ); 
+    cy.findElement(performanceReqs.missingInfo).should("not.exist"); 
+    cy.verifyTextMatches(
+      performanceReqs.categoryNameHeader,
+      trainingObj.label);
+    cy.notAvailableCategory(trainingObj.label);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, selectedServiceOffering);
+  });
+
+  it("TC3: Click on PoP link in Summary page", () => {
+    
+    const selectedClassLevelsLabels = [
+      "Unclassified / Impact Level 2 (IL2)",      
+    ];    
+    
+    cy.selectCheckBoxes([contractDetails.level2]);    
+    
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    
+    cy.btnClick(common.continueBtn, " Continue ");    
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");         
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance is  missing. "
+    );
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const iotObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "IOT"
+    );
+    
+    const iotCheckBoxId = getCheckboxId(iotObj.value);    
+    cy.selectServiceOfferingGroup([iotCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + iotObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',iotObj.serviceOfferingCypressLabels);
+    
+    const labels = getServiceOfferingNames(iotObj);
+    const checkboxIds = getCheckboxIds(iotObj);
+    const selectedServiceOffering = [labels[1]]
+    cy.selectCheckBoxes([checkboxIds[1]]);
+    cy.btnClick(common.continueBtn, " Continue ");
+    //Navigates to the Gather your requirement screen
+    cy.verifyPageHeader(
+      "Next, we’ll gather your requirements for " + labels[1]
+    );     
+
+    //enter the exist in the text box
+    const anticipatedReqText = randomAlphaNumeric()
+    cy.enterTextInTextField(
+      performanceReqs.anticipatedTextBox1,
+      anticipatedReqText
+    );
+    
+    cy.durationPeriodExists(performanceReqs.durationNoRadioBtn,
+      performanceReqs.duration1ActiveRadioBtn,
+      performanceReqs.periodCheckboxLabel1,
+      "NO");
+    cy.findElement(performanceReqs.baseCheckbox1Disabled).should("exist")
+      .and("be.disabled");
+    cy.findElement(performanceReqs.alertPeriod1Text).should("be.visible");
+    const alertText = "Your period of performance details are missing." +
+      " To select specific base or option periods for this requirement," +
+      " revisit the Contract Details section"
+    cy.verifyTextMatches(performanceReqs.alertPeriod1Text,
+      alertText);
+      
+    cy.textExists(performanceReqs.contractDtailsLink, "revisit the Contract Details section ");
+    cy.btnClick(common.continueBtn, " Continue "); 
+    //navigate to Summary page
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );   
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance is  missing. "
+    );
+    const alertInfo = "We cannot gather some details about your" +
+      " unique requirements at this time." +
+      " In order to finalize your performance requirements," +
+      " you need to tell us about your PoP in the Contract Details section first."
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, alertInfo);    
+    cy.textExists(performanceReqs.missingInfo, "Missing info").should("exist");
+    cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
+    cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
+    cy.findElement(contractDetails.baseInputTxtBox).type("12");
+    cy.dropDownClick(contractDetails.baseDropdownIcon);
+    cy.findElement(contractDetails.baseDropdownMonth).click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader("Do you want to request a PoP start date?");
+    cy.clickSideStepper(common.stepPerformanceReqText, " Performance Requirements ");
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    cy.findElement(performanceReqs.categoryAlertheading).should("not.exist");
+    cy.verifyTextMatches(
+      performanceReqs.categoryNameHeader,
+      iotObj.label);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, selectedServiceOffering);
+    cy.notAvailableCategory(iotObj.label);
+  });
+
+    
+
+});

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
@@ -1,0 +1,155 @@
+import { 
+  bootstrapMockApis, 
+  getCheckboxIds,   
+  getServiceOfferingNames,
+  getCheckboxId, 
+  getObjectFromArrayByKey 
+} from "../../../helpers";
+import common from "../../../selectors/common.sel";
+import contractDetails from "../../../selectors/contractDetails.sel";
+import performanceReqs from "../../../selectors/performanceReqs.sel";
+
+
+describe("Test suite: No PoP and Classification Levels exists workflows", () => {
+  let serviceOfferingGroups;
+  const prAlertInfoMessage = "You can continue to add cloud resources" +
+      " and support packages, but we won't be able to gather details" +
+      " about your unique requirements until we have this missing info." +
+      " We recommend revisiting the Contract Details section before proceeding.";
+  let summaryAlertInfo = "We cannot gather some details about your unique" +
+      " requirements at this time. In order to finalize your" +
+      " performance requirements, you need to tell us about your" +
+      " PoP and classification requirements in the Contract Details section first."
+  beforeEach(() => {
+    bootstrapMockApis();
+
+    cy.fixture("serviceOfferingGroups").then((data) => {
+      serviceOfferingGroups = data;
+    });
+    cy.launchATAT();
+    cy.clickSideStepper(common.stepPerformanceReqText, " Performance Requirements ");
+    cy.verifyPageHeader(" Let’s work on your performance requirements ");         
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance and classification requirements are  missing. "
+    );
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, prAlertInfoMessage); 
+    cy.textExists(performanceReqs.contractDetailsLink, " revisiting the Contract Details section");
+  });  
+  
+  it("TC1: Navigation to summary without PoP and Classification levels ", () => {
+    
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const edgeObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "EDGECOMPUTING" 
+    );
+    const labels = getServiceOfferingNames(edgeObj);
+    const edgeCheckBoxId = getCheckboxId(edgeObj.value);    
+    cy.selectServiceOfferingGroup([edgeCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + edgeObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',edgeObj.serviceOfferingCypressLabels);    
+    const checkboxIds = getCheckboxIds(edgeObj);
+    
+    cy.selectCheckBoxes([checkboxIds[0],checkboxIds[1]]);
+    cy.btnClick(common.continueBtn, " Continue ");   
+    //Navigates directly to Summary page.
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance and classification requirements are  missing. "
+    );
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, summaryAlertInfo);
+    cy.verifyTextMatches(performanceReqs.categoryNameHeader, edgeObj.label);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, labels);
+    cy.textExists(performanceReqs.missingInfo, "Missing info").should("exist");
+    cy.btnExists(performanceReqs.reviewbtn, " Review ");
+    cy.textExists(performanceReqs.otherCategories, "Other available categories");
+    cy.notAvailableCategory(edgeObj.label);
+    cy.textExists(performanceReqs.contractDetailsLink, "Contract Details section").click();
+    cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
+    cy.findElement(contractDetails.baseInputTxtBox).type("24");
+    cy.dropDownClick(contractDetails.baseDropdownIcon);
+    cy.findElement(contractDetails.baseDropdownMonth).click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader("Do you want to request a PoP start date?");
+    cy.radioBtn(contractDetails.popStartDateNoRadioOption, "NO").click({ force: true });
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(" Will this be a future recurring requirement? ");
+    cy.radioBtn(contractDetails.yesRadioOption,  "YES").not("[disabled]").click({force: true});
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader( " Which contract type(s) apply to this acquisition? ");
+    cy.findCheckBox(contractDetails.ffpCheckBox, "FFP").should("not.be.checked")
+      .check({ force: true });
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(
+      " What classification level(s) will be required for your cloud resources and/or services? "
+    );
+    const selectedClassLevelsLabels = ["Unclassified / Impact Level 5 (IL5)"];  
+    cy.selectCheckBoxes([contractDetails.level5]);      
+    cy.verifyCheckBoxLabels('input[type=checkbox]:checked', selectedClassLevelsLabels);
+    cy.btnClick(common.continueBtn, " Continue ");
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );
+    cy.findElement(performanceReqs.missingInfo).should("not.exist");
+
+  });
+
+  it("TC2: Navigate to next Step6 in the middle of Workflow ", () => {
+    
+    const expectedLabels = [];
+    serviceOfferingGroups.forEach((obj) => {
+      expectedLabels.push(obj.label);
+    });    
+    cy.verifyCheckBoxLabels('input[type=checkbox]', expectedLabels);
+
+    const adObj = getObjectFromArrayByKey(
+      serviceOfferingGroups, "value", "ADVISORY" 
+    );
+    const adCheckBoxId = getCheckboxId(adObj.value);    
+    cy.selectServiceOfferingGroup([adCheckBoxId]);    
+    //Navigates to the next page
+    cy.verifyPageHeader("What type of " + adObj.label + " do you need?");             
+    cy.verifyCheckBoxLabels('input[type=checkbox]',adObj.serviceOfferingCypressLabels);    
+    cy.clickSideStepper(common.stepGovFurEquipLink, " Government Furnished Equipment ");
+    cy.verifyPageHeader(
+      " Will government equipment be furnished, provided or acquired under this acquisition? "
+    );
+    cy.btnClick(common.backBtn, "Back");   
+    //Navigates directly to Summary page.
+    cy.verifyPageHeader(
+      "Your Performance Requirements"
+    );    
+    cy.textExists(
+      performanceReqs.categoryAlertheading,
+      "Your  period of performance and classification requirements are  missing. "
+    );
+    cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, summaryAlertInfo);
+    cy.verifyTextMatches(performanceReqs.categoryNameHeader, adObj.label);
+    cy.findElement(performanceReqs.serviceOfferingLabels).should("not.to.be.visible");
+    cy.textExists(performanceReqs.missingInfo, "Missing info").should("exist");
+    cy.btnExists(performanceReqs.reviewbtn, " Review ");
+    cy.textExists(performanceReqs.otherCategories, "Other available categories");
+    cy.notAvailableCategory(adObj.label);
+    cy.findElement(common.footerLinks).scrollIntoView();
+    cy.findElement(common.backBtn).then((el) => {
+      console.log(el)
+    })
+    cy.contains("Back to Contract Details")
+      .click( { force: true });
+    
+    cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
+    
+  });
+  
+  
+});

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
@@ -140,16 +140,10 @@ describe("Test suite: No PoP and Classification Levels exists workflows", () => 
     cy.btnExists(performanceReqs.reviewbtn, " Review ");
     cy.textExists(performanceReqs.otherCategories, "Other available categories");
     cy.notAvailableCategory(adObj.label);
-    cy.findElement(common.footerLinks).scrollIntoView();
-    cy.findElement(common.backBtn).then((el) => {
-      console.log(el)
-    })
-    cy.contains("Back to Contract Details")
-      .click( { force: true });
-    
+    cy.findElement(common.footerLinks).scrollIntoView();    
+    cy.contains("Back to Contract Details").click( { force: true });
     cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
     
-  });
-  
+  });  
   
 });

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
@@ -142,7 +142,7 @@ describe("Test suite: No PoP and Classification Levels exists workflows", () => 
     cy.textExists(performanceReqs.otherCategories, "Other available categories");
     cy.notAvailableCategory(adObj.label);
     cy.findElement(common.footerLinks).scrollIntoView();    
-    cy.contains("Back to Contract Details").click( { force: true });
+    cy.btnClick(common.backBtn, "Back to Contract Details");
     cy.verifyPageHeader("Let’s gather some details about the duration of your task order");
     
   });  

--- a/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
+++ b/cypress/integration/ATATDevSnow/DOWScenarios/NoPoPClassLevel.spec.js
@@ -49,7 +49,8 @@ describe("Test suite: No PoP and Classification Levels exists workflows", () => 
       serviceOfferingGroups, "value", "EDGECOMPUTING" 
     );
     const labels = getServiceOfferingNames(edgeObj);
-    const edgeCheckBoxId = getCheckboxId(edgeObj.value);    
+    const edgeCheckBoxId = getCheckboxId(edgeObj.value);
+    const selectedServiceOfferings = [labels[0], labels[1]]  
     cy.selectServiceOfferingGroup([edgeCheckBoxId]);    
     //Navigates to the next page
     cy.verifyPageHeader("What type of " + edgeObj.label + " do you need?");             
@@ -69,7 +70,7 @@ describe("Test suite: No PoP and Classification Levels exists workflows", () => 
     );
     cy.verifyTextMatches(performanceReqs.categoryAlertInfoTxt, summaryAlertInfo);
     cy.verifyTextMatches(performanceReqs.categoryNameHeader, edgeObj.label);
-    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, labels);
+    cy.verifyListMatches(performanceReqs.serviceOfferingLabels, selectedServiceOfferings);
     cy.textExists(performanceReqs.missingInfo, "Missing info").should("exist");
     cy.btnExists(performanceReqs.reviewbtn, " Review ");
     cy.textExists(performanceReqs.otherCategories, "Other available categories");

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -111,6 +111,39 @@ Cypress.Commands.add("launchATAT", () => {
     .its("sessionStorage")
     .invoke("getItem", "ATAT_ACQUISTION_PACKAGE_KEY")
     .should("exist");
+
+  // ==========================================================================
+  // KEEP FOR LOCAL TESTING TO NOT LOG DATA IN CYPRESS RUNNER
+  // UNCOMMENT THIS BLOCK AND COMMENT OUT THE sessionStorage CODE ABOVE
+  // ==========================================================================
+  // //eslint-disable-next-line cypress/no-unnecessary-waiting
+  // cy.window().wait(1000)
+  //   .its("sessionStorage").invoke("getItem", "ATAT_CONTACT_DATA_KEY")
+  //   .then(data => {
+  //     cy.wrap(JSON.parse(data)).its("branchChoices").should("exist")
+  //       // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //       .then(() => cy.window().wait(1000).its("sessionStorage")
+  //         .invoke("getItem", "ATAT_ORGANIZATION_DATA_KEY")
+  //         .then(data => {
+  //           cy.wrap(JSON.parse(data)).its("service_agency_data").should("exist")
+  //             // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //             .then(() => cy.window().wait(1000).its("sessionStorage")
+  //               .invoke("getItem", "ATAT_DESCRIPTION_OF_WORK_KEY")
+  //               .then(data => {
+  //                 cy.wrap(JSON.parse(data)).its("serviceOfferings").should("exist")
+  //                   // eslint-disable-next-line cypress/no-unnecessary-waiting
+  //                   .then(() => cy.window().wait(1000).its("sessionStorage")
+  //                     .invoke("getItem", "ATAT_ACQUISTION_PACKAGE_KEY")
+  //                     .then(data => {
+  //                       cy.wrap(JSON.parse(data)).its("acorInfo").should("exist")
+  //                     })
+  //                   )
+  //               })
+  //             )
+  //         })
+  //       )
+  //   })
+
 });
 
 Cypress.Commands.add("clearSession", () => {
@@ -163,8 +196,13 @@ Cypress.Commands.add('btnExists', (selector, text) => {
 });
 
 Cypress.Commands.add('btnClick', (selector, text) => {
-  cy.findElement(selector).scrollIntoView()
-    .not("[disabled]").and("have.text", text).click()  
+  cy.findElement(selector).then((el) => {
+    if (el.length > 1) {
+      el = el[0]
+    }
+    cy.wrap(el).scrollIntoView()
+      .not("[disabled]").and("have.text", text).click()
+  });
 });
 
 Cypress.Commands.add("clickLink", (selector) => {


### PR DESCRIPTION
DOW expected navigation behavior.

1. If Classification Level missing:

    a. Clicking "Continue" from Service Offerings page goes to next selected Service Offerings page, or Summary page if at last 
         Service Offerings page. 

    b. Clicking "Contract Details Section" link  in  Summary page navigates to last Classification Levels page.  

   c. Select the Classification level, then Clicking "Continue " button navigates to Summary page  page. 

2. If PoP missing:  

   a. Clicking "Continue" from Service Offerings page with selection(s) made navigates to the Offering Details page. 

   b. If user selects "No" for "Is this requirement for the entire duration of your task order?" a disabled "Base period" checkbox is 
      present with the existing alert with message and link to Contract Details. 

  c. If user clicks link in yellow warning, navigates to Contract Details POP screen page.

  d.  Enter the POP details, click on “Continue” button , navigates to summary view.

3.  If PoP missing & Classification Level:  

       a. Clicking "Continue" from Service Offerings page with selection(s) made navigates to the Offering Details page. 

      b. If user selects "No" for "Is this requirement for the entire duration of your task order?" a disabled "Base period" checkbox is present with the   existing alert with message and link to Contract Details. 

    c. If user clicks link in yellow warning, navigates to Contract Details POP screen page.

   d.  Enter the POP details, click on “Continue” button , navigates to summary view.



AT-7648