### PR TITLE
Fix IFP nav if no base period

### DIFF
--- a/src/steps/10-FinancialDetails/SeverabilityAndIncrementalFunding.vue
+++ b/src/steps/10-FinancialDetails/SeverabilityAndIncrementalFunding.vue
@@ -245,12 +245,15 @@ export default class SeverabilityAndIncrementalFunding extends Mixins(SaveOnLeav
   }
 
   public get PoPUnder9Months(): boolean {
-    return AcquisitionPackage.totalBasePoPDuration < 270
+    return AcquisitionPackage.totalBasePoPDuration < 270 
+      && AcquisitionPackage.totalBasePoPDuration > 0;
   }
 
   public get basePeriod(): string {
-    return `${this.base.period_unit_count} ${this.base.period_unit.toLowerCase()}`
-
+    const hasBasePeriod = this.base && this.base.period_unit_count && this.base.period_unit;
+    return hasBasePeriod
+      ? `${this.base.period_unit_count} ${this.base.period_unit.toLowerCase()}`
+      : ""
   }
 
   public async loadOnEnter(): Promise<void> {


### PR DESCRIPTION
If no base period entered, user was seeing the blue alert saying don't qualify for incremental funding. Fix shows the yes/no radios, and if select yes, then show the warning alert indicating need to set base period.