### PR TITLE
Feature/at 7664 spend summary

### DIFF
--- a/src/components/charts/DonutChart.vue
+++ b/src/components/charts/DonutChart.vue
@@ -20,6 +20,7 @@ export default class DonutChart extends Vue {
   @Prop({ required: false, default: "" }) public centerText1!: string;
   @Prop({ required: false, default: "" }) public centerText2!: string;
   @Prop({ required: false, default: "" }) public amount!: number;
+  @Prop({ required: false, default: true }) public showHoverLegend!: boolean;
 
   private myChart!: Chart;
 
@@ -30,13 +31,15 @@ export default class DonutChart extends Vue {
   }
 
   private mounted() {
-    const toolTipExternalOptions = {
-      enabled: false,
-      position: "nearest",
-      external: this.externalTooltipHandler,
-    };
+    if (this.showHoverLegend) {
+      const toolTipExternalOptions = {
+        enabled: false,
+        position: "nearest",
+        external: this.externalTooltipHandler,
+      };
 
-    this.chartOptions.plugins.tooltip = toolTipExternalOptions;
+      this.chartOptions.plugins.tooltip = toolTipExternalOptions;
+    }
 
     this.createChart();
   }

--- a/src/components/icons/ATATSVGIcon.vue
+++ b/src/components/icons/ATATSVGIcon.vue
@@ -75,6 +75,7 @@ export default class ATATSVGIcon extends Vue {
     { "primary": "544496" },
     { "info": "009ddd" },
     { "success": "62bd59" },
+    { "success-dark": "498e43" },    
     { "error": "c60634" },
     { "disabled": "c9c9c9" },
     { "disabled-dark": "adadad"},

--- a/src/components/icons/ATATSVGIcon.vue
+++ b/src/components/icons/ATATSVGIcon.vue
@@ -22,8 +22,10 @@ import ExclamationMark from "@/components/icons/ExclamationMark.vue";
 import FilePresent from "@/components/icons/FilePresent.vue";
 import MonetizationOn from "@/components/icons/MonetizationOn.vue";
 import Pdf from "@/components/icons/Pdf.vue";
-import Search from "@/components/icons/Search.vue";
 import Remove from "@/components/icons/Remove.vue";
+import Search from "@/components/icons/Search.vue";
+import TrendingDown from "@/components/icons/TrendingDown.vue";
+import TrendingUp from "@/components/icons/TrendingUp.vue";
 import UploadFile from "@/components/icons/UploadFile.vue";
 
 @Component({
@@ -38,6 +40,8 @@ import UploadFile from "@/components/icons/UploadFile.vue";
     Pdf,
     Remove,
     Search,
+    TrendingDown,
+    TrendingUp,
     UploadFile,
   }
 })

--- a/src/components/icons/TrendingDown.vue
+++ b/src/components/icons/TrendingDown.vue
@@ -16,6 +16,6 @@ import { Component, Prop } from "vue-property-decorator";
 
 @Component({})
 export default class TrendingDown extends Vue {
-  @Prop({default: "498e43", required: true}) private color!:string;
+  @Prop({ default: "498e43", required: false }) private color!:string;
 }
 </script>

--- a/src/components/icons/TrendingDown.vue
+++ b/src/components/icons/TrendingDown.vue
@@ -1,0 +1,21 @@
+<template>
+  <svg viewBox="0 0 20 13" xmlns="http://www.w3.org/2000/svg">
+
+    <!-- eslint-disable -->
+    <path d="M14 12.8267L16.29 10.5367L11.41 5.65666L7.41 9.65666L0 2.23666L1.41 0.82666L7.41 6.82666L11.41 2.82666L17.71 9.11666L20 6.82666V12.8267H14Z"
+      :fill="'#' + color"
+    />
+    <!-- eslint-enable -->
+
+  </svg>
+</template>
+
+<script lang='ts'>
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+@Component({})
+export default class TrendingDown extends Vue {
+  @Prop({default: "498e43", required: true}) private color!:string;
+}
+</script>

--- a/src/components/icons/TrendingUp.vue
+++ b/src/components/icons/TrendingUp.vue
@@ -16,6 +16,6 @@ import { Component, Prop } from "vue-property-decorator";
 
 @Component({})
 export default class TrendingUp extends Vue {
-  @Prop({default: "c60634", required: true}) private color!:string;
+  @Prop({ default: "c60634", required: false }) private color!:string;
 }
 </script>

--- a/src/components/icons/TrendingUp.vue
+++ b/src/components/icons/TrendingUp.vue
@@ -1,0 +1,21 @@
+<template>
+  <svg viewBox="0 0 20 13" xmlns="http://www.w3.org/2000/svg">
+
+    <!-- eslint-disable -->
+    <path d="M14 0.82666L16.29 3.11666L11.41 7.99666L7.41 3.99666L0 11.4167L1.41 12.8267L7.41 6.82666L11.41 10.8267L17.71 4.53666L20 6.82666V0.82666H14Z" 
+      :fill="'#' + color"
+    />
+    <!-- eslint-enable -->
+
+  </svg>
+</template>
+
+<script lang='ts'>
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+@Component({})
+export default class TrendingUp extends Vue {
+  @Prop({default: "c60634", required: true}) private color!:string;
+}
+</script>

--- a/src/dashboards/Portfolio.vue
+++ b/src/dashboards/Portfolio.vue
@@ -175,6 +175,7 @@
                             height="13"
                             color="error"
                           />
+                          {{ lastMonthSpendPercent }}%
                         </v-card>
                       </v-col>
                       <v-col>
@@ -368,6 +369,7 @@ export default class PortfolioDashboard extends Vue {
   public monthlySpendAverageStr = "";
   public lastMonthSpend = 0;
   public lastMonthSpendStr = "";
+  public lastMonthSpendPercent = 0;
   public endOfMonthForecast = 0;
   public endOfMonthForecastStr = "";
   public endOfMonthForecastPercent = 0;
@@ -462,9 +464,9 @@ export default class PortfolioDashboard extends Vue {
       clinCosts[clinNo] = clinValues;
     });
     
-    this.endOfMonthForecastPercent 
-      = Math.round((Number(
-        (this.endOfMonthForecast / this.totalPortfolioFunds).toFixed(3)) * 100) * 10) / 10;
+    // this.endOfMonthForecastPercent 
+    //   = Math.round((Number(
+    //     (this.endOfMonthForecast / this.totalPortfolioFunds).toFixed(3)) * 100) * 10) / 10;
 
     this.estimatedRemainingPercent 
       // = 100 - this.endOfMonthForecastPercent - this.fundsSpentPercent;
@@ -583,10 +585,16 @@ export default class PortfolioDashboard extends Vue {
       const twoMoAgoAmt = monthsWithSpend[len - 2];
       const lastMoAmt = monthsWithSpend[len - 1];
       if (twoMoAgoAmt && lastMoAmt) {
+        // EJY LAST MONTH SPEND
         this.lastMonthSpend = twoMoAgoAmt - lastMoAmt;
         this.lastMonthSpendStr = toCurrencyString(this.lastMonthSpend);
+        this.lastMonthSpendPercent 
+          = Math.round(this.lastMonthSpend / this.monthlySpendAverage * 100) / 100;
       }
     }
+
+    this.endOfMonthForecastPercent 
+      = Math.round(this.endOfMonthForecast / this.monthlySpendAverage * 100) / 100;
 
     debugger;
 

--- a/src/dashboards/Portfolio.vue
+++ b/src/dashboards/Portfolio.vue
@@ -204,7 +204,7 @@
                               label="PeriodToDate"
                             />
                             </div>
-                          <span class="h1 d-block">${{ lastMonthSpendStr }}</span>
+                          <span class="h1 d-block">${{ fundsSpentStr }}</span>
                         </v-card>
 
                       </v-col>
@@ -375,10 +375,11 @@ export default class PortfolioDashboard extends Vue {
   public endOfMonthForecastPercent = 0;
   public estimatedRemainingPercent = 0;
 
-
   public taskOrder: TaskOrderDTO = TaskOrder.value;
   public costs: CostsDTO[] = [];
   public clins: ClinDTO[] = [];
+
+  public clinSpending: Record<string, string>[] = [];
 
   public chartDataColors = ATATCharts.chartDataColors;
   public chartDataColorSequence = ATATCharts.chartDataColorSequence;
@@ -397,7 +398,9 @@ export default class PortfolioDashboard extends Vue {
 
   public async calculateFundsSpent(): Promise<void> {
     this.costs.forEach((cost) => {
-      this.fundsSpent = this.fundsSpent + parseFloat(cost.value);
+      if (cost.is_actual === "true") {
+        this.fundsSpent = this.fundsSpent + parseFloat(cost.value);
+      }
     });
   }
 
@@ -464,9 +467,9 @@ export default class PortfolioDashboard extends Vue {
       clinCosts[clinNo] = clinValues;
     });
     
-    // this.endOfMonthForecastPercent 
-    //   = Math.round((Number(
-    //     (this.endOfMonthForecast / this.totalPortfolioFunds).toFixed(3)) * 100) * 10) / 10;
+    this.endOfMonthForecastPercent 
+      = Math.round((Number(
+        (this.endOfMonthForecast / this.totalPortfolioFunds).toFixed(3)) * 100) * 10) / 10;
 
     this.estimatedRemainingPercent 
       // = 100 - this.endOfMonthForecastPercent - this.fundsSpentPercent;
@@ -575,26 +578,23 @@ export default class PortfolioDashboard extends Vue {
         }
       }
     });
