### PR TITLE
Feature/at 8133 eval plan callout

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --watch --no-cache src/router/resolvers/index.spec.ts",
+    "test-file:watch": "jest --watch --no-cache src/steps/02-EvaluationCriteria/EvalPlan/EvalPlanDetails.spec.ts",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",
     "cypress:single-test": "npm run test:e2e --  --spec 'cypress/integration/ATATDevSnow/OtherContractConsiderations/Trainin*.spec.js'",

--- a/src/steps/02-EvaluationCriteria/EvalPlan/EvalPlanDetails.spec.ts
+++ b/src/steps/02-EvaluationCriteria/EvalPlan/EvalPlanDetails.spec.ts
@@ -25,7 +25,8 @@ describe("Testing NoEvalPlan Component", () => {
   let vuetify: Vuetify;
   let wrapper: Wrapper<DefaultProps & Vue, Element>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await AcquisitionPackage.setEvaluationPlan(evalPlanPopulated);
     vuetify = new Vuetify();
     wrapper = mount(EvalPlanDetails, {
       vuetify,
@@ -41,10 +42,47 @@ describe("Testing NoEvalPlan Component", () => {
 
   describe("testing methods", () => {
     it("loadOnEnter() - gets eval plan data from store", async () => {
-      await AcquisitionPackage.setEvaluationPlan(evalPlanPopulated);
       await wrapper.vm.loadOnEnter();
       expect(wrapper.vm.$data.evalPlan.source_selection).toBe("TechProposal")
     });
-  })
+
+  });
+
+  describe("testing getters", () => {
+    it ("gets header for tech proposal required", async () => {
+      expect(wrapper.vm.isStandards).toBeTruthy();
+      expect(wrapper.vm.header).toContain("proposals are required")  
+    });
+    it ("gets header for no proposal required", async () => {
+      await wrapper.setData({
+        // eslint-disable-next-line camelcase
+        evalPlan: { source_selection: "NoTechProposal" }
+      })
+
+      expect(wrapper.vm.isStandards).toBeTruthy();
+      expect(wrapper.vm.header).toContain("no technical proposal is required")    
+    });
+
+    it ("gets header for lump sum one CSP", async () => {
+      await wrapper.setData({
+        // eslint-disable-next-line camelcase
+        evalPlan: { source_selection: "SetLumpSum" }
+      })
+
+      expect(wrapper.vm.isStandards).toBeFalsy();
+      expect(wrapper.vm.header).toContain("assessment criteria")    
+    });
+
+    it ("gets header for lump sum multiple CSPs", async () => {
+      await wrapper.setData({
+        // eslint-disable-next-line camelcase
+        evalPlan: { source_selection: "EqualSetLumpSum" }
+      });
+
+      expect(wrapper.vm.isStandards).toBeFalsy();
+      expect(wrapper.vm.header).toContain("assessment criteria")    
+    });
+
+  });
 
 })

--- a/src/steps/02-EvaluationCriteria/EvalPlan/EvalPlanDetails.vue
+++ b/src/steps/02-EvaluationCriteria/EvalPlan/EvalPlanDetails.vue
@@ -2,16 +2,19 @@
 <template>
   <div class="container-max-width">
     <h1 class="page-header">
-      Now let’s review compliance standards when no technical proposal is required
+      {{ header }}
     </h1>
     <Callout 
+      :sourceSelection="evalPlan.source_selection"
+      :method="evalPlan.method"
     />
     
     <ATATRadioGroup
+      v-if="isStandards"
       id="CustomStandards"
-      :items="radioGroupItems"
+      :items="standardsRadioGroupItems"
       :legend="radioGroupLegend"
-      :value.sync="selectedRadioItem"
+      :value.sync="selectedStandardsRadioItem"
       :rules="[
         $validators.required('Please select an option.'),
       ]"
@@ -43,7 +46,25 @@ import { RadioButton } from "types/Global";
   }
 })
 
