### PR TITLE
Hotfix to have a empty PoP when first visiting the page

### DIFF
--- a/src/steps/04-ContractDetails/PeriodOfPerformance.vue
+++ b/src/steps/04-ContractDetails/PeriodOfPerformance.vue
@@ -498,7 +498,7 @@ export default class PeriodOfPerformance extends Mixins(SaveOnLeave) {
       return optionPeriod;
     }) : [ {
       duration:null ,
-      unitOfTime: "Year",
+      unitOfTime: "",
       id: null,
       order: 1,
     }];


### PR DESCRIPTION
correct a case when you load into PoP for the first time dropdown holds a value