+    debugger;
+    // EJY come back to this - populate clinSpending
+    // uniqueIdiqClins.forEach((idiqClinNo) => {
+    //   actualBurn.forEach((idiqClinNo) => {
+    //     this.clinSpending[idiqClinNo]
+    //   });
+    // })
 
     totalProjectedBurnData.push(0);
+
     const monthsWithSpend = totalActualBurnData.filter(amt => amt !== null);
     const len = monthsWithSpend.length;
     this.monthlySpendAverage = Math.round(this.fundsSpent / len * 100) / 100;
     this.monthlySpendAverageStr = "$" + toCurrencyString(this.monthlySpendAverage);
-    if (monthsWithSpend && len > 1) {
-      const twoMoAgoAmt = monthsWithSpend[len - 2];
-      const lastMoAmt = monthsWithSpend[len - 1];
-      if (twoMoAgoAmt && lastMoAmt) {
-        // EJY LAST MONTH SPEND
-        this.lastMonthSpend = twoMoAgoAmt - lastMoAmt;
-        this.lastMonthSpendStr = toCurrencyString(this.lastMonthSpend);
-        this.lastMonthSpendPercent 
-          = Math.round(this.lastMonthSpend / this.monthlySpendAverage * 100) / 100;
-      }
-    }
 
-    this.endOfMonthForecastPercent 
-      = Math.round(this.endOfMonthForecast / this.monthlySpendAverage * 100) / 100;
+    // this.endOfMonthForecastPercent 
+    //   = Math.round(this.endOfMonthForecast / this.monthlySpendAverage * 100) / 100;
 
     debugger;
 
