### PR TITLE
Bugfix/at 8445 current contract

### DIFF
--- a/src/action-handlers/index.ts
+++ b/src/action-handlers/index.ts
@@ -7,7 +7,8 @@ const actionHandlerNames = {
   sampleAdditionalButtonAction: "sampleAdditionalButtonAction",
   deleteServiceOfferingGroup: "deleteServiceOfferingGroup",
   confirmComputeDeletion: "confirmComputeDeletion",
-  confirmServiceDeletion: "confirmServiceDeletion"
+  confirmServiceDeletion: "confirmServiceDeletion",
+  clearCurrentContractInfo: "clearCurrentContractInfo",
 }
 
 const actions =  {
@@ -15,6 +16,8 @@ const actions =  {
   [actionHandlerNames.deleteServiceOfferingGroup]: deleteServiceOfferingGroup,
   [actionHandlerNames.confirmComputeDeletion]: confirmComputeDeletion,
   [actionHandlerNames.confirmServiceDeletion]: confirmServiceDeletion,
+  [actionHandlerNames.clearCurrentContractInfo]: clearCurrentContractInfo,
+
 };
 
 async function actionHandler(actionName: string, actionArgs: string[]): Promise<void> {
@@ -28,6 +31,10 @@ function sampleAdditionalButtonAction(actionArgs: string[]) {
   // console.log("in action-handler: foo: " + foo + "bar: " + bar);
   AcquisitionPackage.sampleAdditionalButtonActionInStore(actionArgs);
   alert("\"Cancel\" will navigate to JWCC intro when completed.");
+}
+
+function clearCurrentContractInfo() {
+  AcquisitionPackage.clearCurrentContractInfo();
 }
 
 // used in Performance Requirements when user clicks "I don't need these cloud resources" button

--- a/src/packages/components/Card.vue
+++ b/src/packages/components/Card.vue
@@ -13,6 +13,9 @@
             role="button"
             tabindex="0"
             class="h3 _text-decoration-none d-flex align-center _package-title"
+            @click="packageTitleClick(modifiedData.packageStatus)"
+            @keydown.enter="packageTitleClick(modifiedData.packageStatus)"
+            @keydown.space="packageTitleClick(modifiedData.packageStatus)"
           >
             {{ modifiedData.projectOverview || 'Untitled package'}}
           </a>
@@ -212,6 +215,12 @@ export default class Card extends Vue {
     this.$emit("updateStatus", this.cardData.sys_id, newStatus);
   }
 
+
+  public packageTitleClick(status: string): void {
+    if (status.toLowerCase() === "draft") {
+      this.cardMenuClick({action: 'Edit draft package', title: ""})    
+    }
+  }
 
   public async cardMenuClick(menuItem: MeatballMenuItem): Promise<void> {
     switch (menuItem.action) {

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -150,7 +150,7 @@ export const ArchitecturalDesignDetailsRouteResolver = (current: string): string
 
 };
 
-export const CurrentContractEnvRouteResolver = (current: string): string => {
+export const CurrentEnvRouteResolver = (current: string): string => {
   const hasCurrentEnv
     = CurrentEnvironment.currentEnvironment?.current_environment_exists === "YES";
   if (hasCurrentEnv) {
@@ -861,7 +861,7 @@ const routeResolvers: Record<string, StepRouteResolver> = {
   AcorsRouteResolver,
   CurrentContractDetailsRouteResolver,
   ReplicateDetailsResolver,
-  CurrentContractEnvRouteResolver,
+  CurrentEnvRouteResolver,
   PIIRecordResolver,
   FOIARecordResolver,
   A11yRequirementResolver,

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -126,7 +126,7 @@ import GeneratingPackageDocuments
 import {
   AcorsRouteResolver,
   CurrentContractDetailsRouteResolver,
-  CurrentContractEnvRouteResolver,
+  CurrentEnvRouteResolver,
   ReplicateDetailsResolver,
   PIIRecordResolver,
   FOIARecordResolver,
@@ -529,7 +529,8 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
             buttonText: "I don’t have an existing contract",
             buttonId: "NoExistingContract",
             buttonClass: "secondary",
-            name: routeNames.PeriodOfPerformance,
+            name: routeNames.RequirementCategories,
+            actionName: "clearCurrentContractInfo"
           },
         ],
       },
@@ -549,7 +550,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         component: UploadSystemDocuments,
         completePercentageWeight: 5,
         completed: false,
-        routeResolver: CurrentContractEnvRouteResolver,
+        routeResolver: CurrentEnvRouteResolver,
       },
       {
         menuText: "Upload Process",

--- a/src/steps/03-Background/CurrentContract/CurrentContract.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContract.vue
@@ -32,7 +32,9 @@ import { Component, Mixins } from "vue-property-decorator";
 
 import CurrentContractOptions from "./components/CurrentContractOptions.vue"
 
-import AcquisitionPackage, {StoreProperties} from "@/store/acquisitionPackage";
+import AcquisitionPackage, 
+{initialCurrentContract, StoreProperties} from "@/store/acquisitionPackage";
+
 import SaveOnLeave from "@/mixins/saveOnLeave";
 import { CurrentContractDTO } from "@/api/models";
 import { hasChanges } from "@/helpers";
@@ -83,7 +85,12 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.hasChanged()) {
-        await AcquisitionPackage.saveData<CurrentContractDTO>({data: this.currentData,
+        let data = this.currentData;
+        if (data.current_contract_exists === "NO") {
+          data = initialCurrentContract();
+          data.current_contract_exists = "NO"
+        }
+        await AcquisitionPackage.saveData<CurrentContractDTO>({data,
           storeProperty: StoreProperties.CurrentContract});
       }
     } catch (error) {

--- a/src/steps/07-OtherContractConsiderations/ConflictOfInterest.vue
+++ b/src/steps/07-OtherContractConsiderations/ConflictOfInterest.vue
@@ -70,7 +70,7 @@ import CoILearnMore from "./CoILearnMore.vue";
 
 import SlideoutPanel from "@/store/slideoutPanel/index";
 import { RadioButton, SlideoutPanelContent } from "../../../types/Global";
-import AcquisitionPackage from "@/store/acquisitionPackage";
+import AcquisitionPackage, { StoreProperties } from "@/store/acquisitionPackage";
 import { ContractConsiderationsDTO } from "@/api/models";
 
 @Component({
@@ -83,7 +83,7 @@ import { ContractConsiderationsDTO } from "@/api/models";
 export default class ConflictOfInterest extends Mixins(SaveOnLeave) {
   private explanation 
     = AcquisitionPackage.contractConsiderations?.conflict_of_interest_explanation || "";
-  private saved: ContractConsiderationsDTO = {};
+  private savedData: ContractConsiderationsDTO = {};
   private hasConflict 
     = AcquisitionPackage.contractConsiderations?.potential_conflict_of_interest || "";
   private conflictOfInterestOptions: RadioButton[] = [
@@ -107,7 +107,7 @@ export default class ConflictOfInterest extends Mixins(SaveOnLeave) {
     }
   }
 
-  public get current(): ContractConsiderationsDTO {
+  public get currentData(): ContractConsiderationsDTO {
     return {
       potential_conflict_of_interest: this.hasConflict || "",
       conflict_of_interest_explanation: this.explanation,
@@ -124,10 +124,11 @@ export default class ConflictOfInterest extends Mixins(SaveOnLeave) {
   }
 
   public async loadOnEnter(): Promise<void> {
-    const storeData = await AcquisitionPackage.loadContractConsiderations();
-
+    const storeData = await AcquisitionPackage.loadData<ContractConsiderationsDTO>({
+      storeProperty: StoreProperties.ContractConsiderations
+    });
     if (storeData) {
-      this.saved = {
+      this.savedData = {
         potential_conflict_of_interest: storeData.potential_conflict_of_interest || "",
         conflict_of_interest_explanation : storeData.conflict_of_interest_explanation || "",
       }
@@ -135,7 +136,7 @@ export default class ConflictOfInterest extends Mixins(SaveOnLeave) {
   }
 
   public isChanged(): boolean {
-    return hasChanges(this.saved, this.current);
+    return hasChanges(this.savedData, this.currentData);
   }
 
   @Watch('hasConflict')
@@ -148,7 +149,10 @@ export default class ConflictOfInterest extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.isChanged()) {
-        await AcquisitionPackage.saveContractConsiderations(this.current);
+        await AcquisitionPackage.saveData({
+          data: this.currentData,
+          storeProperty: StoreProperties.ContractConsiderations,
+        });
       }
     } catch (error) {
       console.log(error);

--- a/src/steps/07-OtherContractConsiderations/TrainingCourses.vue
+++ b/src/steps/07-OtherContractConsiderations/TrainingCourses.vue
@@ -89,7 +89,7 @@ import { Component, Mixins } from "vue-property-decorator";
 import ATATTextField from "@/components/ATATTextField.vue";
 import { stringObj } from "../../../types/Global";
 import { ContractConsiderationsDTO } from "@/api/models";
-import AcquisitionPackage from "@/store/acquisitionPackage";
+import AcquisitionPackage, { StoreProperties } from "@/store/acquisitionPackage";
 import { hasChanges } from "@/helpers";
 import SaveOnLeave from "@/mixins/saveOnLeave";
 
@@ -100,7 +100,7 @@ import SaveOnLeave from "@/mixins/saveOnLeave";
   },
 })
 export default class TrainingCourses extends Mixins(SaveOnLeave) {
-  private saved: ContractConsiderationsDTO = {};
+  private savedData: ContractConsiderationsDTO = {};
   public trainingCerts: stringObj[] = [
     {name: ""}
   ];
@@ -132,15 +132,18 @@ export default class TrainingCourses extends Mixins(SaveOnLeave) {
 
   }
 
-  public get current(): ContractConsiderationsDTO {
+  public get currentData(): ContractConsiderationsDTO {
     return {
       required_training_courses: this.transformTrainingCerts(this.trainingCerts) || "",
     };
   }
 
   public async loadOnEnter(): Promise<void> {
-    const storeData = await AcquisitionPackage.loadContractConsiderations();
-    this.saved = {
+    const storeData = await AcquisitionPackage.loadData<ContractConsiderationsDTO>({
+      storeProperty: StoreProperties.ContractConsiderations
+    });
+
+    this.savedData = {
       required_training_courses: storeData.required_training_courses || '',
     }
     if (storeData && storeData.required_training_courses) {
@@ -149,13 +152,17 @@ export default class TrainingCourses extends Mixins(SaveOnLeave) {
   }
 
   public isChanged(): boolean {
-    return hasChanges(this.saved, this.current);
+    return hasChanges(this.savedData, this.currentData);
   }
 
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.isChanged()) {
-        await AcquisitionPackage.saveContractConsiderations(this.current);
+        await AcquisitionPackage.saveData({
+          data: this.currentData,
+          storeProperty: StoreProperties.ContractConsiderations,
+        });
+
       }
     } catch (error) {
       console.log(error);

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -58,7 +58,8 @@ export const StoreProperties = {
   RequirementsCostEstimate:"requirementsCostEstimate",
   SensitiveInformation: "sensitiveInformation",
   ClassificationLevel: "ClassificationRequirements",
-  CurrentEnvironment: "currentEnvironment"
+  CurrentEnvironment: "currentEnvironment",
+  ContractConsiderations: "contractConsiderations",
 };
 
 export const Statuses: Record<string, Record<string, string>> = {
@@ -150,14 +151,14 @@ const initialContact = () => {
 
 const initialContractConsiderations = ()=> {
   return {
-    packaging_shipping_other: "false",
+    packaging_shipping_other: "",
     contractor_required_training: "",
     packaging_shipping_other_explanation: "",
     conflict_of_interest_explanation: "",
     potential_conflict_of_interest: "",
     required_training_courses: "",
-    packaging_shipping_none_apply: "false",
-    contractor_provided_transfer: "false",
+    packaging_shipping_none_apply: "",
+    contractor_provided_transfer: "",
   }
 }
 
@@ -1059,7 +1060,6 @@ export class AcquisitionPackageStore extends VuexModule {
     [StoreProperties.ContractType]: api.contractTypeTable,
     [StoreProperties.CurrentContract]: api.currentContractTable,
     [StoreProperties.FairOpportunity]: api.fairOpportunityTable,
-    // [StoreProperties.EvaluationPlan]: api.evaluationPlanTable, // FUTURE TICKET
     [StoreProperties.Organization]: api.organizationTable,
     // [StoreProperties.Periods]: api.periodTable,
     [StoreProperties.ProjectOverview]: api.projectOverviewTable,
@@ -1068,6 +1068,7 @@ export class AcquisitionPackageStore extends VuexModule {
     [StoreProperties.SensitiveInformation]: api.sensitiveInformationTable,
     [StoreProperties.CurrentEnvironment]: api.currentEnvironmentTable,
     [StoreProperties.ClassificationLevel]: api.classificationLevelTable,
+    [StoreProperties.ContractConsiderations]: api.contractConsiderationsTable,
   }
 
   //mapping store propertties name to acquisition package properties
@@ -1084,6 +1085,7 @@ export class AcquisitionPackageStore extends VuexModule {
     [StoreProperties.SensitiveInformation]: "sensitive_information",
     [StoreProperties.ClassificationLevel]: "classification_level",
     [StoreProperties.CurrentEnvironment]: "current_environment",
+    [StoreProperties.ContractConsiderations]: "contract_considerations",
   }
 
   @Action({ rawError: true })
@@ -1361,55 +1363,6 @@ export class AcquisitionPackageStore extends VuexModule {
       } as AcquisitionPackageDTO);
     } catch (error) {
       throw new Error(`error occurred saving sensitive info data ${error}`);
-    }
-  }
-
-  @Action({ rawError: true })
-  async loadContractConsiderations(): Promise<ContractConsiderationsDTO> {
-    try {
-      await this.ensureInitialized();
-      const sys_id = this.contractConsiderations?.sys_id || "";
-
-      if (sys_id.length > 0) {
-        const contractConsiderationsData =
-          await api.contractConsiderationsTable.retrieve(sys_id as string);
-        this.setContractConsiderations(contractConsiderationsData);
-        this.setAcquisitionPackage({
-          ...this.acquisitionPackage,
-          contract_considerations: {value: sys_id}
-        } as AcquisitionPackageDTO);
-      }
-      return this.contractConsiderations as ContractConsiderationsDTO;
-    } catch (error) {
-      throw new Error(`error occurred loading Contract Type data ${error}`);
-    }
-  }
-
-  @Action({ rawError: true })
-  async saveContractConsiderations(
-    data: ContractConsiderationsDTO
-  ): Promise<void> {
-    try {
-      const sys_id = this.contractConsiderations?.sys_id || "";
-      const savedData =
-        sys_id.length > 0
-          ? await api.contractConsiderationsTable.update(sys_id, {
-            ...data,
-            sys_id,
-          })
-          : await api.contractConsiderationsTable.create({
-            ...initialContractConsiderations(),
-            ...data,
-          });
-      this.setContractConsiderations(savedData);
-      this.setAcquisitionPackage({
-        ...this.acquisitionPackage,
-        contract_considerations: {value: sys_id}
-      } as AcquisitionPackageDTO);
-    } catch (error) {
-      throw new Error(
-        `error occurred saving Contract Considerations data ${error}`
-      );
     }
   }
 

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -84,7 +84,7 @@ export const Statuses: Record<string, Record<string, string>> = {
 }
 
 
-const initialCurrentContract = ()=> {
+export const initialCurrentContract = (): CurrentContractDTO => {
   return {
     current_contract_exists: "",
     incumbent_contractor_name: "",
@@ -476,19 +476,13 @@ export class AcquisitionPackageStore extends VuexModule {
   }
 
   @Action
-  public clearCurrentContractInfo(): void {
-    const data: CurrentContractDTO = {
-      current_contract_exists: "NO",
-      incumbent_contractor_name: "",
-      contract_number: "",
-      task_delivery_order_number: "",
-      contract_order_expiration_date: "",
-    }
+  public async clearCurrentContractInfo(): Promise<void> {
+    const data = initialCurrentContract();
+    data.current_contract_exists = "NO";
     this.setCurrentContract(data);
-    // EJY keep me
-
+    this.saveData<CurrentContractDTO>({data,
+      storeProperty: StoreProperties.CurrentContract});
   }
-
 
   @Mutation
   public setSensitiveInformation(value: SensitiveInformationDTO): void {

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -474,6 +474,21 @@ export class AcquisitionPackageStore extends VuexModule {
       : value;
   }
 
+  @Action
+  public clearCurrentContractInfo(): void {
+    const data: CurrentContractDTO = {
+      current_contract_exists: "NO",
+      incumbent_contractor_name: "",
+      contract_number: "",
+      task_delivery_order_number: "",
+      contract_order_expiration_date: "",
+    }
+    this.setCurrentContract(data);
+    // EJY keep me
+
+  }
+
+
   @Mutation
   public setSensitiveInformation(value: SensitiveInformationDTO): void {
     this.sensitiveInformation = this.sensitiveInformation


### PR DESCRIPTION
User navigates to step 3.1 instead of 5.1 when clicking I don't have an existing contract in step 4.1.  Please resolve.

Any current contract info previously entered should be cleared from store and snow if user either navigates back to Current Contract page and selects No, or on the Current Contract Details page, the user clicks the "I don't have an existing contract" button.