### PR TITLE
Removed duplicate add members modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --watch --no-cache src/steps/10-FinancialDetails/IGCE/CreatePriceEstimate.spec.ts",
+    "test-file:watch": "jest --watch --no-cache src/store/portfolio/index.spec.ts",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/src/portfolios/portfolio/components/shared/AddMembersModal.spec.ts
+++ b/src/portfolios/portfolio/components/shared/AddMembersModal.spec.ts
@@ -34,6 +34,33 @@ describe("Testing AddMembersModal", () => {
     expect(wrapper.vm.$data.enteredEmails.length).toEqual(0);  
   });
 
+  it("sets PorfolioData.setShowAddMembersModal to false when modal closes", async () => {
+    wrapper.setProps({showModal: false})
+    expect(PortfolioData.showAddMembersModal).toEqual(false);
+  });
+
+  it("sets PorfolioData.title to ensure $data.projectTitle is set correctly", async () => {
+    const dummyTitle = "dummy Title";
+    PortfolioData.setPortfolioData({
+      title: dummyTitle
+    })
+    await wrapper.vm.showModalChange(true);
+    expect(await wrapper.vm.$data.projectTitle).toBe(
+      dummyTitle
+    );
+  });
+
+  it("sets PorfolioData.title='' to ensure $data.projectTitle is set correctly", async () => {
+    const noTitle = "";
+    PortfolioData.setPortfolioData({
+      title: noTitle
+    })
+    await wrapper.vm.showModalChange(true);
+    expect(await wrapper.vm.$data.projectTitle).toBe(
+      "New Acquisition"
+    );
+  });
+
   it("validates email address - missing domain and @ symbol", async () => {
     wrapper.vm.$data.enteredEmails = [{ email: "", isValid: false }];
     const isValid = await wrapper.vm.validateEmail("foo", 0);
@@ -252,11 +279,9 @@ describe("Testing AddMembersModal", () => {
       ],
     });
     const emailInput = await wrapper.find("input[data-email-key='123']");
-    console.log("emailInput", emailInput)
     await emailInput.trigger("blur");
     Vue.nextTick(async () => {
       const emailDeleteButton = await wrapper.find("#RemoveEmail123");
-      console.log("emailDeleteButton", emailDeleteButton)
       await emailDeleteButton.trigger("click");
       expect(wrapper.vm.$data.enteredEmails.length).toBe(0);
     });

--- a/src/portfolios/portfolio/components/shared/AddMembersModal.vue
+++ b/src/portfolios/portfolio/components/shared/AddMembersModal.vue
@@ -169,6 +169,8 @@ export default class AddMembersModal extends Vue {
           this.inputWidthFaker = document.getElementById("inputWidthFaker");
         });
       }
+    } else {
+      PortfolioData.setShowAddMembersModal(false);
     }
   }
 

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.spec.ts
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.spec.ts
@@ -83,6 +83,11 @@ describe("Testing Portfolio Drawer component", () => {
     expect(name).toBe(members[1].email);
   })
 
