### PR TITLE
8188 8189 Updates from FR and AC changes

### DIFF
--- a/src/components/DOW/InstanceConfig.vue
+++ b/src/components/DOW/InstanceConfig.vue
@@ -25,6 +25,7 @@
           type="number"
           :rules="[
             $validators.required('Enter a number greater than or equal to 1.'),
+            $validators.greaterThan('0', 'Enter a number greater than or equal to 1.'),
           ]"
           :allowDecimals="false"
         />
@@ -39,6 +40,7 @@
           type="number"
           :rules="[
             $validators.required('Enter a number greater than or equal to 1.'),
+            $validators.greaterThan('0', 'Enter a number greater than or equal to 1.'),
           ]"
           :allowDecimals="false"
         />
@@ -67,6 +69,7 @@
           appendText="GB"
           :rules="[
             $validators.required('Enter a number greater than or equal to 1.'),
+            $validators.greaterThan('0', 'Enter a number greater than or equal to 1.'),
           ]"
           :isMaskRegex="true"
           :mask="['^[0-9]*\.?[0-9]{1}$']"
@@ -98,7 +101,7 @@
           :selectedDropdownValue.sync="_instanceConfig.storageUnit"
           type="number"
           :rules="[
-            $validators.required('Enter a number greater than or equal to 1.'),
+            $validators.required('Enter a number greater than or equal to 0.'),
           ]"
           :allowDecimals="false"
         />       
@@ -137,7 +140,7 @@ export default class InstanceConfig extends Vue {
     { 
       text: "Block storage", 
       description: "Fixed-sized raw storage capacity", 
-      value: "Block storage VAL" 
+      value: "Block storage" 
     },
     { 
       text: "Object storage", 

--- a/src/components/DOW/PerformanceTier.vue
+++ b/src/components/DOW/PerformanceTier.vue
@@ -16,12 +16,12 @@
       id="NumberOfSimilarInstances"
       class="mt-8 _input-max-width-240"
       :value.sync="_performanceTier.numberOfSimilarInstances"
-      label="Number of similar instances"
+      label="Number of instances with these configurations"
       type="number"
       :rules="[
         $validators.required('Enter a number greater than or equal to 1.'),
+        $validators.greaterThan('0', 'Enter a number greater than or equal to 1.'),
       ]"    
-      tooltipText="Specify the quantity of instances you need with these configurations."
     />
 
     <ATATTextField
@@ -37,6 +37,7 @@
       type="number"
       :rules="[
         $validators.required('Enter a number greater than or equal to 1.'),
+        $validators.greaterThan('0', 'Enter a number greater than or equal to 1.'),
       ]"
       :allowDecimals="false"
     />       

--- a/src/steps/03-Background/CurrentEnvironment/EnvironmentDetailsPage.vue
+++ b/src/steps/03-Background/CurrentEnvironment/EnvironmentDetailsPage.vue
@@ -131,7 +131,7 @@ export default class EnvironmentDetails extends Vue {
 
   public performanceTier: CurrentEnvPerformanceTier = {
     performanceTier: "",
-    numberOfSimilarInstances: null,
+    numberOfSimilarInstances: 1,
     dataEgressMonthlyAmount: null,
     dataEgressMonthlyUnit: "GB",
   }


### PR DESCRIPTION
Updates to [AT-8188](https://ccpo.atlassian.net/browse/AT-8188) from functional review - validation - number fields should not allow 0

Updates to [AT-8189 ](https://ccpo.atlassian.net/browse/AT-8189)from AC changes:
- 2.a Label: Number of instances with these configurations
    - default this field value to `1`
- 2.b Tooltip: remove
- 3.c.i.1 Data Egress validation message: "Enter a number greater than or equal to 1."
