### PR TITLE
bugfix AT-8433

### DIFF
--- a/src/components/ATATSingleAndMultiplePeriods.vue
+++ b/src/components/ATATSingleAndMultiplePeriods.vue
@@ -16,6 +16,7 @@
         id="SingleAmount"
         width="190"
         class="mr-2"
+        type="number"
         :alignRight="true"
         :value.sync="_values[0]"
         :isCurrency="textboxSuffix === ''"
@@ -24,7 +25,7 @@
         :showErrorMessages="true"
         :rules="[
           $validators.required(
-            'Enter you estimated price per period.',
+            'Enter your estimated price per period.',
           ),
         ]"
       />
@@ -64,7 +65,7 @@
             :showErrorMessages="true"
             :rules="[
               $validators.required(
-                'Enter you estimated price for this period.',
+                'Enter your estimated price for this period.',
               ),
             ]"
           />

--- a/src/components/ATATSingleAndMultiplePeriods.vue
+++ b/src/components/ATATSingleAndMultiplePeriods.vue
@@ -56,6 +56,7 @@
         <div>
           <ATATTextField
             :id="period.period_type"
+            type="number"
             width="190"
             class="ml-5"
             :alignRight="true"

--- a/src/components/DOW/AnticipatedDataNeeds.vue
+++ b/src/components/DOW/AnticipatedDataNeeds.vue
@@ -4,6 +4,7 @@
       v-if="needs === 'data'">
       <ATATTextField
         width="234"
+        type="number"
         :label="dataLabel"
         :tooltipText="dataTooltipText"
         :appendDropdown="true"


### PR DESCRIPTION
 Approximate data/internet egress across the entire duration of your task order “input field should only accept Integer not string.

Misspelled word in validation message “Enter your estimated price per period”.

Estimated Percentage of growth in data “input field should accept Integers only