-export default class LumpSum extends Vue {
+export default class EvalPlanDetails extends Vue {
+
+  public get isStandards(): boolean {
+    return this.evalPlan.source_selection.indexOf("TechProposal") > -1;
+  }
+
+  public get header(): string {
+    switch(this.evalPlan.source_selection) {
+    case "NoTechProposal":
+      return "Now let’s review compliance standards when no technical proposal is required";
+    case "TechProposal":
+      return "Now let’s review compliance standards when technical proposals are required";
+    case "SetLumpSum":
+    case "EqualSetLumpSum":
+      return "Now let’s review assessment criteria required for white papers";
+    default:
+      return ""
+    }
+  }
 
   public evalPlan: EvaluationPlanDTO = {
     /* eslint-disable camelcase */
@@ -55,8 +76,8 @@ export default class LumpSum extends Vue {
     /* eslint-enable camelcase */
   }
 
-  public selectedRadioItem = "";
-  public radioGroupItems: RadioButton[] = [
+  public selectedStandardsRadioItem = "";
+  public standardsRadioGroupItems: RadioButton[] = [
     {
       id: "Yes",
       label: "Yes, I want to write my own custom compliance standard(s).",
@@ -88,7 +109,6 @@ export default class LumpSum extends Vue {
   public async mounted(): Promise<void> {
     await this.loadOnEnter();
   }
-
 
 }
 </script>

--- a/src/steps/02-EvaluationCriteria/EvalPlan/components/Callout.spec.ts
+++ b/src/steps/02-EvaluationCriteria/EvalPlan/components/Callout.spec.ts
@@ -15,14 +15,72 @@ describe("Testing CreateEvalPlan Component", () => {
     vuetify = new Vuetify();
     wrapper = mount(Callout, {
       vuetify,
-      localVue
+      localVue,
+      propsData: {
+        sourceSelection: "TechProposal",
+        method: "",
+      }
     });
   });
 
-  describe("testing Callout component", () => {
+  describe("Rendering Callout component", () => {
     it("renders successfully", async () => {
       expect(wrapper.exists()).toBe(true);
     });
+  });
+
+  describe("testing getters for eval plan variations", () => {
+    it("testing no-tech-proposal required", async () => {
+      await wrapper.setProps({
+        sourceSelection: "NoTechProposal"
+      });
+      expect(wrapper.vm.isStandards).toBeTruthy();
+      expect(wrapper.vm.heading).toBe("Compliance Standards");
+      expect(wrapper.vm.listType).toBe("Standard");
+      expect(wrapper.vm.introP).toContain("to provide a price quote");
+      expect(wrapper.vm.subhead).toContain("compliance standards");
+      expect(wrapper.vm.listItems).toHaveLength(2);
+    });
+
+    it("testing tech-proposal required", async () => {
+      await wrapper.setProps({
+        sourceSelection: "TechProposal"
+      });
+      expect(wrapper.vm.isStandards).toBeTruthy();
+      expect(wrapper.vm.heading).toBe("Compliance Standards");
+      expect(wrapper.vm.listType).toBe("Standard");
+      expect(wrapper.vm.introP).toContain("propose a technical solution");
+      expect(wrapper.vm.subhead).toContain("compliance standards");
+      expect(wrapper.vm.listItems).toHaveLength(3);
+    });
+
+    it("testing set lump sum one CSP - Best Use method", async () => {
+      await wrapper.setProps({
+        sourceSelection: "SetLumpSum",
+        method: "BestUse"
+      });
+      expect(wrapper.vm.isStandards).toBeFalsy();
+      expect(wrapper.vm.heading).toBe("Assessment Areas");
+      expect(wrapper.vm.listType).toBe("Criteria");
+      expect(wrapper.vm.introP).toContain("white paper");
+      expect(wrapper.vm.subhead).toContain("best use");
+      expect(wrapper.vm.listItems).toHaveLength(4);
+    });
+
+    it("testing set lump sum one CSP - Lowest Risk method", async () => {
+      await wrapper.setProps({
+        sourceSelection: "SetLumpSum",
+        method: "LowestRisk"
+      });
+      expect(wrapper.vm.isStandards).toBeFalsy();
+      expect(wrapper.vm.heading).toBe("Assessment Areas");
+      expect(wrapper.vm.listType).toBe("Criteria");
+      expect(wrapper.vm.introP).toContain("white paper");
+      expect(wrapper.vm.subhead).toContain("lowest risk");
+      expect(wrapper.vm.listItems).toHaveLength(5);
+    });
+
 
   })
+
 })

--- a/src/steps/02-EvaluationCriteria/EvalPlan/components/Callout.vue
+++ b/src/steps/02-EvaluationCriteria/EvalPlan/components/Callout.vue
@@ -8,42 +8,36 @@
   >
     <template v-slot:content>
       <h2 class="mb-2">
-        Compliance Standards
+        {{ heading }}
       </h2>
       <p id="IntroP" class="mb-4">
-         {{ calloutData.introP }}
+         {{ introP }}
       </p>
       <p class="font-weight-700 mb-2" id="Subhead">
-        {{ calloutData.subhead }}
+        {{ subhead }}
       </p>
       <div style="border-left: 4px solid #544496">
         <div 
-          v-for="(item, index) in calloutData.listItems"
+          v-for="(item, index) in listItems"
           :key="index"
           class="d-flex"
+          :class="{ 'pb-3' : index < listItems.length - 1 }"
         >
-          <div 
-            class="font-weight-700 nowrap mr-4 pl-3 align-top"
-            :class="{ 'pb-2' : index < calloutData.listItems.length - 1 }"
-            style="width: 100px;"
-          >
-            {{ calloutData.listType }} #{{ index + 1 }}
+          <div class="font-weight-700 nowrap pl-4 align-top">
+            {{ listType }} #{{ index + 1 }}
           </div>
-          <div class="align-top">
+          <div class="align-top pl-6 width-100">
             {{ item }}
           </div>
         </div>
       </div>
-
-
     </template>
-
   </ATATAlert>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
-import { Component } from "vue-property-decorator";
+import { Component, Prop } from "vue-property-decorator";
 
 import ATATAlert from "@/components/ATATAlert.vue";
 
@@ -54,21 +48,87 @@ import ATATAlert from "@/components/ATATAlert.vue";
 })
 
 export default class Callout extends Vue {
-  public calloutData: Record<string, string | string[]> = {
-    heading: "Compliance Standards",
-    introP: `Your Contracting Officer (KO) will request CSPs to provide a price 
-      quote that includes the total price and a complete list of cloud service 
-      offerings with catalog item numbers/SKUs, the unit price, unit of issue, 
-      and quantities calculated on a monthly basis for each catalog item number/SKU 
-      required to meet the criteria in your Description of Work.`,
-    subhead: `Award will be made to the lowest priced offeror meeting the following 
-      compliance standards:`,
-    listType: "Standard",
-    listItems: [
-      "Each requirement element has one or more specific catalog item number/SKU specified.",
-      "The CSP mapped the catalog item numbers/SKUs to the requirement element(s)."
-    ]
-  };
+  @Prop() public sourceSelection!: string;
+  @Prop() public method?: string;
+
+  public get isStandards(): boolean {
+    return this.sourceSelection.indexOf("TechProposal") > -1;
+  }
+
+  public get heading(): string {
+    return this.isStandards ? "Compliance Standards" : "Assessment Areas"
+  }
+
+  public get listType(): string {
+    return this.isStandards ? "Standard" : "Criteria"
+  }
+
+  public get introP(): string {
+    if (!this.isStandards) {
+      return `Your Contracting Officer (KO) will request CSPs submit a white paper
+        identifying a strategy and approach that will meet or exceed the requirements 
+        within the proposed costs. CSPs must also provide a price proposal which 
+        includes a complete list of cloud service offerings with catalog item 
+        numbers/SKUs and quantities to meet the requirements.`
+    }
+    const substr1 = this.sourceSelection === "NoTechProposal"
+      ? "to provide a price quote"
+      : "propose a technical solution and provide a price proposal"
+    const substr2 = this.sourceSelection === "NoTechProposal"
+      ? " required to meet the criteria in your Description of Work"
+      : "";
+    return `Your Contracting Officer (KO) will request CSPs ${substr1} that 
+      includes the total price and a complete list of cloud service offerings 
+      with catalog item numbers/SKUs, the unit price, unit of issue, and quantities 
+      calculated on a monthly basis for each catalog item number/SKU${substr2}.`
+  }
+
+  public get subhead(): string {
+    if (this.isStandards) {
+      return `Award will be made to the lowest priced offeror meeting the following 
+        compliance standards:`;
+    }
+    const methodStr = this.method === "LowestRisk" ? "lowest risk" : "best use";
+    return `Award will be made to the CSP whose white paper offers the “${ methodStr }” 
+      solution and meets the following assessment areas:`;
+  }
+
+  public get listItems(): string[] {
+    let listItems = [];
+    switch (this.sourceSelection) {
+    case "NoTechProposal":
+      listItems = [
+        "Each requirement element has one or more specific catalog item number/SKU specified.",
+        "The CSP mapped the catalog item numbers/SKUs to the requirement element(s)."
+      ];
+      break;
+    case "TechProposal":
+      listItems = [
+        "The proposed solution fully addresses each requirement element.",
+        `The proposed solution identifies all catalog items (and quantity) necessary 
+          to meet the requirements.`,
+        `Each catalog item is mapped to a specific requirement and an explanation 
+          of how the item will contribute to the solution is provided.`
+      ];
+      break;
+    default:
+      listItems = [
+        `Solution adequately addresses each requirement element or identifies any 
+          requirement elements which are not explicitly identified in the strategy 
+          or approach.`,
+        `The proposed solution identifies all cloud service offerings with catalog 
+          item numbers/SKUs (and quantities) that are required.`,
+        `Each catalog item is mapped to a specific requirement and an explanation 
+          of how the item will contribute to the solution is provided.`,
+        `The proposed solution addresses how the Contractor will facilitate the described need.`
+      ];
+    }
+    if (this.method === "LowestRisk") {
+      listItems.push("Risk to the Government.")
+    }
+    return listItems;
+  }
+
 }
 </script>
 


### PR DESCRIPTION
**Note: also contains work for [AT-8131](https://ccpo.atlassian.net/browse/AT-8131) - AC needs updating to navigate to single page `EvalPlanDetails.vue` with appropriate heading and callout content.**

Create a component styled as below to accept props for each of the following values
1. Headline
    1. Lead Paragraph
    1. Bolded subhead (optional)
    1. Keyword: Standard or Criteria  (Either the word Standards (as shown below) or the word Criteria is to be displayed)  (optional)
    1. List Items (optional)

To test:  Please visit one of the four Eval Plan pages with the component below to ensure the component is displayed as expected.