@@ -689,6 +689,7 @@ export default class PortfolioDashboard extends Vue {
     });
 
     await this.calculateFundsSpent();
+    this.fundsSpentStr = toCurrencyString(this.fundsSpent);
     this.availableFunds = this.totalPortfolioFunds - this.fundsSpent;
     this.availableFundsStr = toCurrencyString(this.availableFunds);
 

--- a/src/dashboards/Portfolio.vue
+++ b/src/dashboards/Portfolio.vue
@@ -26,7 +26,9 @@
                           class="bg-info-lighter px-6 py-6"
                           style="border-radius: 4px;"
                         >
-                          <span id="AvailableFunds" class="h1 mb-0">${{ availableFundsStr }}</span>
+                          <span id="AvailableFunds" class="h1 mb-0">
+                            {{ getCurrencyString(availableFunds) }}
+                          </span>
                           <p class="font-weight-bold mb-0 pb-5">Available Funds</p>
                           <p class="mb-0 font-size-14">
                             Your remaining portfolio balance from all of your active task
@@ -37,7 +39,7 @@
                       <v-col>
                         <p class="text--base-darkest pt-1 mb-0">Total Portfolio Funds</p>
                         <span id="TotalPortfolioFunds" class="h2 mb-0">
-                          ${{ totalPortfolioFundsStr }}
+                          {{ getCurrencyString(totalPortfolioFunds) }}
                         </span>
                         <p class="text--base-dark mb-0 font-size-14">
                           Total value of your active task orders
