### PR TITLE
bugfix at 8457 dropdown validation

### DIFF
--- a/src/components/ATATSelect.vue
+++ b/src/components/ATATSelect.vue
@@ -34,7 +34,6 @@
         :rules="_rules"
         :menu-props="{ bottom: true, offsetY: true }"
         :disabled="menuDisabled"
-        :validate-on-blur="validateOnBlur"
       >
         <template v-if="showSelectedValue" v-slot:selection="{ item }">
           {{ item.value }}
@@ -126,7 +125,6 @@ export default class ATATSelect extends Vue {
   @Prop({ default: "standard" }) public iconType?: string;
   @Prop({ default: false }) private menuDisabled?: boolean;
   @Prop({ default: false }) private showSelectedValue?: boolean;
-  @Prop({ default: true }) private validateOnBlur!: boolean;
 
   //data
   private rounded = false;
@@ -190,10 +188,6 @@ export default class ATATSelect extends Vue {
 
   //@Events
   private onBlur(value: string) : void {
-    if (this.validateOnBlur) {
-      this.addRequiredRule();
-      this.setErrorMessage();
-    }
     this.$emit('blur', value);
   }
 

--- a/src/components/ATATSelect.vue
+++ b/src/components/ATATSelect.vue
@@ -188,6 +188,7 @@ export default class ATATSelect extends Vue {
 
   //@Events
   private onBlur(value: string) : void {
+    this.setErrorMessage();
     this.$emit('blur', value);
   }
 


### PR DESCRIPTION
Currently the ATATDropdown control displays errored state immediately on focus and errored state remains after user selects a valid value.

Errored state should only appear when a validation rule is broken and the control loses focus.