### PR TITLE
Feature/at 7984 portfolio card

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --watch --no-cache src/portfolio/CSPPortalAccess.spec.ts",
+    "test-file:watch": "jest --watch --no-cache src/portfolios/components/PortfolioCard.spec.ts",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --watch --no-cache src/portfolios/components/PortfolioCard.spec.ts",
+    "test-file:watch": "jest --watch --no-cache src/portfolios/components/AllPortfolios.spec.ts",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/src/components/ATATSlideoutPanel.vue
+++ b/src/components/ATATSlideoutPanel.vue
@@ -19,7 +19,7 @@
         {{ panelTitle }}
       </div>
       <v-btn
-        class="text--base-darkest pa-0 icon-24"
+        class="text-base-darkest pa-0 icon-24"
         text
         small
         @click.stop="closeSlideoutPanel"

--- a/src/components/icons/ATATSVGIcon.vue
+++ b/src/components/icons/ATATSVGIcon.vue
@@ -16,6 +16,7 @@ import { Component, Prop, PropSync } from "vue-property-decorator";
 import ArrowBack from "@/components/icons/ArrowBack.vue";
 import Aws from "@/components/icons/Aws.vue";
 import Azure from "@/components/icons/Azure.vue";
+import Bullet from "@/components/icons/Bullet.vue";
 import Calendar from "@/components/icons/Calendar.vue";
 import ChevronDown from "@/components/icons/ChevronDown.vue";
 import ChevronRight from "@/components/icons/ChevronRight.vue";
@@ -62,6 +63,7 @@ import ManageAccount from "@/components/icons/ManageAccount.vue";
     ArrowBack,
     Aws,
     Azure,
+    Bullet,
     Calendar,
     ChevronDown,
     ChevronRight,

--- a/src/components/icons/Bullet.vue
+++ b/src/components/icons/Bullet.vue
@@ -1,0 +1,16 @@
+<template>
+  <svg viewBox="0 0 9 9"  xmlns="http://www.w3.org/2000/svg">
+    <circle cx="4.3" cy="4.3" r="4.3" fill="transparent"/>
+    <circle cx="4.15" cy="4.15" r="2.15" :fill="'#' + color"/>
+  </svg>
+</template>
+
+<script lang='ts'>
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+@Component({})
+export default class Close extends Vue {
+  @Prop({ default: "959A9D", required: false }) private color?: string;
+}
+</script>

--- a/src/dashboards/Portfolio.vue
+++ b/src/dashboards/Portfolio.vue
@@ -43,24 +43,24 @@
                         </div>
                       </v-col>
                       <v-col>
-                        <p class="text--base-darkest pt-1 mb-0">
+                        <p class="text-base-darkest pt-1 mb-0">
                           Total Portfolio Funds
                         </p>
                         <span id="TotalPortfolioFunds" class="h2 mb-0">
                           {{ getCurrencyString(totalPortfolioFunds) }}
                         </span>
-                        <p class="text--base-dark mb-0 font-size-14">
+                        <p class="text-base-dark mb-0 font-size-14">
                           Total value of your active task orders
                         </p>
                         <v-divider class="my-4" />
-                        <p class="text--base-darkest mb-0 font-size-14">
+                        <p class="text-base-darkest mb-0 font-size-14">
                           Current Period of Performance
                         </p>
                         <span id="PoPDates" class="h3 mb-0">
                           {{ popStart }}&ndash;{{ popEnd }}
                         </span>
                         <p
-                          class="text--base-dark mb-0 font-size-14"
+                          class="text-base-dark mb-0 font-size-14"
                           v-if="!hasTimeSensativeAlert()"
                         >
                           {{ timeToExpiration }} to expiration
@@ -218,7 +218,7 @@
                 <v-col>
                   <v-card class="_no-shadow v-sheet--outlined pa-8">
                     <h3 class="mb-4">Actual and Projected Burn Rate</h3>
-                    <p class="text--base-dark font-size-14">
+                    <p class="text-base-dark font-size-14">
                       Track your rate of spend and available funds throughout
                       the current period of performance. Forecasted future costs
                       are based on historical trends and show approximately when

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -2,6 +2,8 @@ import { ClassificationLevelDTO, PeriodDTO, SystemChoiceDTO } from "@/api/models
 import { Checkbox, SelectData, User } from "types/Global";
 import _ from "lodash";
 import Periods from "@/store/periods";
+import { PortFolioStatusTypes } from "@/store/portfolio";
+
 
 export const hasChanges = <TData>(argOne: TData, argTwo: TData): boolean =>
   !_.isEqual(argOne, argTwo);
@@ -197,3 +199,23 @@ export function getUserInitials(member:User): string {
   const initials = firstI && lastI ? firstI + lastI : "XX";
   return initials.toUpperCase();
 }
+
+export function getStatusChipBgColor(status: string): string {
+  switch (status) {
+  case PortFolioStatusTypes.Active:
+    return "bg-success";
+  case PortFolioStatusTypes.Processing:
+    return "bg-info-dark";
+  case PortFolioStatusTypes.AtRisk:
+    return "bg-warning";
+  case PortFolioStatusTypes.Delinquent:
+  case PortFolioStatusTypes.Expired:
+    return "bg-error";
+  case PortFolioStatusTypes.Archived:
+    return "bg-base-dark";
+  default:
+    return "";
+  }
+
+}
+