@@ -160,16 +162,19 @@
                     <p class="font-size-14">
                       View a breakdown of how much you spend on cloud resources, 
                       tools, and services compared to the 
-                      <strong>monthly average of {{ monthlySpendAverageStr }}.</strong> 
+                      <strong>
+                        monthly average of {{ getCurrencyString(monthlySpendAverage) }}.
+                      </strong> 
                       Use forecasts to project upcoming spend and ensure your 
                       portfolio is funded appropriately.
                     </p>
-
                     <v-row>
                       <v-col>
                         <v-card class="bg-base-lightest _no-shadow pa-4">
                           Last month
-                          <span class="h1 d-block my-2">${{ lastMonthSpendStr }}</span>
+                          <span class="h1 d-block my-2">
+                            {{ getCurrencyString(lastMonthSpend) }}
+                          </span>
                           <span class="d-flex align-center">
                             <ATATSVGIcon 
                               :name="lastMonthSpendTrendPercent > 0 
@@ -193,7 +198,9 @@
                       <v-col>
                         <v-card class="bg-base-lightest _no-shadow pa-4">
                           End-of-month forecast
-                          <span class="h1 d-block my-2">${{ endOfMonthForecastStr }}</span>
+                          <span class="h1 d-block my-2">
+                            {{ getCurrencyString(endOfMonthForecast) }}
+                          </span>
                           <span 
                             class="d-flex align-center"
                             :class="endOfMonthForecastTrendPercent > 0 
@@ -215,10 +222,8 @@
                               </span>
                               vs monthly average
                             </span>
-
                           </span>
                         </v-card>
-
                       </v-col>
                     </v-row>
                     <v-row>
@@ -232,19 +237,20 @@
                               label="PeriodToDate"
                             />
                             </div>
-                          <span class="h1 d-block">${{ fundsSpentStr }}</span>
+                          <span class="h1 d-block">
+                            {{ getCurrencyString(fundsSpent) }}
+                          </span>
                         </v-card>
-
                       </v-col>
                       <v-col>
                         <v-card class="bg-base-lightest _no-shadow pa-4">
                           End-of-period forecast
-                          <span class="h1 d-block mt-2">${{ endOfPeriodForecastStr }}</span>
+                          <span class="h1 d-block mt-2">
+                            {{ getCurrencyString(endOfPeriodForecast) }}
+                          </span>
                         </v-card>
-
                       </v-col>                      
                     </v-row>
-
                   </v-card>
                 </v-col>
               </v-row>
@@ -266,7 +272,7 @@
                           :chart-data="donutChartData"
                           :chart-options="donutChartOptions"
                           :use-chart-data-labels="true"
-                          :center-text1="'$' + totalPortfolioFundsStr.slice(0, -3)"
+                          :center-text1="getCurrencyString(totalPortfolioFunds, false)"
                           center-text2="Total Portfolio Funds"
                           :amount="totalPortfolioFunds"
                         />
@@ -308,7 +314,7 @@
 
                             </div>
                             <div class="pr-4 py-2 font-weight-700">
-                              ${{ totalPortfolioFundsStr }}
+                              {{ getCurrencyString(totalPortfolioFunds) }}
                             </div>
                             <div style="width: 50px;">
                             </div>
@@ -382,11 +388,8 @@ export default class PortfolioDashboard extends Vue {
   }
 
   public totalPortfolioFunds = 0;
-  public totalPortfolioFundsStr = "";
   public fundsSpent = 0;
-  public fundsSpentStr = "";
   public availableFunds = 0;
-  public availableFundsStr = "";
   public fundsSpentPercent = 0;
  
   public popStart = "";
