### PR TITLE
Bugfix/at 8444 landing page edit archive

### DIFF
--- a/src/home/ExistingUser.vue
+++ b/src/home/ExistingUser.vue
@@ -26,6 +26,7 @@
                     :cardData="cardData"
                     :index="index"
                     :isLastCard="index === packageData.length - 1"
+                    @updateStatus="loadPackageData"
                   />
 
                 </v-expansion-panel-content>
@@ -201,6 +202,9 @@ export default class ExistingUser extends Vue {
     this.packageCount = this.packageData.length;
     const draftPackages = this.packageData.filter(obj => obj.package_status?.value === "DRAFT");
     this.draftPackageCount = draftPackages?.length || 0;
+    if (this.packageCount === 0) {
+      this.$emit("allPackagesCleared");
+    }
   }
 
   public async loadOnEnter(): Promise<void>{

--- a/src/home/Index.vue
+++ b/src/home/Index.vue
@@ -6,6 +6,8 @@
       {'_is-existing-user' : !isNewUser }
     ]"  
   >
+    <ATATToast />
+
     <div class="_hero-banner"></div>
     <v-main class="_home">
       <div class="_home-content">
@@ -65,6 +67,7 @@
           v-else 
           class="mt-8" 
           @startNewAcquisition="startNewAcquisition" 
+          @allPackagesCleared="isNewUser = true"
         />      
 
         <div class="bg-white">
@@ -84,6 +87,7 @@ import { Component, Watch } from "vue-property-decorator";
 import ATATFooter from "@/components/ATATFooter.vue";
 import ExistingUser from "./ExistingUser.vue";
 import NewUser from "./NewUser.vue";
+import ATATToast from "@/components/ATATToast.vue";
 
 import HelpfulResourcesCards from "./components/HelpfulResourcesCards.vue";
 import Steps from "@/store/steps";
