### PR TITLE
Feature/at 7878 invite members modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --watch --no-cache --onlyChanged --findRelatedTests src/components/ATATFileUpload.spec.ts",
+    "test-file:watch": "jest --watch --no-cache --onlyChanged --findRelatedTests src/portfolio/components/AddMembersModal.spec.ts",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/src/components/ATATSelect.vue
+++ b/src/components/ATATSelect.vue
@@ -39,7 +39,8 @@
             v-on="on" 
             :class="[
               {'_item-disabled': item.disabled },
-              {'d-none': item.hidden }
+              {'d-none': item.hidden },
+              {'_selected': item.value === _selectedValue || item === _selectedValue }
             ]"
           >
             <v-list-item-content
@@ -55,7 +56,18 @@
           </v-list-item>
         </template>
         <template v-slot:append>
-          <v-icon>arrow_drop_down</v-icon>
+          <v-icon v-if="iconType === 'standard'">arrow_drop_down</v-icon>
+          <div
+            class="_dropdown-icon"
+            v-if="iconType === 'chevron'"
+          >
+            <ATATSVGIcon 
+              name="chevronDown" 
+              color="base-darkest" 
+              :width="10" 
+              :height="7" 
+            />
+          </div>
         </template>
       </v-select>
   
@@ -70,12 +82,13 @@ import Vue from "vue";
 import { Component, Emit, Prop, PropSync } from "vue-property-decorator";
 
 import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