+  it("showMembersModal()", async()=>{
+    const showMembersModal = await wrapper.vm.showMembersModal;
+    expect(showMembersModal).toBe(false)
+  })
+
   it("membersInvited()", async () => {
     const _portfolio = {
       csp: "Azure",
@@ -101,9 +106,9 @@ describe("Testing Portfolio Drawer component", () => {
 
   });
 
-  it("openMembersModal() - call functionensure $data.showMembersModal===true", async()=>{
+  it("openMembersModal() - call function ensure $data.showMembersModal===true", async()=>{
     await wrapper.vm.openMembersModal()
-    expect(wrapper.vm.$data.showMembersModal).toBe(true);
+    expect(await wrapper.vm.showMembersModal).toBe(true);
   })
 
   it("onSelectedMemberRoleChanged() - pass params to successfully change roles ", async()=>{

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -220,7 +220,6 @@ export default class PortfolioDrawer extends Vue {
   public csp = "";
   public currentUser: User = {};
 
-  public showMembersModal = false;
   public showDeleteMemberDialog = false;
   public deleteMemberName = "";
   public deleteMemberIndex = -1;
@@ -241,6 +240,14 @@ export default class PortfolioDrawer extends Vue {
     { text: "Remove from portfolio", value: "Remove", isSelectable: false },
     { text: "About Roles", value: "AboutRoles", isSelectable: false },
   ];
+
+  public get showMembersModal(): boolean {
+    return PortfolioData.getShowAddMembersModal;
+  }
+
+  public set showMembersModal(value: boolean) {
+    PortfolioData.setShowAddMembersModal(value);
+  }
 
   public getMemberMenuItems(member: User): SelectData[] {
     const menuItems = _.cloneDeep(this.memberMenuItems);
@@ -314,7 +321,7 @@ export default class PortfolioDrawer extends Vue {
   }
 
   public openMembersModal(): void {
-    this.showMembersModal = true;
+    PortfolioData.setShowAddMembersModal(true);
   }
 
   private async onSelectedMemberRoleChanged(val: string, index: number): Promise<void> {

--- a/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.spec.ts
+++ b/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.spec.ts
@@ -5,6 +5,7 @@ import { DefaultProps } from "vue/types/options";
 import PortfolioSummaryPageHead from
   "@/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue";
 import SlideoutPanel from "@/store/slideoutPanel";
+import PortfolioData from "@/store/portfolio";
 Vue.use(Vuetify);
 
 describe("Testing Members Component", () => {
@@ -28,16 +29,47 @@ describe("Testing Members Component", () => {
     expect(wrapper.exists()).toBe(true);
   });
 
-  test("test openModal()- should change the value of showMemberModal", () => {
-    const memberModal = wrapper.vm.showMembersModal
-    expect(memberModal).toBe(false)
-    wrapper.vm.openModal();
-    Vue.nextTick(() => {
-      expect(memberModal).toBe(true)
+  it("test openModal() - check expected results", 
+    async () => {
+      await wrapper.vm.openModal();
+      expect(PortfolioData.showAddMembersModal).toBe(true);
     })
-  })
 
-  test("test openSlideoutPanel()- should toggle the value of showDrawer to true",async ()=> {
+  it("test openModal() - check expected results", 
+    async () => {
+      const booleanVar = true;
+      jest.spyOn(PortfolioData,'setShowAddMembersModal').mockImplementation(
+        ()=>{
+          return{
+            showAddMembersModal: booleanVar
+          }
+        }
+      )
+      await wrapper.vm.openModal();
+      expect(PortfolioData.showAddMembersModal).toBe(booleanVar);
+    })
+
+
+  it("test saveTitle() - check expected results ", 
+    async () => {
+      const dummyTitle = "dummyTitle";
+      jest.spyOn(PortfolioData,'getPortfolioData').mockImplementation(
+        ()=>Promise.resolve(
+          {
+            title: dummyTitle
+          }
+        ));
+      
+      await wrapper.setProps({
+        title: dummyTitle
+      })
+      await wrapper.vm.saveTitle();
+      expect(PortfolioData.portfolio.title).toBe(dummyTitle);
+    })
+
+
+
+  it("test openSlideoutPanel()- should toggle the value of showDrawer to true",async ()=> {
     jest.spyOn(SlideoutPanel,'openSlideoutPanel').mockImplementation()
     const eObject = {
       currentTarget: 'test', 
@@ -50,12 +82,35 @@ describe("Testing Members Component", () => {
     wrapper.vm.$nextTick(()=> expect(memberModal).toBe(true))
   })
 
-  test("test openSlideoutPanel()- should toggle the value of showDrawer to false",async ()=> {
+  it("test openSlideoutPanel()- should toggle the value of showDrawer to false",async ()=> {
     jest.spyOn(SlideoutPanel,'openSlideoutPanel').mockImplementation()
     wrapper.setData({showDrawer:true})
     const memberModal = wrapper.vm.showDrawer
     expect(memberModal).toBe(true)
     wrapper.vm.openSlideoutPanel()
     wrapper.vm.$nextTick(()=> expect(memberModal).toBe(false))
+  })
+
+  it("test openSlideoutPanel()- should toggle the value of showDrawer to false",async ()=> {
+    jest.spyOn(SlideoutPanel,'openSlideoutPanel').mockImplementation()
+    wrapper.setData({showDrawer:true})
+    const memberModal = wrapper.vm.showDrawer
+    expect(memberModal).toBe(true)
+    wrapper.vm.openSlideoutPanel()
+    wrapper.vm.$nextTick(()=> expect(memberModal).toBe(false))
+  })
+
+  it("movetoinput", async()=> {
+    // stub in necessary header text field textbox 
+    const id = "HeaderTextField";
+    const input = document.createElement("input");
+    input.setAttribute("type", "text");
+    input.setAttribute("id", id);
+    document.body.appendChild(input);
+
+    await wrapper.vm.moveToInput();
+    expect(document.activeElement?.id).toBe(id);
+
+
   })
 })

--- a/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
@@ -119,9 +119,6 @@
           </v-list>
         </v-menu>
       </div>
-      <AddMembersModal
-        :showModal.sync="showMembersModal"
-      />
     </div>
   </v-app-bar>
 </template>
@@ -159,11 +156,10 @@ export default class PortfolioSummaryPageHead extends Vue {
 
   public moreMenuOpen = false;
   public activeAppSection = AppSections.activeAppSection;
-  public showMembersModal = false;
   public showDrawer = false;
 
   public openModal():void {
-    this.showMembersModal = true;
+    PortfolioData.setShowAddMembersModal(true);
   }
 
   public saveTitle() {
@@ -204,6 +200,13 @@ export default class PortfolioSummaryPageHead extends Vue {
 
   private getIdText(string: string) {
     return getIdText(string);
+  }
+
+  public async mounted(): Promise<void> {
+    const slideoutPanelContent: SlideoutPanelContent = {
+      component: PortfolioDrawer,
+    }
+    await SlideoutPanel.setSlideoutPanelComponent(slideoutPanelContent);
   }
 
 }

--- a/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
@@ -162,7 +162,7 @@ export default class PortfolioSummaryPageHead extends Vue {
     PortfolioData.setShowAddMembersModal(true);
   }
 
-  public saveTitle() {
+  public saveTitle(): void {
     const obj ={
       title: this._title
     }

--- a/src/store/portfolio/index.spec.ts
+++ b/src/store/portfolio/index.spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import Vuex, { Store } from 'vuex';
-import { createLocalVue } from '@vue/test-utils';
+import { createLocalVue, createWrapper } from '@vue/test-utils';
 import {FundingAlertTypes, PortfolioDataStore,
   getThresholdAmount, thresholdAtOrAbove} from "@/store/portfolio/index";
 import { getModule } from 'vuex-module-decorators';
@@ -9,6 +9,7 @@ import storeHelperFunctions  from "../helpers";
 import Vue from "vue";
 import AcquisitionPackage, { StatusTypes } from "@/store/acquisitionPackage";
 import { AlertDTO } from '@/api/models';
+import { MemberInvites } from 'types/Global';
 const localVue = createLocalVue();
 localVue.use(Vuex);
 
@@ -128,6 +129,19 @@ describe("Portfolio Store", () => {
     expect(portfolioStore.portfolio.title).toBe("some title to test")
   })
 
+  it('getStatus() returns default result', async()=>{
+    expect(await portfolioStore.getStatus).toBe(StatusTypes.Active);
+  })
+
+  it('getShowAddMembersModal() returns default result', async()=>{
+    expect(await portfolioStore.getShowAddMembersModal).toBe(false);
+  })
+
+  it('setShowAddMembersModal() returns default result', async()=>{
+    await portfolioStore.setShowAddMembersModal(false)
+    expect(await portfolioStore.showAddMembersModal).toBe(false);
+  })
+
   it('Test setStoreData- sets portfolio to the passed in value', async () => {
     const mockData = {
       title: "some title to test",
@@ -235,6 +249,27 @@ describe("Portfolio Store", () => {
       expect(fundingAlertData.fundingAlertType).toBe(FundingAlertTypes.POPFundsAt100Percent);
       expect(fundingAlertData.hasLowFundingAlert).toBe(true);
     })
+  })
+
+  it('saveMembers() add members to Portfolio.portflio.members', async()=>{
+    const memberInvites: MemberInvites = {
+      emails:["dummyemail01@mail.mil", "dummyemail02@mail.mil"],
+      role: "Viewer"
+    } 
+    portfolioStore.portfolio.members = [];
+    await portfolioStore.saveMembers(memberInvites)
+    expect(portfolioStore.portfolio.members?.length).toBe(2)
+  })
+
+  it('getPortolioData()', async()=>{
+    const dummyTitle = "dummy Title";
+    portfolioStore.setPortfolioData(
+      {
+        title: dummyTitle
+      }
+    )
+    const portfolio = await portfolioStore.getPortfolioData();
+    expect(portfolio.title).toBe(dummyTitle)
   })
 
   it('Test getFundingTrackerAlerts Alerts Detect Expired', async () => {

--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -88,6 +88,20 @@ export class PortfolioDataStore extends VuexModule {
     return this.status;
   }
 
+  public showAddMembersModal = false;
+  public get getShowAddMembersModal(): boolean {
+    return this.showAddMembersModal;
+  }
+
+  @Action
+  public setShowAddMembersModal(show: boolean): void {
+    this.doSetShowAddMembersModal(show);
+  }
+  @Mutation
+  public doSetShowAddMembersModal(show: boolean): void {
+    this.showAddMembersModal = show;
+  }
+
   @Mutation
   public setInitialized(value: boolean): void {
     this.initialized = value;


### PR DESCRIPTION
Fix issue when opening "Add Members" to portfolio modal from the portfolio slideout drawer