--- a/src/portfolio/CSPPortalAccess.vue
+++ b/src/portfolio/CSPPortalAccess.vue
@@ -304,7 +304,7 @@ export default class CSPPortalAccess extends Vue {
   public toolTipText = `This 10-digit number is printed on the back of your administrator's
     Common Access Card (CAC). You may also ask your administrator to log into
     <span class="text-decoration-underline">DoD ID Card Office Online</span>
-    and locate it under "My Profile."`;
+    and locate it under “My Profile.”`;
 
   public statusImg = {
     "Failed":{

--- a/src/portfolio/components/PortfolioDrawer.spec.ts
+++ b/src/portfolio/components/PortfolioDrawer.spec.ts
@@ -169,7 +169,7 @@ describe("Testing Portfolio Drawer component", () => {
       expect(result.length).toBeGreaterThan(0)
     })
     it("Test getTag(archived)- showed return tags based on Portfolio.status",()=>{
-      wrapper.vm.$data.portfolioStatus = "archived"
+      wrapper.vm.$data.portfolioStatus = PortFolioStatusTypes.Archived
       const result = wrapper.vm.getBgColor()
       expect(result.length).toBeGreaterThan(0)
     })

--- a/src/portfolio/components/PortfolioDrawer.vue
+++ b/src/portfolio/components/PortfolioDrawer.vue
@@ -183,7 +183,7 @@ import ATATSelect from "@/components/ATATSelect.vue";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import PortfolioRolesLearnMore from "@/portfolio/components/PortfolioRolesLearnMore.vue";
 
-import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
+import PortfolioData, { PortfolioDataStore, PortFolioStatusTypes } from "@/store/portfolio";
 import SlideoutPanel from "@/store/slideoutPanel/index";
 import Toast from "@/store/toast";
 
@@ -197,6 +197,7 @@ import {
 import { format, parseISO } from "date-fns";
 import _ from "lodash";
 import MemberCard from "@/portfolio/components/MemberCard.vue";
+import { getStatusChipBgColor } from "@/helpers";
 
 @Component({
   components: {
@@ -257,21 +258,7 @@ export default class PortfolioDrawer extends Vue {
   }
 
   public getBgColor(): string {
-    switch (this.portfolioStatus) {
-    case PortFolioStatusTypes.Active:
-      return "bg-success";
-    case PortFolioStatusTypes.Processing:
-      return "bg-info-dark";
-    case PortFolioStatusTypes.AtRisk:
-      return "bg-warning";
-    case PortFolioStatusTypes.Delinquent:
-    case PortFolioStatusTypes.Expired:
-      return "bg-error";
-    case "archived":
-      return "bg-base-dark";
-    default:
-      return "";
-    }
+    return getStatusChipBgColor(this.portfolioStatus);
   }
 
   public async loadPortfolio(): Promise<void> {

--- a/src/portfolio/components/PortfolioDrawer.vue
+++ b/src/portfolio/components/PortfolioDrawer.vue
@@ -183,7 +183,7 @@ import ATATSelect from "@/components/ATATSelect.vue";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import PortfolioRolesLearnMore from "@/portfolio/components/PortfolioRolesLearnMore.vue";
 
-import PortfolioData, { PortfolioDataStore, PortFolioStatusTypes } from "@/store/portfolio";
+import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
 import SlideoutPanel from "@/store/slideoutPanel/index";
 import Toast from "@/store/toast";
 

--- a/src/portfolios/Index.vue
+++ b/src/portfolios/Index.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-main>
+  <v-main class="pb-20">
     <div>
       Future Portfolios page
     </div>
@@ -7,7 +7,7 @@
       link portfolio Summary
     </v-btn>
 
-    <div class="mt-10">
+    <div class="mt-10" style="padding-bottom: 100px;">
       <PortfolioCard
         v-for="(cardData, index) in portfolioCardData"
         :key="index"
@@ -16,6 +16,7 @@
         :isLastCard="index === portfolioCardData.length - 1"
       />
     </div>
+
   </v-main>
 </template>
 <script lang="ts">
@@ -63,7 +64,7 @@ export default class Portfolios extends Vue {
     },
     {
       title: "DEF456 portfolio",
-      status: "Processing",
+      status: "At-Risk",
       csp: "google",
       branch: "Navy",
       lastModified: "Last modified Sept. 1, 2022",
@@ -74,7 +75,7 @@ export default class Portfolios extends Vue {
     },
     {
       title: "GHI789 portfolio",
-      status: "Processing",
+      status: "Delinquent",
       csp: "oracle",
       branch: "Marine Corps",
       lastModified: "Last modified Sept. 1, 2022",

--- a/src/portfolios/Index.vue
+++ b/src/portfolios/Index.vue
@@ -6,21 +6,65 @@
     <v-btn @click="changeSection">
       link portfolio Summary
     </v-btn>
+
+    <div class="mt-10">
+      <PortfolioCard
+        v-for="(cardData, index) in portfolioCardData"
+        :key="index"
+        :cardData="cardData"
+        :index="index"
+        :isLastCard="index === portfolioCardData.length - 1"
+      />
+    </div>
   </v-main>
 </template>
 <script lang="ts">
 import Vue from "vue";
-
-
 import { Component } from "vue-property-decorator";
+
+import PortfolioCard from "./components/PortfolioCard.vue";
+
 import AppSections from "@/store/appSections";
+import { PortfolioCardData } from "types/Global";
+
 @Component({
+  components: {
+    PortfolioCard
+  }
 })
+
 export default class Portfolios extends Vue {
   public async changeSection(): Promise<void> {
-    const sectionData = await AppSections.getSectionData();
     AppSections.changeActiveSection("Portfolio Summary")
   }
+
+  public portfolioCardData: PortfolioCardData[] = [
+    {
+      title: "ABC123 portfolio",
+      status: "Processing",
+      csp: "azure",
+      branch: "Joint Force",
+      lastModified: "Started 23 minutes ago",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+    {
+      title: "Army-Navy Game",
+      status: "Active",
+      csp: "aws",
+      branch: "Army",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "Oct. 1, 2022 - Sept. 31, 2023",
+      totalObligated: "$1,000,000.00",
+      fundsSpent: "$500,000",
+      fundsSpentPercent: "50",
+    }
+  ];
+
+
 }
+
 </script>
 

--- a/src/portfolios/Index.vue
+++ b/src/portfolios/Index.vue
@@ -42,7 +42,7 @@ export default class Portfolios extends Vue {
     {
       title: "ABC123 portfolio",
       status: "Processing",
-      csp: "azure",
+      csp: "aws",
       branch: "Joint Force",
       lastModified: "Started 23 minutes ago",
       currentPoP: "",
@@ -53,14 +53,37 @@ export default class Portfolios extends Vue {
     {
       title: "Army-Navy Game",
       status: "Active",
-      csp: "aws",
+      csp: "azure",
       branch: "Army",
       lastModified: "Last modified Sept. 1, 2022",
       currentPoP: "Oct. 1, 2022 - Sept. 31, 2023",
       totalObligated: "$1,000,000.00",
       fundsSpent: "$500,000",
       fundsSpentPercent: "50",
-    }
+    },
+    {
+      title: "DEF456 portfolio",
+      status: "Processing",
+      csp: "google",
+      branch: "Navy",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+    {
+      title: "GHI789 portfolio",
+      status: "Processing",
+      csp: "oracle",
+      branch: "Marine Corps",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+
   ];
 
 

--- a/src/portfolios/Index.vue
+++ b/src/portfolios/Index.vue
@@ -32,14 +32,16 @@
         class="container-max-width"
         style="margin-bottom:300px !important"
       >
-        <v-btn @click="changeSection">
-          link portfolio Summary
-        </v-btn>
         <AllPortfolios v-if="tabItems[tabIndex] === 'All portfolios'" />
         <ProcessingPortfolios v-if="tabItems[tabIndex] === 'Processing'"/>
         <ActivePortfolios
           v-if="tabItems[tabIndex] === 'Active'"
         />
+
+        <v-btn @click="changeSection" class="my-10">
+          link portfolio Summary
+        </v-btn>
+
       </v-container>
       <ATATFooter/>
     </v-main>

--- a/src/portfolios/components/AllPortfolios.vue
+++ b/src/portfolios/components/AllPortfolios.vue
@@ -29,54 +29,45 @@ import { PortfolioCardData } from "types/Global";
 })
 
 export default class AllPortfolios extends Vue {
-  // dummy data until backend ready
-  public portfolioCardData: PortfolioCardData[] = [
-    {
-      title: "ABC123 portfolio",
-      status: "Processing",
-      csp: "aws",
-      branch: "Joint Force",
-      lastModified: "Started 23 minutes ago",
-      currentPoP: "",
-      totalObligated: "",
-      fundsSpent: "",
-      fundsSpentPercent: "",
-    },
-    {
-      title: "Army-Navy Game",
-      status: "Active",
-      csp: "azure",
-      branch: "Army",
-      lastModified: "Last modified Sept. 1, 2022",
-      currentPoP: "Oct. 1, 2022 - Sept. 31, 2023",
-      totalObligated: "$1,000,000.00",
-      fundsSpent: "$500,000",
-      fundsSpentPercent: "50",
-    },
-    {
-      title: "DEF456 portfolio",
-      status: "At-Risk",
-      csp: "google",
-      branch: "Navy",
-      lastModified: "Last modified Sept. 1, 2022",
-      currentPoP: "",
-      totalObligated: "",
-      fundsSpent: "",
-      fundsSpentPercent: "",
-    },
-    {
-      title: "GHI789 portfolio",
-      status: "Delinquent",
-      csp: "oracle",
-      branch: "Marine Corps",
-      lastModified: "Last modified Sept. 1, 2022",
-      currentPoP: "",
-      totalObligated: "",
-      fundsSpent: "",
-      fundsSpentPercent: "",
-    },
-  ];
+  public portfolioCardData: PortfolioCardData[] = []
 
+  // delete this function when backend hooked up with actual data
+  public async generateDummyObj(
+    title?: string,
+    status?: string,
+    csp?: string,
+    branch?: string,
+    lastModified?: string,
+    currentPoP?: string,
+    totalObligated?: string,
+    fundsSpent?: string,
+    fundsSpentPercent?: string,
+  ): Promise<PortfolioCardData> {
+    return {
+      title, status, csp, branch, lastModified, currentPoP, 
+      totalObligated, fundsSpent, fundsSpentPercent
+    }
+  }
+
+  // delete this function when backend hooked up with actual data
+  public async generateDummyData(): Promise<void> {
+    const cardObjValues = [
+      ["ABC123 portfolio", "Processing", "aws", "Joint Force", "Started 23 minutes ago"],
+      // eslint-disable-next-line max-len
+      ["Army-Navy Game", "Active", "azure", "Army", "Last modified Sept. 1, 2022", "Oct. 1, 2022 - Sept. 31, 2023", "$1,000,000.00", "$500,000", "50"],
+      ["DEF456 portfolio", "At-Risk", "google", "Navy", "Last modified Sept. 2, 2022"],
+      ["GHI789 portfolio", "Delinquent", "oracle", "Marine Corps", "Last modified Sept. 3, 2022"]
+    ]
+    cardObjValues.forEach(async (values) => {
+      const obj = await this.generateDummyObj(...values);
+      this.portfolioCardData.push(obj);
+    });
+  }
+
+  public async mounted(): Promise<void> {
+    // delete next line when backend hooked up with actual data
+    await this.generateDummyData();
+  }
 }
 </script>
 

--- a/src/portfolios/components/AllPortfolios.vue
+++ b/src/portfolios/components/AllPortfolios.vue
@@ -1,15 +1,82 @@
 <template>
-  <v-main>
+  <div>
+  
     Future page for All Portfolios
-  </v-main>
+
+    <div class="mt-10">
+      <PortfolioCard
+        v-for="(cardData, index) in portfolioCardData"
+        :key="index"
+        :cardData="cardData"
+        :index="index"
+        :isLastCard="index === portfolioCardData.length - 1"
+      />
+    </div>
+
+  </div>
 </template>
 <script lang="ts">
 import Vue from "vue";
 
 import { Component } from "vue-property-decorator";
+import PortfolioCard from "./PortfolioCard.vue";
+import { PortfolioCardData } from "types/Global";
+
 @Component({
+  components: {
+    PortfolioCard
+  }
 })
+
 export default class AllPortfolios extends Vue {
+  // dummy data until backend ready
+  public portfolioCardData: PortfolioCardData[] = [
+    {
+      title: "ABC123 portfolio",
+      status: "Processing",
+      csp: "aws",
+      branch: "Joint Force",
+      lastModified: "Started 23 minutes ago",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+    {
+      title: "Army-Navy Game",
+      status: "Active",
+      csp: "azure",
+      branch: "Army",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "Oct. 1, 2022 - Sept. 31, 2023",
+      totalObligated: "$1,000,000.00",
+      fundsSpent: "$500,000",
+      fundsSpentPercent: "50",
+    },
+    {
+      title: "DEF456 portfolio",
+      status: "At-Risk",
+      csp: "google",
+      branch: "Navy",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+    {
+      title: "GHI789 portfolio",
+      status: "Delinquent",
+      csp: "oracle",
+      branch: "Marine Corps",
+      lastModified: "Last modified Sept. 1, 2022",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    },
+  ];
+
 }
 </script>
 

--- a/src/portfolios/components/PortfolioCard.spec.ts
+++ b/src/portfolios/components/PortfolioCard.spec.ts
@@ -3,18 +3,40 @@ import Vuetify from "vuetify";
 import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import { DefaultProps } from "vue/types/options";
 import PortfolioCard from "@/portfolios/components/PortfolioCard.vue";
+import { PortfolioCardData } from "types/Global";
+
 Vue.use(Vuetify);
+
+
 
 describe("Testing index Component", () => {
   const localVue = createLocalVue();
   let vuetify: Vuetify;
   let wrapper: Wrapper<DefaultProps & Vue, Element>;
 
+  const cardData: PortfolioCardData =
+    {
+      title: "ABC123 portfolio",
+      status: "Processing",
+      csp: "aws",
+      branch: "Joint Force",
+      lastModified: "Started 23 minutes ago",
+      currentPoP: "",
+      totalObligated: "",
+      fundsSpent: "",
+      fundsSpentPercent: "",
+    };
+
   beforeEach(() => {
     vuetify = new Vuetify();
     wrapper = mount(PortfolioCard, {
       localVue,
       vuetify,
+      propsData:({
+        cardData,
+        index: 0,
+        isLastCard: false,
+      })      
     });
   });
 
@@ -22,4 +44,22 @@ describe("Testing index Component", () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-})
+  it("generates ID string", async () => {
+    const str = "My String";
+    const ID = wrapper.vm.getIdText(str);
+    expect(ID).toBe("MyString");
+  });
+
+  it("gets status chip background color", async () => {
+    const bgColor = wrapper.vm.statusChipBgColor;
+    expect(bgColor.length).toBeGreaterThan(0);
+  });
+
+  it("gets NO status chip background color", async () => {
+    wrapper.vm.$props.cardData.status = undefined;
+    const bgColor = wrapper.vm.statusChipBgColor;
+    expect(bgColor.length).toEqual(0);
+  });
+
+
+});

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -4,8 +4,33 @@
     :class="{ '_first': index === 0, '_last': isLastCard }"
     elevation="0"
   >
+
     <div class="pr-5">
-      <div class="font-size-10 text-base-light">CSP logo</div>
+      <div class="d-flex align-center" style="width: 48px; height: 48px;">
+        <v-tooltip
+          transition="slide-y-reverse-transition"
+          color="rgba(0,0,0,1)"
+          top
+          :open-on-hover="true"
+          :open-delay="500"
+        >
+          <template v-slot:activator="{ on, attrs }">
+            <span
+              v-bind="attrs"
+              v-on="on"
+            >
+              <ATATSVGIcon 
+                :name="CSPs[cardData.csp].img.name" 
+                :width="CSPs[cardData.csp].img.width" 
+                :height="CSPs[cardData.csp].img.height" 
+              />
+            </span>
+          </template>
+          <div class="_tooltip-content-wrap">
+            {{ CSPs[cardData.csp].title }}
+          </div>
+        </v-tooltip>
+      </div>
     </div>
     <div class="pr-5 flex-grow-1">
       <div
@@ -150,6 +175,41 @@ export default class PortfolioCard extends Vue {
 
   private getIdText(string: string) {
     return getIdText(string);
+  }
+
+  public CSPs = {
+    aws: {
+      title: "Amazon Web Services",
+      img: {
+        name:"aws",
+        width:"48",
+        height:"29"
+      }
+    },
+    azure: {
+      title: "Azure",
+      img: {
+        name:"azure",
+        width:"48",
+        height:"37",
+      }
+    },
+    google: {
+      title: "Google Cloud Platform",
+      img: {
+        name:"gcp",
+        width:"48",
+        height:"47"
+      }
+    },
+    oracle: {
+      title: "Oracle",
+      img: {
+        name:"oracle",
+        width:"48",
+        height:"30"
+      }
+    },
   }
 
 }

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -135,7 +135,7 @@ import { Component, Prop } from "vue-property-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 
 import { PortfolioCardData } from "types/Global";
-import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
+import { PortFolioStatusTypes } from "@/store/portfolio";
 import { getIdText, getStatusChipBgColor } from "@/helpers";
 
 @Component({

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -5,7 +5,7 @@
     elevation="0"
   >
     <div class="pr-5">
-      <div class="logo">{{ cardData.csp }} logo</div>
+      <div class="font-size-10 text-base-light">CSP logo</div>
     </div>
     <div class="pr-5 flex-grow-1">
       <div
@@ -51,22 +51,25 @@
         <span class="nowrap">{{ cardData.lastModified }}</span>
       </div>
 
-      <v-row v-if="cardData.status === portfolioStatuses.Active">
+      <div 
+        v-if="cardData.status === portfolioStatuses.Active"
+        class="d-flex"
+      >
 
-        <v-col class="col-12 col-md-4 col-lg-6">
+        <div class="mr-15">
           <span class="_data-header">Current Period of Performance</span>
           <span class="_data-primary d-block">
             {{ cardData.currentPoP }}
           </span>
-        </v-col>
+        </div>
 
-        <v-col class="col-12 col-md-4 col-lg-3 col-xl-2">
+        <div class="mr-15">
           <span class="_data-header">Total Obligated</span>
           <span class="_data-primary d-block nowrap">
             {{ cardData.totalObligated }}
           </span>
-        </v-col>
-        <v-col class="col-12 col-md-4 col-lg-3">
+        </div>
+        <div class="flex-grow-1">
           <span class="_data-header">Funds Spent (%)</span>
           <span class="_data-primary d-block">
             <span class="mr-1 nowrap">{{ cardData.fundsSpent }}</span>
@@ -74,39 +77,41 @@
               ({{ cardData.fundsSpentPercent }}%)
             </span>
           </span>
-        </v-col>
+        </div>
 
-      </v-row>
+      </div>
     </div>
     <div>
-      <!-- <v-menu
-        transition="slide-y-transition"
-        offset-y
-        nudge-left="192"
-        nudge-top="1"
+
+      <v-menu
+        :offset-y="true"
+        left
+        id="MoreMenu"
+        class="_meatball-menu"
+        attach
       >
         <template v-slot:activator="{ on, attrs }">
           <v-btn
-            :id="moreButtonId(card.id)"
             v-bind="attrs"
             v-on="on"
-            class="meatball-menu-button mt-n1 width-auto pa-0"
+            id="MoreMenuButton"
+            class="_meatball-menu-button"
           >
-            <v-icon class="width-auto">more_horiz</v-icon>
+            <v-icon class="text-base-dark">more_horiz</v-icon>
           </v-btn>
         </template>
-        <v-list class="meatball-menu pa-0">
+  
+        <v-list>
           <v-list-item
-            v-for="(menuOptionText, index) in menuOptions"
+            v-for="(item, index) in moreMenuItems"
             :key="index"
-            @click="handleMenuClick(menuOptionText, $event, card)"
+            :id="getIdText(item.title) + '_MenuItem'"
           >
-            <v-list-item-title class="body-lg py-2">
-              {{ menuOptionText }}
-            </v-list-item-title>
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
           </v-list-item>
         </v-list>
-      </v-menu> -->
+      </v-menu>         
+
     </div>
   </v-card>
 </template>
@@ -118,7 +123,8 @@ import { Component, Prop } from "vue-property-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 
 import { PortfolioCardData } from "types/Global";
-import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
+import { PortFolioStatusTypes } from "@/store/portfolio";
+import { getIdText } from "@/helpers";
 
 @Component({
   components: {
@@ -132,6 +138,19 @@ export default class PortfolioCard extends Vue {
   @Prop() private isLastCard!: boolean;
 
   public portfolioStatuses = PortFolioStatusTypes;
+
+  public moreMenuItems = [
+    {
+      title: "Item 1",
+    },
+    {
+      title: "Item 2",
+    },
+  ];
+
+  private getIdText(string: string) {
+    return getIdText(string);
+  }
 
 }
 

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -1,15 +1,139 @@
 <template>
-  <div>
-    Future page for Portfolio Card
-  </div>
+  <v-card
+    class="_portfolio-summary-card-wrapper width-100 py-5 px-6 d-flex"
+    :class="{ '_first': index === 0, '_last': isLastCard }"
+    elevation="0"
+  >
+    <div class="pr-5">
+      <div class="logo">{{ cardData.csp }} logo</div>
+    </div>
+    <div class="pr-5 flex-grow-1">
+      <div
+        class="d-flex flex-row-reverse flex-md-row flex-column-reverse"
+      >
+        <div class="card-header flex-grow-1">
+          <a
+            role="button"
+            tabindex="0"
+            class="h3 _text-decoration-none"
+          >
+            {{ cardData.title }}
+          </a>
+        </div>
+        <div
+          v-if="cardData.status !== portfolioStatuses.Active"
+          class="
+            status-alert-banner-wrapper
+            ml-md-5
+            text-md-right
+            mb-2 mb-md-0
+          "
+        >
+          <v-chip 
+            :id="'StatusChip' + index" 
+            :class="'_' + cardData.status.toLowerCase()" 
+            label
+          >
+            {{ cardData.status }}
+          </v-chip>
+
+        </div>
+      </div>
+      <div class="text-base-dark">
+        <span>{{ cardData.branch }}</span>
+        <ATATSVGIcon 
+          name="bullet" 
+          color="base-light" 
+          :width="9" 
+          :height="9" 
+          class="d-inline-block ml-2 mr-3" 
+        />
+        <span class="nowrap">{{ cardData.lastModified }}</span>
+      </div>
+
+      <v-row v-if="cardData.status === portfolioStatuses.Active">
+
+        <v-col class="col-12 col-md-4 col-lg-6">
+          <span class="_data-header">Current Period of Performance</span>
+          <span class="_data-primary d-block">
+            {{ cardData.currentPoP }}
+          </span>
+        </v-col>
+
+        <v-col class="col-12 col-md-4 col-lg-3 col-xl-2">
+          <span class="_data-header">Total Obligated</span>
+          <span class="_data-primary d-block nowrap">
+            {{ cardData.totalObligated }}
+          </span>
+        </v-col>
+        <v-col class="col-12 col-md-4 col-lg-3">
+          <span class="_data-header">Funds Spent (%)</span>
+          <span class="_data-primary d-block">
+            <span class="mr-1 nowrap">{{ cardData.fundsSpent }}</span>
+            <span class="text-base font-size-12 nowrap">
+              ({{ cardData.fundsSpentPercent }}%)
+            </span>
+          </span>
+        </v-col>
+
+      </v-row>
+    </div>
+    <div>
+      <!-- <v-menu
+        transition="slide-y-transition"
+        offset-y
+        nudge-left="192"
+        nudge-top="1"
+      >
+        <template v-slot:activator="{ on, attrs }">
+          <v-btn
+            :id="moreButtonId(card.id)"
+            v-bind="attrs"
+            v-on="on"
+            class="meatball-menu-button mt-n1 width-auto pa-0"
+          >
+            <v-icon class="width-auto">more_horiz</v-icon>
+          </v-btn>
+        </template>
+        <v-list class="meatball-menu pa-0">
+          <v-list-item
+            v-for="(menuOptionText, index) in menuOptions"
+            :key="index"
+            @click="handleMenuClick(menuOptionText, $event, card)"
+          >
+            <v-list-item-title class="body-lg py-2">
+              {{ menuOptionText }}
+            </v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu> -->
+    </div>
+  </v-card>
 </template>
+
 <script lang="ts">
 import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
 
-import { Component } from "vue-property-decorator";
+import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
+
+import { PortfolioCardData } from "types/Global";
+import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
+
 @Component({
+  components: {
+    ATATSVGIcon,
+  }
 })
+
 export default class PortfolioCard extends Vue {
+  @Prop() private cardData!: PortfolioCardData;
+  @Prop() private index!: number;
+  @Prop() private isLastCard!: boolean;
+
+  public portfolioStatuses = PortFolioStatusTypes;
+
 }
+
 </script>
 

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -1,12 +1,12 @@
 <template>
   <v-card
-    class="_portfolio-summary-card-wrapper width-100 py-5 px-6 d-flex"
+    class="_portfolio-summary-card-wrapper"
     :class="{ '_first': index === 0, '_last': isLastCard }"
     elevation="0"
   >
 
     <div class="pr-5">
-      <div class="d-flex align-center" style="width: 48px; height: 48px;">
+      <div class="_csp-icon-wrap">
         <v-tooltip
           transition="slide-y-reverse-transition"
           color="rgba(0,0,0,1)"
@@ -32,10 +32,8 @@
         </v-tooltip>
       </div>
     </div>
-    <div class="pr-5 flex-grow-1">
-      <div
-        class="d-flex flex-row-reverse flex-md-row flex-column-reverse"
-      >
+    <div class="pr-8 flex-grow-1">
+      <div class="d-flex">
         <div class="card-header flex-grow-1">
           <a
             role="button"
@@ -45,18 +43,13 @@
             {{ cardData.title }}
           </a>
         </div>
-        <div
-          v-if="cardData.status !== portfolioStatuses.Active"
-          class="
-            status-alert-banner-wrapper
-            ml-md-5
-            text-md-right
-            mb-2 mb-md-0
-          "
-        >
+        <div v-if="cardData.status !== portfolioStatuses.Active">
           <v-chip 
             :id="'StatusChip' + index" 
-            :class="'_' + cardData.status.toLowerCase()" 
+            :class="[
+              '_' + cardData.status.toLowerCase(),
+              statusChipBgColor
+            ]" 
             label
           >
             {{ cardData.status }}
@@ -65,22 +58,18 @@
         </div>
       </div>
       <div class="text-base-dark">
-        <span>{{ cardData.branch }}</span>
+        {{ cardData.branch }}
         <ATATSVGIcon 
           name="bullet" 
           color="base-light" 
           :width="9" 
           :height="9" 
-          class="d-inline-block ml-2 mr-3" 
+          class="d-inline-block mx-1" 
         />
-        <span class="nowrap">{{ cardData.lastModified }}</span>
+        {{ cardData.lastModified }}
       </div>
 
-      <div 
-        v-if="cardData.status === portfolioStatuses.Active"
-        class="d-flex"
-      >
-
+      <div v-if="cardData.status === portfolioStatuses.Active" class="d-flex">
         <div class="mr-15">
           <span class="_data-header">Current Period of Performance</span>
           <span class="_data-primary d-block">
@@ -106,38 +95,36 @@
 
       </div>
     </div>
-    <div>
 
-      <v-menu
-        :offset-y="true"
-        left
-        id="MoreMenu"
-        class="_meatball-menu"
-        attach
-      >
-        <template v-slot:activator="{ on, attrs }">
-          <v-btn
-            v-bind="attrs"
-            v-on="on"
-            id="MoreMenuButton"
-            class="_meatball-menu-button"
-          >
-            <v-icon class="text-base-dark">more_horiz</v-icon>
-          </v-btn>
-        </template>
-  
-        <v-list>
-          <v-list-item
-            v-for="(item, index) in moreMenuItems"
-            :key="index"
-            :id="getIdText(item.title) + '_MenuItem'"
-          >
-            <v-list-item-title>{{ item.title }}</v-list-item-title>
-          </v-list-item>
-        </v-list>
-      </v-menu>         
+    <v-menu
+      :offset-y="true"
+      left
+      id="MoreMenu"
+      class="_meatball-menu"
+      attach
+    >
+      <template v-slot:activator="{ on, attrs }">
+        <v-btn
+          v-bind="attrs"
+          v-on="on"
+          id="MoreMenuButton"
+          class="_meatball-menu-button"
+        >
+          <v-icon class="text-base-dark">more_horiz</v-icon>
+        </v-btn>
+      </template>
 
-    </div>
+      <v-list>
+        <v-list-item
+          v-for="(item, index) in moreMenuItems"
+          :key="index"
+          :id="getIdText(item.title) + '_MenuItem'"
+        >
+          <v-list-item-title>{{ item.title }}</v-list-item-title>
+        </v-list-item>
+      </v-list>
+    </v-menu>         
+
   </v-card>
 </template>
 
@@ -148,8 +135,8 @@ import { Component, Prop } from "vue-property-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 
 import { PortfolioCardData } from "types/Global";
-import { PortFolioStatusTypes } from "@/store/portfolio";
-import { getIdText } from "@/helpers";
+import PortfolioData, { PortFolioStatusTypes } from "@/store/portfolio";
+import { getIdText, getStatusChipBgColor } from "@/helpers";
 
 @Component({
   components: {
@@ -165,16 +152,16 @@ export default class PortfolioCard extends Vue {
   public portfolioStatuses = PortFolioStatusTypes;
 
   public moreMenuItems = [
-    {
-      title: "Item 1",
-    },
-    {
-      title: "Item 2",
-    },
+    { title: "Item 1" },
+    { title: "Item 2" },
   ];
 
   private getIdText(string: string) {
     return getIdText(string);
+  }
+
+  public get statusChipBgColor(): string {
+    return getStatusChipBgColor(this.cardData.status ? this.cardData.status : "");
   }
 
   public CSPs = {
@@ -182,32 +169,32 @@ export default class PortfolioCard extends Vue {
       title: "Amazon Web Services",
       img: {
         name:"aws",
-        width:"48",
-        height:"29"
+        width:"40",
+        height:"24"
       }
     },
     azure: {
       title: "Azure",
       img: {
         name:"azure",
-        width:"48",
-        height:"37",
+        width:"40",
+        height:"31",
       }
     },
     google: {
       title: "Google Cloud Platform",
       img: {
         name:"gcp",
-        width:"48",
-        height:"47"
+        width:"40",
+        height:"39"
       }
     },
     oracle: {
       title: "Oracle",
       img: {
         name:"oracle",
-        width:"48",
-        height:"30"
+        width:"40",
+        height:"25"
       }
     },
   }

--- a/src/sass/atat.scss
+++ b/src/sass/atat.scss
@@ -24,6 +24,7 @@
 @import "./components/ATATFooter";
 @import "./components/ATATPageHead";
 @import "./components/ATATPhoneInput";
+@import "./components/ATATPortfolioCard";
 @import "./components/ATATRadioGroup";
 @import "./components/ATATSelect";
 @import "./components/ATATSearch";

--- a/src/sass/components/ATATButton.scss
+++ b/src/sass/components/ATATButton.scss
@@ -159,3 +159,35 @@
   }
  
 }
+
+._meatball-menu {
+  .v-list-item__title {
+    font-size: 1.4rem;
+  }
+
+  .v-list-item {
+    &:hover {
+      background-color: $base-lightest;
+    }
+  }
+}
+
+._meatball-menu-button {
+  &.v-btn.v-size--default {
+    min-width: 28px;
+    width: 28px;
+    height: 28px;
+    padding: 0 !important;
+    border-radius: 4px;
+    background-color: transparent;
+    
+    &:hover {
+      background-color: $base-lightest !important;
+    }
+
+    &[aria-expanded=true] {
+      background-color: $primary-lighter !important;
+    }
+  }
+}
+

--- a/src/sass/components/ATATPortfolioCard.scss
+++ b/src/sass/components/ATATPortfolioCard.scss
@@ -1,6 +1,6 @@
 ._portfolio-summary-card-wrapper.v-sheet.v-card {
   width: 100%;
-  padding: 20px 24px;
+  padding: 24px 32px !important;
   border: 1px solid $base-lighter !important;
   border-bottom: none !important;
   border-radius: 0;
@@ -10,6 +10,7 @@
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
   }
+  
   &._last {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;

--- a/src/sass/components/ATATPortfolioCard.scss
+++ b/src/sass/components/ATATPortfolioCard.scss
@@ -1,0 +1,30 @@
+._portfolio-summary-card-wrapper.v-sheet.v-card {
+  width: 100%;
+  padding: 20px 24px;
+  border: 1px solid $base-lighter !important;
+  border-bottom: none !important;
+  border-radius: 0;
+  font-size: 1.4rem;
+
+  &._first {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+  }
+  &._last {
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom: 1px solid $base-lighter !important;
+  }
+
+  ._data-header {
+    font-size: 1rem;
+    font-weight: 700;
+    color: $base-dark;
+    line-height: 1.1rem;
+  }
+
+  ._data-primary {
+    color: $base-darkest;
+    line-height: 1;
+  }
+}

--- a/src/sass/components/ATATPortfolioCard.scss
+++ b/src/sass/components/ATATPortfolioCard.scss
@@ -1,6 +1,7 @@
 ._portfolio-summary-card-wrapper.v-sheet.v-card {
+  display: flex;
   width: 100%;
-  padding: 24px 32px !important;
+  padding: 24px 32px 24px 28px !important;
   border: 1px solid $base-lighter !important;
   border-bottom: none !important;
   border-radius: 0;
@@ -10,11 +11,19 @@
     border-top-left-radius: 4px;
     border-top-right-radius: 4px;
   }
-  
+
   &._last {
     border-bottom-left-radius: 4px;
     border-bottom-right-radius: 4px;
     border-bottom: 1px solid $base-lighter !important;
+  }
+
+  ._csp-icon-wrap {
+    display: flex;
+    align-items: center;
+    width: 48px;
+    height: 48px;
+    padding: 4px;
   }
 
   ._data-header {

--- a/src/sass/utils/typography.scss
+++ b/src/sass/utils/typography.scss
@@ -278,9 +278,6 @@ $sizes: 16, 18, 20, 22, 24, 26, 28, 32, 50, 60, 65, 200;
       color: $base-darkest;
     }
   }
-  &._processing {
-    background-color: $info-dark !important;
-  }
 }
 
 ._semibold {

--- a/src/sass/utils/typography.scss
+++ b/src/sass/utils/typography.scss
@@ -174,7 +174,7 @@ hr, .hr {
   }
 }
 
-.text-decoration-none {
+._text-decoration-none {
   text-decoration: none !important;
 }
 
@@ -237,11 +237,6 @@ $sizes: 16, 18, 20, 22, 24, 26, 28, 32, 50, 60, 65, 200;
   }
 }
 
-.separator-bullet {
-  display: inline-block;
-  font-size: 20px;
-}
-
 .text-clamp {
   display: -webkit-box;
   -webkit-box-orient: vertical;
@@ -282,6 +277,9 @@ $sizes: 16, 18, 20, 22, 24, 26, 28, 32, 50, 60, 65, 200;
     .v-chip__content {
       color: $base-darkest;
     }
+  }
+  &._processing {
+    background-color: $info-dark !important;
   }
 }
 

--- a/src/steps/05-PerformanceRequirements/DOW/Summary.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/Summary.vue
@@ -80,7 +80,7 @@
         <h2 class="mb-5">Other available categories</h2>
         <a
           id="ShowMoreLink"
-          class="expandable-content-opener mt-1 text-decoration-none"
+          class="expandable-content-opener mt-1 _text-decoration-none"
           :class="[{ 'open' : showMore }]"
           v-show="availableServiceGroups.length > 4"
           @click="showMore = !showMore"

--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -33,17 +33,14 @@ export const FundingAlertTypes = {
   POPFundsDepleted: "POPFundsDepleted",
   POPExpired: "POPExpired",
 };
-  
 
 export interface FundingAlertData {
-
-     alerts: AlertDTO[],
-     daysRemaining: number,
-     spendingViolation: number;
-     fundingAlertType: string;
-     hasLowFundingAlert: boolean;
+  alerts: AlertDTO[],
+  daysRemaining: number,
+  spendingViolation: number;
+  fundingAlertType: string;
+  hasLowFundingAlert: boolean;
 }
-
 
 export const getThresholdAmount = (value: string): number => {
   const stringVal = value.replace('%', '');

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -392,12 +392,12 @@ export interface Portfolio {
 }
 
 export interface PortfolioCardData extends Portfolio {
-  branch: string;
-  lastModified: string;
-  currentPoP: string;
-  totalObligated: string;
-  fundsSpent: string;
-  fundsSpentPercent: string;
+  branch?: string;
+  lastModified?: string;
+  currentPoP?: string;
+  totalObligated?: string;
+  fundsSpent?: string;
+  fundsSpentPercent?: string;
 }
 
 export interface EmailEntry {

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -391,6 +391,15 @@ export interface Portfolio {
   updated?: string;
 }
 
+export interface PortfolioCardData extends Portfolio {
+  branch: string;
+  lastModified: string;
+  currentPoP: string;
+  totalObligated: string;
+  fundsSpent: string;
+  fundsSpentPercent: string;
+}
+
 export interface EmailEntry {
   key: string;
   email: string;


### PR DESCRIPTION
Add the following elements to the src/portfolios/components/PortfolioCard.vue (See Figure 1.0) to accommodate for both active and processing cards.
1. The component card is to contain the following elements (for now style and stub in the values as they appear in both Figure 1.0 and 1.1)
    1. Avatar:  CSP logo
        1. Event: Hover
            1. Show tooltip (500ms delay) with the correct CSP name
                1. Amazon Web Services
                1. Google Cloud Platform
                1. Azure
                1. Oracle
    1. Headline:  name (See Figure 1.2, line 26)
    1. Text: Please stub in ‘Joint Force’
    1. Text: Please stub in ‘Last Modified Sept 1, 2022’
    1. Status Chip 
        1. Text: Temporarily add processing text with info-dark background color (as in Figure 1.0).  The chip will be upgraded in an upcoming task this sprint regarding notifications
    1. Text: (Please stub in as below, both styles and placement  – see Figure 1.1 –  to prepare for when data is provided)
        1. Current Period of Performance
        Oct. 1, 2021 - Sept. 31, 2022
    1. Text: (Please stub in as below, both styles and placement – see Figure 1.1 –  to prepare for when data is provided)
        1. Total Obligated
        $1,000,000.00
    1. Text: (Please stub in as below, both styles and placement  – see Figure 1.1 –  to prepare for when data is provided)
        1. Funds Spent (%)
        $500,000.00 (50%)
    1. Button
        1. Icon: more_horiz
            1. Event: Click - display menu (AC 2)
    1. Menu (See Figure 1.3)
        1. Options (temporary)
            1. Item 1
            1. Item 2
Portfolio card is to appear on the All portfolios tab