-
+import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import { SelectData } from "../../types/Global";
 
 @Component({
   components: {
-    ATATErrorValidation
+    ATATErrorValidation,
+    ATATSVGIcon,
   }
 })
 export default class ATATSelect extends Vue {
@@ -100,6 +113,7 @@ export default class ATATSelect extends Vue {
   @Prop({ default: false }) private returnObject!: boolean;
   @Prop({ default: "" }) private width!: string;
   @Prop({ default: true }) private showErrorMessages?: boolean;
+  @Prop({ default: "standard" }) public iconType?: string;
 
   //data
   private rounded = false;

--- a/src/components/icons/ATATSVGIcon.vue
+++ b/src/components/icons/ATATSVGIcon.vue
@@ -15,6 +15,7 @@ import Vue from "vue";
 import { Component, Prop, PropSync } from "vue-property-decorator";
 
 import Calendar from "@/components/icons/Calendar.vue";
+import ChevronDown from "@/components/icons/ChevronDown.vue";
 import ChevronRight from "@/components/icons/ChevronRight.vue";
 import Close from "@/components/icons/Close.vue";
 import ControlPoint from "@/components/icons/ControlPoint.vue";
@@ -37,6 +38,7 @@ import TriangleDown from "@/components/icons/TriangleDown.vue";
 @Component({
   components:{
     Calendar,
+    ChevronDown,
     ChevronRight,
     Close,
     ControlPoint,

--- a/src/components/icons/ChevronDown.vue
+++ b/src/components/icons/ChevronDown.vue
@@ -1,0 +1,21 @@
+<template>
+<svg viewBox="0 0 10 7" xmlns="http://www.w3.org/2000/svg">
+
+<!-- eslint-disable -->
+  <path d="M8.825 0.658203L5 4.47487L1.175 0.658203L0 1.8332L5 6.8332L10 1.8332L8.825 0.658203Z" 
+    :fill="'#' + color"
+/>
+<!-- eslint-enable -->
+
+
+</svg>
+</template>
+
+<script lang='ts'>
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+@Component({})
+export default class ChevronDown extends Vue {
+  @Prop({ default: "161B1E", required: false }) private color!:string;
+}
+</script>

--- a/src/portfolio/components/AddMembersModal.spec.ts
+++ b/src/portfolio/components/AddMembersModal.spec.ts
@@ -3,6 +3,8 @@ import Vuetify from "vuetify";
 import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import { DefaultProps } from "vue/types/options";
 import AddMembersModal from "@/portfolio/components/AddMembersModal.vue";
+import AcquisitionPackage from "@/store/acquisitionPackage";
+
 Vue.use(Vuetify);
 
 describe("Testing AddMembersModal", () => {
@@ -19,7 +21,8 @@ describe("Testing AddMembersModal", () => {
   });
 
   it("renders successfully", async () => {
+    AcquisitionPackage.setProjectTitle("testing");
     expect(wrapper.exists()).toBe(true);
   });
 
-})
+});

--- a/src/portfolio/components/AddMembersModal.vue
+++ b/src/portfolio/components/AddMembersModal.vue
@@ -1,16 +1,59 @@
 
 <template>
-  <div>
-    Future Add Members Modal page
-  </div>
+
+  <ATATDialog
+    :showDialog.sync="showModal"
+    :title="'Invite people to “' + projectTitle + '”'"
+    no-click-animation
+    okText="Invite"
+    width="632"
+    :OKDisabled="true"
+  >
+    <template #content>
+      <p class="body">
+        Use “.mil” or “.gov” email addresses to ensure people can authenticate with 
+        a CAC to access your portfolio. 
+        <a
+          id="LearnMoreLink" 
+          role="button"
+        >
+          Learn more about portfolio roles
+        </a>
+      </p>
+      <ATATTextArea
+        id="EmailAddresses"
+        label="Email addresses"
+        rows="7"
+        class="pb-16"
+      />
+    </template>
+  </ATATDialog>
+
 </template>
 <script lang="ts">
 import Vue from "vue";
 
-import { Component } from "vue-property-decorator";
+import { Component, Prop } from "vue-property-decorator";
+import AcquisitionPackage from "@/store/acquisitionPackage";
+
+import ATATDialog from "@/components/ATATDialog.vue";
+import ATATTextArea from "@/components/ATATTextArea.vue";
+
 @Component({
+  components: {
+    ATATDialog,
+    ATATTextArea,
+  }
 })
+
 export default class AddMembersModal extends Vue {
+  @Prop({ default: false }) public showModal?: boolean;
+
+  public get projectTitle(): string {
+    return AcquisitionPackage.projectTitle !== ""
+      ? AcquisitionPackage.projectTitle
+      : "New Acquisition";
+  }
+
 }
 </script>
-

--- a/src/portfolio/components/AddMembersModal.vue
+++ b/src/portfolio/components/AddMembersModal.vue
@@ -20,12 +20,27 @@
           Learn more about portfolio roles
         </a>
       </p>
-      <ATATTextArea
-        id="EmailAddresses"
-        label="Email addresses"
-        rows="7"
-        class="pb-16"
-      />
+      <div class="d-flex">
+        <div style="flex-grow: 1;" class="mr-5">
+          <ATATTextArea
+            id="EmailAddresses"
+            label="Email addresses"
+            rows="7"
+            class="pb-16"
+          />
+        </div>
+        <div>
+          <ATATSelect
+            id="Role"
+            class="mt-8 _small _alt-style _invite-members-modal"
+            :items="roles"
+            width="105"
+            :selectedValue.sync="selectedRole"
+            iconType="chevron"
+          />
+        </div>
+
+      </div>
     </template>
   </ATATDialog>
 
@@ -37,11 +52,15 @@ import { Component, Prop } from "vue-property-decorator";
 import AcquisitionPackage from "@/store/acquisitionPackage";
 
 import ATATDialog from "@/components/ATATDialog.vue";
+import ATATSelect from "@/components/ATATSelect.vue";
 import ATATTextArea from "@/components/ATATTextArea.vue";
+
+import { SelectData } from "../../../types/Global";
 
 @Component({
   components: {
     ATATDialog,
+    ATATSelect,
     ATATTextArea,
   }
 })
@@ -54,6 +73,14 @@ export default class AddMembersModal extends Vue {
       ? AcquisitionPackage.projectTitle
       : "New Acquisition";
   }
+
+  public selectedRole = "Manager";
+  public roles: SelectData[] = [
+    { header: "Roles" },
+    { text: "Manager", value: "Manager" },
+    { text: "Viewer", value: "Viewer" },
+  ];
+
 
 }
 </script>

--- a/src/sass/components/ATATAutoComplete.scss
+++ b/src/sass/components/ATATAutoComplete.scss
@@ -17,6 +17,16 @@
   .v-autocomplete__content.v-menu__content {
     box-shadow: 0px 4px 10px rgba(194, 194, 194, 0.5);
     border-radius: 8px;
+    .v-list-item--active {
+      &:before {
+        opacity: 0;
+      }
+      background-color: $primary-lighter !important;
+      color: $base-darkest !important;
+      .v-list-item__title {
+        font-weight: 700 !important;
+      }
+    }
   }
   
   .v-select__slot {

--- a/src/sass/components/ATATSelect.scss
+++ b/src/sass/components/ATATSelect.scss
@@ -15,6 +15,9 @@
       .v-list-item__title {
         font-weight: 700 !important;
       }
+      &:hover:before {
+        background-color: transparent;
+      }
     }
   }
   .v-list-item__content {
@@ -59,6 +62,9 @@
 }
 
 .atat-select {
+  &:hover {
+    cursor: pointer !important;
+  }
   ._dropdown-icon {
     width: 20px;
     height: 24px;
@@ -72,6 +78,7 @@
     font-weight: 500;
     padding-left: 16px;
   }
+
   &._small {
     .v-subheader {
       font-size: 1.2rem;
@@ -85,10 +92,12 @@
       min-height: 32px !important;
       height: 32px !important;
     }
-
     .v-text-field {
       input[type="text"] {
         padding: 0;
+        &:hover {
+          cursor: pointer;
+        }
       } 
     }
     .v-select__selections {
@@ -113,9 +122,16 @@
   &._alt-style {
     fieldset {
       border: none;
-      background-color: $primary-lighter;
+      background-color: $primary-10;
+    }
+
+    &:hover {
+      fieldset {
+        background-color: $primary-20;
+      }
     }
   }
+
   &._invite-members-modal {
     .v-menu__content {
       min-width: 180px !important;

--- a/src/sass/components/ATATSelect.scss
+++ b/src/sass/components/ATATSelect.scss
@@ -10,9 +10,15 @@
         }
       }
     }
+    &._selected {
+      background-color: $primary-lighter;
+      .v-list-item__title {
+        font-weight: 700 !important;
+      }
+    }
   }
   .v-list-item__content {
-    padding: 8px 0;
+    padding: 12px 0 !important;
   }
   .v-list-item__title, .v-list-item__subtitle {
     text-align: left;
@@ -50,4 +56,70 @@
 .v-menu__content {
   box-shadow: 0px 4px 10px rgba(194, 194, 194, 0.5) !important;
   border-radius: 8px !important;
+}
+
+.atat-select {
+  ._dropdown-icon {
+    width: 20px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+  }
+  .v-subheader {
+    text-transform: uppercase;
+    color: $base;
+    font-size: 14px;
+    font-weight: 500;
+    padding-left: 16px;
+  }
+  &._small {
+    .v-subheader {
+      font-size: 1.2rem;
+      height: 30px;
+    }
+    .v-select__selection {
+      font-size: 1.4rem !important;
+    }
+    .v-input__slot {
+      padding: 0 4px 0 12px !important;
+      min-height: 32px !important;
+      height: 32px !important;
+    }
+
+    .v-text-field {
+      input[type="text"] {
+        padding: 0;
+      } 
+    }
+    .v-select__selections {
+      padding: 0 !important;
+    }
+    .v-select__selection {
+      margin: 0;
+    }
+    fieldset {
+      height: 36px;
+    }
+    .v-select__slot {
+      height: 32px;
+    }
+    .v-input__append-inner {
+      // dropdown arrow icon
+      margin-top: 4px !important;
+      padding: 0;
+    }
+  }
+  
+  &._alt-style {
+    fieldset {
+      border: none;
+      background-color: $primary-lighter;
+    }
+  }
+  &._invite-members-modal {
+    .v-menu__content {
+      min-width: 180px !important;
+      left: -75px !important;
+    }
+  }
 }

--- a/src/sass/utils/colors.scss
+++ b/src/sass/utils/colors.scss
@@ -13,6 +13,8 @@ $primary-dark: #3b3069;
 $primary: #544496;
 $primary-light: #a9a1ca;
 $primary-lighter: #eeecf5;
+$primary-10: #54449610;
+$primary-20: #54449620;
 
 // DISA BLUE
 $info-darker: #004f6f;

--- a/src/steps/11-ReviewRequiredForms/ReviewRequiredFormsStepOne.vue
+++ b/src/steps/11-ReviewRequiredForms/ReviewRequiredFormsStepOne.vue
@@ -2,15 +2,39 @@
 <template>
   <div>
     Future Review Required Forms page
+    <p class="my-10">
+      <a 
+        role="button"
+        @click="openModal"
+      >      
+        Temporary open "Invite Members" modal link
+      </a>
+    </p>
+
+    <AddMembersModal 
+      :showModal.sync="showModal"
+    />
+
   </div>
 </template>
 <script lang="ts">
 import Vue from "vue";
 
 import { Component } from "vue-property-decorator";
+
+import AddMembersModal from "@/portfolio/components/AddMembersModal.vue";
+
 @Component({
+  components: {
+    AddMembersModal,
+  }
 })
 export default class ReviewRequiredFormsStepOne extends Vue {
+  public showModal = false;
+
+  public openModal(): void {
+    this.showModal = true;
+  }
 }
 </script>
 

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -29,11 +29,12 @@ export interface StepperStep {
  * interface for select items
  */
 export interface SelectData {
-  text: string;
+  text?: string;
   value?: string;
   multiSelectOrder?: number;
   disabled?: boolean;
   hidden?: boolean;
+  header?: string;
 }
 
 /**


### PR DESCRIPTION
The modal is to be created that will contain the following HTML elements. (see figure 1.0).  Emails are not to be validated for this task.
1. Headline:  Invite people to “Hosting and Compute Center (HaCC)”
1. Paragraph with hyperlink
    1. Text: Use “.mil” or “.gov” email addresses to ensure people can authenticate with a CAC to access your portfolio. Learn more about portfolio roles
    1. Hyperlink
        1. Text: Learn more about portfolio roles
        1. Target:  Modal slide out drawer to be added in future sprint and is explained here  AT-7881: UI - Portfolio Page - Invite Members Modal - Slideout DrawerTO DO 
1. Textarea
    1. Label: Email addresses
1. Dropdown
    1. Options
        1. Manager
        1. Viewer
    1. Default Option: Manager
1. Buttons
    1. Button
        1. Text:  Cancel
        1. Event
            1. Click:  Closes window and no member’s email addresses are saved
    1. Button
        1. Text: Invite
        1. Event:
            1. Click:  Closes window