### PR TITLE
Fix coverage reporting for Vue with Istanbul

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,11 @@
 // instrument .js and .vue files
+const plugins = [];
+if (process.env.NODE_ENV === "test") {
+  plugins.push(["babel-plugin-istanbul", { extension: [".js", ".ts", ".vue"]}, "istanbul-coverage"]);
+}
 module.exports = {
   presets: [
     '@vue/app'
   ],
+  plugins,
 }


### PR DESCRIPTION
It seems that Istanbul, by default, is not configured to collect
coverage for `.vue` files. This adds that configuration. It also only
adds the plugin when `NODE_ENV` is `test` (should happen by default with
`npm run test`).

A custom name is required because it seems that `@vue/app` already
includes the istanbul plugin but misconfigured.
