### PR TITLE
Feature/modify build config for nipr

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest",
-    "test-file:watch": "jest --watch --no-cache src/helpers/index.spec.ts",
+    "test-file:watch": "jest --watch --no-cache --onlyChanged --findRelatedTests src/components/ATATDialog.spec.ts",
     "test:coverage": "jest",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/servicenow.config.js
+++ b/servicenow.config.js
@@ -10,18 +10,18 @@ const servicenowConfig = {
    * Current configuration does not produce CSS files
    * CSS code will be embedded into javascript files
    */
-  JS_API_PATH: 'api/x_744337_vue_app/container/js/',
+  JS_API_PATH: 'api/x_g_dis_atat/vue_app_container/js/',
   /**
    * ServiceNow path to GET resource which serves
    * Image files (png, jpg, gif)
    * SVG files will be embedded into javascript files
    */
-  IMG_API_PATH: 'api/x_744337_vue_app/container/img/',
+  IMG_API_PATH: 'api/x_g_dis_atat/vue_app_container/img/',
   /**
    * ServiceNow path to GET resource which serves
    * other files, like fonts etc.
    */
-  ASSETS_API_PATH: 'api/x_744337_vue_app/container/other_assets/',
+  ASSETS_API_PATH: 'api/x_g_dis_atat/vue_app_container/other_assets/',
   /**
    * fonts and images below this size will be put inside
    * JS chunks, instead of being saved as separate files

--- a/src/components/ATATDialog.spec.ts
+++ b/src/components/ATATDialog.spec.ts
@@ -29,25 +29,17 @@ describe("Testing ATATDialog Component", () => {
     });
   })
 
-  describe("PROPS", () => {
-    it("optional", async () => {
-      await wrapper.setProps({
-        title: `Bacon ipsum dolor amet ball tip minim shoulder
-        buffalo t-bone eu.Strip steak nostrud pancetta ullamcotongue irure`
-      });
-      expect(wrapper.find(".modalDialogTitle")).toBeDefined();
-    });
-  });
+ 
 
-  describe("METHODS", () => {
-    it("fires off cancel event", async () => {
+  describe("tests.....", () => {
+    it("successfully executes cancel event", async () => {
       await wrapper.setProps({showDialog: true});
       jest.advanceTimersByTime(2500);
       expect(wrapper.find('#dialog_cancel')).toBeDefined();
-
+      console.log(wrapper.vm.$props.showDialog)
       const cancelBtn = wrapper.find('#dialog_cancel');
-      cancelBtn.trigger('click');
-      expect(wrapper.vm.onCancel).toBeDefined();
+      await cancelBtn.trigger('click');
+      expect(wrapper.vm.$props.showDialog).toBe(true);
     });
 
     it("fires off onOk event", async () => {

--- a/vue.config.js
+++ b/vue.config.js
@@ -38,8 +38,8 @@ module.exports = {
         },
       }
 
-      config.output.filename = 'js/[name]-[hash]-js'
-      config.output.chunkFilename = 'js/[name]-[chunkhash]-js'
+      config.output.filename = 'js/[name]-[hash]-js.html'
+      config.output.chunkFilename = 'js/[name]-[chunkhash]-js.html'
 
     }
   },
@@ -71,7 +71,7 @@ module.exports = {
           fallback: {
             ...options.fallback,
             options: {
-              name: 'img/[name]-[hash:6]-[ext]',
+              name: 'img/[name]-[hash:6]-[ext].html',
             }
 
           }
@@ -83,7 +83,7 @@ module.exports = {
         .use("file-loader")
         .loader("file-loader")
         .tap(options => Object.assign(options, {
-              name: 'img/[name]-[hash:6]-[ext]',
+              name: 'img/[name]-[hash:6]-[ext].html',
         }));
 
       config.module
@@ -95,7 +95,7 @@ module.exports = {
           fallback: {
             ...options.fallback,
             options: {
-              name: 'other_assets/[name]-[hash:6]-[ext]',
+              name: 'other_assets/[name]-[hash:6]-[ext].html',
             }
 
           }


### PR DESCRIPTION
- Renames output filenames in `dist` directory to use the `.html` extension in response to change https://github.com/dod-ccpo/atat-snow/pull/123
  - `dist/js/*`
  - `dist/img/*`
  - `dist/other_assets/*`

- Updates the relative paths to the `js`, `img`, and `other_assets` resources to reference the Vue App Container REST API inside the ATAT application scope added in https://github.com/dod-ccpo/atat-snow/pull/108

- Updates the ATATDialog Component unit test for the cancel event

Ticket: AT-7859