@@ -394,17 +397,13 @@ export default class PortfolioDashboard extends Vue {
   public timeToExpiration = "";
   public runOutOfFundsDate = "";
   public monthlySpendAverage = 0;
-  public monthlySpendAverageStr = "";
   public lastMonthSpend = 0;
-  public lastMonthSpendStr = "";
   public lastMonthSpendTrendPercent = 0;
   public endOfMonthForecast = 0;
-  public endOfMonthForecastStr = "";
   public endOfMonthForecastTrendPercent = 0; // for spending summary
   public estimatedFundsToBeInvoicedPercent = 0; // for donut chart
   public estimatedRemainingPercent = 0;
   public endOfPeriodForecast = 0;
-  public endOfPeriodForecastStr = "";
   public monthsForEndOfPeriodForecast = 0;
 
   public taskOrder: TaskOrderDTO = TaskOrder.value;
@@ -494,8 +493,6 @@ export default class PortfolioDashboard extends Vue {
           clinValues[date] = clin.value;
         } else if (clin) {
           this.endOfMonthForecast += parseFloat(clin.value);
-          this.endOfMonthForecastStr
-            = toCurrencyString(this.endOfMonthForecast);
         }
       });
       clinCosts[clinNo] = clinValues;
@@ -627,14 +624,12 @@ export default class PortfolioDashboard extends Vue {
     const monthsWithSpend = totalActualBurnData.filter(amt => amt !== null);
     const len = monthsWithSpend.length;
     this.monthlySpendAverage = Math.round(this.fundsSpent / len * 100) / 100;
-    this.monthlySpendAverageStr = "$" + toCurrencyString(this.monthlySpendAverage);
+
     if (len && len >= 2) {
       const twoMoAgoAvl = monthsWithSpend[len - 2];
       const lastMoAvl = monthsWithSpend[len - 1];
       if (twoMoAgoAvl && lastMoAvl) {
         this.lastMonthSpend = twoMoAgoAvl - lastMoAvl;
-        this.lastMonthSpendStr = toCurrencyString(this.lastMonthSpend);
-        // EJY calculate percent trend based on monthlySpendAverage
         this.lastMonthSpendTrendPercent 
           = (this.lastMonthSpend - this.monthlySpendAverage) / this.monthlySpendAverage * 100;
       }
@@ -646,7 +641,6 @@ export default class PortfolioDashboard extends Vue {
     const m = this.monthsForEndOfPeriodForecast;
     this.endOfPeriodForecast 
       = this.fundsSpent + this.endOfMonthForecast + (this.monthlySpendAverage * m);
-    this.endOfPeriodForecastStr = toCurrencyString(this.endOfPeriodForecast);
 
     this.burnChartData.labels = this.burnChartXLabels;
     this.burnChartData.datasets = [];
@@ -715,7 +709,6 @@ export default class PortfolioDashboard extends Vue {
     this.idiqClins.forEach((clin) => {
       this.totalPortfolioFunds = this.totalPortfolioFunds + parseInt(clin.funds_obligated);
     });
-    this.totalPortfolioFundsStr = toCurrencyString(this.totalPortfolioFunds);
 
     this.burnChartYMax = Math.ceil(this.totalPortfolioFunds / 100000) * 100000;
     this.burnChartYStepSize = Math.round(this.burnChartYMax / 6);
@@ -739,13 +732,11 @@ export default class PortfolioDashboard extends Vue {
     });
 
     await this.calculateFundsSpent();
-    this.fundsSpentStr = toCurrencyString(this.fundsSpent);
     this.availableFunds = this.totalPortfolioFunds - this.fundsSpent;
-    this.availableFundsStr = toCurrencyString(this.availableFunds);
 
     this.tooltipHeaderData = {
       title: "Total Funds Available",
-      amount: this.availableFundsStr,
+      amount: this.getCurrencyString(this.availableFunds),
       legend: "Funds Available",
     };
 
@@ -952,8 +943,7 @@ export default class PortfolioDashboard extends Vue {
 
   public getLegendAmount(index: number): string {
     const amount = this.totalPortfolioFunds * this.donutChartData.datasets[0].data[index] / 100;
-    let amountStr = "$" + toCurrencyString(amount);
-    return amountStr;
+    return this.getCurrencyString(amount);
   }
 
   public spendingTooltipText = `This is the total value of all active task 
@@ -974,6 +964,9 @@ export default class PortfolioDashboard extends Vue {
     return Math.abs(roundedVal);
   }
 
+  public getCurrencyString(value: number, decimals?: boolean): string {
+    return "$" + toCurrencyString(value, decimals);
+  }
 }
 
 </script>

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -66,10 +66,11 @@ export const sanitizeOfferingName = (offeringName: string): string => {
 }
 
 // formats a number to currency string with commas and 2 decimal places
-export const toCurrencyString = (num: number): string => {
+export const toCurrencyString = (num: number, decimals?: boolean): string => {
+  const d = decimals === false ? 0 : 2;
   if (!isNaN(num)) {
     return num.toLocaleString(
-      undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }
+      undefined, { minimumFractionDigits: d, maximumFractionDigits: d }
     );
   }
   return "";

--- a/src/sass/utils/color-classes.scss
+++ b/src/sass/utils/color-classes.scss
@@ -36,10 +36,8 @@
 
   .text-white { color: $white };
 
-  .text-base-error         { color: $error !important; }
-  .text-base-error-dark    { color: $error-dark !important; }
-  .text-base-error-darker  { color: $error-darker !important; }
-  .text-base-success       { color: $success !important; }
+  .text-error           { color: $error !important; }
+  .text-success-dark    { color: $success-dark !important; }
 
   .border-base-darkest  { border-color: $base-darkest !important; }
   .border-base-darker   { border-color: $base-darker !important; }

--- a/src/sass/utils/dashboard.scss
+++ b/src/sass/utils/dashboard.scss
@@ -13,3 +13,11 @@
     }
   }
 }
+
+._trending-up {
+  color: $error;
+}
+
+.trending-down {
+  color: $success-dark;
+}

--- a/src/sass/utils/utils.scss
+++ b/src/sass/utils/utils.scss
@@ -139,3 +139,7 @@ $widths: 500, 640, 740, 760;
 .drag-img-fake {
   opacity: 0 !important;
 }
+
+._no-shadow {
+  box-shadow: none !important;
+}

--- a/src/steps/04-ContractDetails/PeriodOfPerformance.vue
+++ b/src/steps/04-ContractDetails/PeriodOfPerformance.vue
@@ -118,7 +118,7 @@
             :class="{ 'd-flex': totalPoPDuration > maxTotalPoPDuration }"
             v-show="totalPoPDuration > maxTotalPoPDuration"
           >
-            <v-icon class="text-base-error icon-20"> error </v-icon>
+            <v-icon class="text-error icon-20"> error </v-icon>
             <div class="field-error ml-2">
               The total length of your base and option periods should be 5 years
               or less.


### PR DESCRIPTION
1. Figma can be found [here](https://www.figma.com/file/DhwLh5B4y6pFbeLgMY63Rp/ATAT-Prototype-MVP%2B-(Master)). 
    1. Please note:
        1. that calculations listed on the screencap might NOT be correct.
        1. Values may come in as expected.  If not, formulas are listed alongside each value when provided.
1. HTML UI Elements
    1. Title: Spend Summary
    1. Paragraph: View a breakdown of how much you spend on cloud resources, tools, and services compared to the monthly average of $16,000. Use forecasts to project upcoming spend and ensure your portfolio is funded appropriately
        1. Calculation: average monthly spend = [CSP Total Actual Spend since PoP start date] / [# of completed months since PoP Start Date]
    1. Card
        1. Title: Last Month
        1. Value: Data will be provided by CSP API (CSP Total Actual Spend for the previous month)
        1. Calculation: = ( [CSP Total Actual Spend for the previous month]-[Average Monthly Spend] ) / [Average Monthly Spend]
            1. If positive number, difference is an increase --> display up icon
            1. If negative number, difference is a decrease --> display down icon
    1. Card
        1. Title: End-of-month forecast
        1. Value: Data will be provided by CSP API (CSP Forecasted Spend for Task Order for the current month)
        1. Value: Monthly Average value will be provided by CSP API
    1. Card
        1. Title: Period-to-date
        1. Tooltip: This is the total spend from the start of the current period of performance through last month. It does not include funds that will be invoiced this month.
        1. Value: Data will be provided by CSP API (CSP Total Actual Spend since PoP start date)
    1. Card
        1. Title: End-of-period forecast
        1. Value:  Data will be provided by CSP API (CSP Forecasted Spend for Task Order up to the PoP end date)