@@ -100,6 +104,7 @@ import CurrentUserStore from "@/store/user";
 @Component({
   components: {
     ATATFooter,
+    ATATToast,
     ExistingUser,
     HelpfulResourcesCards,
     NewUser,

--- a/src/packages/Index.spec.ts
+++ b/src/packages/Index.spec.ts
@@ -74,11 +74,9 @@ describe("Testing Packages Component", () => {
     })
 
     it("test updateStatus()",()=>{
-      const spy = jest.spyOn(AcquisitionPackageSummary,"updateAcquisitionPackageStatus")
+      const spy = jest.spyOn(AcquisitionPackageSummary,"searchAcquisitionPackageSummaryList")
         .mockImplementation()
-      wrapper.vm.updateStatus("testsysID","DELETED")
-      wrapper.vm.updateStatus("testsysID","ARCHIVED")
-      wrapper.vm.updateStatus("testsysID","DRAFT")
+      wrapper.vm.updateStatus()
       expect(spy).toBeCalled();
     })
 

--- a/src/packages/Index.vue
+++ b/src/packages/Index.vue
@@ -86,8 +86,7 @@ import {
   AcquisitionPackageSummaryMetadataAndDataDTO,
   AcquisitionPackageSummarySearchDTO,
 } from "@/api/models";
-import { ToastObj } from "../../types/Global";
-import Toast from "@/store/toast";
+
 import AcquisitionPackageSummary from "@/store/acquisitionPackageSummary";
 import Search from "@/packages/components/Search.vue";
 import ATATNoResults from "@/components/ATATNoResults.vue";
@@ -192,34 +191,7 @@ export default class Packages extends Vue {
     return getIdText(string);
   }
 
-  public async updateStatus(sysId: string,newStatus: string): Promise<void> {
-    let message = "";
-    switch(newStatus){
-    case 'DELETED':
-      message = "Acquisition package deleted"
-      break;
-    case 'ARCHIVED':
-      message = "Acquisition package archived"
-      break;
-    case 'DRAFT':
-      message = "Acquisition package restored to draft"
-      break;
-    }
-    await AcquisitionPackageSummary
-      .updateAcquisitionPackageStatus({
-        acquisitionPackageSysId: sysId,
-        newStatus
-      });
-
-    const toastObj: ToastObj = {
-      type: "success",
-      message,
-      isOpen: true,
-      hasUndo: false,
-      hasIcon: true,
-    };
-
-    Toast.setToast(toastObj);
+  public async updateStatus(): Promise<void> {
     await this.updateSearchDTO("","")
   }
 

--- a/src/packages/Index.vue
+++ b/src/packages/Index.vue
@@ -40,6 +40,7 @@
       </v-app-bar>
       <v-container
         class="container-max-width"
+        style="margin-bottom: 200px;"
       >
         <Search
           :searchString.sync="searchString"

--- a/src/packages/components/Card.vue
+++ b/src/packages/components/Card.vue
@@ -39,19 +39,21 @@
             color="base"
             class="mr-1"
           />
+          <!-- 
+          TODO: Add back in when saving progress to snow  
           <span v-if="modifiedData.packageStatus.toLowerCase() === 'draft'" >
             30% complete
           </span>
           <span v-else>
             100% complete
-          </span>
+          </span> 
           <ATATSVGIcon
             name="bullet"
             color="base-light"
             :width="9"
             :height="9"
             class="d-inline-block mx-1"
-          />
+          /> -->
         </div>
         <div
           v-if="modifiedData.packageStatus.toLowerCase() === 'task order awarded'"
@@ -98,14 +100,14 @@
       :showModal.sync="showDeleteModal"
       :packageName="modifiedData.projectOverview"
       :hasContributor="hasContributor"
-      :waitingForSignature = "modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
+      :waitingForSignature="modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
       @okClicked="updateStatus('DELETED')"
     />
     <ArchiveModal
       :showModal.sync="showArchiveModal"
       :hasContributor="hasContributor"
       :packageName="modifiedData.projectOverview"
-      :waitingForSignature = "modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
+      :waitingForSignature="modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
       @okClicked="updateStatus('ARCHIVED')"
     />
   </v-card>
@@ -115,7 +117,7 @@
 import Vue from "vue";
 
 import { Component, Prop, Watch } from "vue-property-decorator";
-import { MeatballMenuItem } from "../../../types/Global";
+import { MeatballMenuItem, ToastObj } from "../../../types/Global";
 import { createDateStr, getStatusChipBgColor } from "@/helpers";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import ATATMeatballMenu from "@/components/ATATMeatballMenu.vue";
@@ -128,6 +130,8 @@ import {
 import { routeNames } from "@/router/stepper";
 import AppSections from "@/store/appSections";
 import CurrentUserStore from "@/store/user";
+import AcquisitionPackageSummary from "@/store/acquisitionPackageSummary";
+import Toast from "@/store/toast";
 @Component({
   components:{
     ATATSVGIcon,
@@ -208,10 +212,37 @@ export default class Card extends Vue {
     this.modifiedData.updated = cardData.sys_updated_on || ""
     this.modifiedData.contributors = cardData.contributors?.value || ""
   }
-  public updateStatus(newStatus: string): void {
+
+  public async updateStatus(newStatus: string): Promise<void> {
+    let message = "";
+    switch(newStatus){
+    case 'DELETED':
+      message = "Acquisition package deleted"
+      break;
+    case 'ARCHIVED':
+      message = "Acquisition package archived"
+      break;
+    case 'DRAFT':
+      message = "Acquisition package restored to draft"
+      break;
+    }
+    await AcquisitionPackageSummary
+      .updateAcquisitionPackageStatus({
+        acquisitionPackageSysId: this.cardData.sys_id as string,
+        newStatus
+      });
+
+    const toastObj: ToastObj = {
+      type: "success",
+      message,
+      isOpen: true,
+      hasUndo: false,
+      hasIcon: true,
+    };
+
+    Toast.setToast(toastObj);
     this.$emit("updateStatus", this.cardData.sys_id, newStatus);
   }
-
 
   public async cardMenuClick(menuItem: MeatballMenuItem): Promise<void> {
     switch (menuItem.action) {

--- a/src/packages/components/Card.vue
+++ b/src/packages/components/Card.vue
@@ -98,7 +98,7 @@
     />
     <DeletePackageModal
       :showModal.sync="showDeleteModal"
-      :packageName="modifiedData.projectOverview"
+      :packageName="modifiedData.projectOverview || 'Untitled package'"
       :hasContributor="hasContributor"
       :waitingForSignature="modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
       @okClicked="updateStatus('DELETED')"
@@ -106,7 +106,7 @@
     <ArchiveModal
       :showModal.sync="showArchiveModal"
       :hasContributor="hasContributor"
-      :packageName="modifiedData.projectOverview"
+      :packageName="modifiedData.projectOverview || 'Untitled package'"
       :waitingForSignature="modifiedData.packageStatus.toLowerCase() === 'waiting for signatures'"
       @okClicked="updateStatus('ARCHIVED')"
     />

--- a/src/sass/components/ATATSearch.scss
+++ b/src/sass/components/ATATSearch.scss
@@ -2,6 +2,7 @@
   fieldset {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    top: -4px;
   }
   .v-text-field__details {
     display: none;


### PR DESCRIPTION
1. User can’t successfully edit or archive package from home page.  Please note, user can edit/archive successfully from the acquisition package summary page. (See Figure 1.0). Please resolve
2. Dialog has no title if users selects to edit or archive Untitled package (See Figure 1.1).  Please resolve behavior on both 
    1. home page
    1. Acqusition Package Summary page