### PR TITLE
Update .secrets.baseline version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
     - id: detect-secrets
       args: ['--baseline', '.secrets.baseline']

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.3.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -140,5 +140,5 @@
       }
     ]
   },
-  "generated_at": "2022-06-24T14:58:14Z"
+  "generated_at": "2022-07-22T18:56:26Z"
 }


### PR DESCRIPTION
Update the version reference for using `detect-secrets` to `v1.3.0`. This resolves the action failure caused by the `.secrets.baseline` using the `v1.2.0`