### PR TITLE
Configure webpack to generate static names 'app-js' and 'vendor-js'

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -116,15 +116,6 @@
     }
   ],
   "results": {
-    "src/steps/01-AcquisitionPackageDetails/Organization.vue": [
-      {
-        "type": "Hex High Entropy String",
-        "filename": "src/steps/01-AcquisitionPackageDetails/Organization.vue",
-        "hashed_secret": "69ca6e7efbae075b0e7207f76fde80dc0bdf087c",
-        "is_verified": false,
-        "line_number": 214
-      }
-    ],
     "src/components/DOW/SecurityRequirementsForm.vue": [
       {
         "type": "Secret Keyword",
@@ -139,6 +130,15 @@
         "hashed_secret": "59db809e0e83d142c751d15c8ce9aa15b0ce2416",
         "is_verified": false,
         "line_number": 23
+      }
+    ],
+    "src/steps/01-AcquisitionPackageDetails/Organization.vue": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "src/steps/01-AcquisitionPackageDetails/Organization.vue",
+        "hashed_secret": "69ca6e7efbae075b0e7207f76fde80dc0bdf087c",
+        "is_verified": false,
+        "line_number": 214
       }
     ],
     "src/steps/04-ContractDetails/SecurityRequirements.vue": [
@@ -181,5 +181,5 @@
       }
     ]
   },
-  "generated_at": "2022-11-22T19:52:25Z"
+  "generated_at": "2022-12-22T07:51:54Z"
 }

--- a/vue.config.js
+++ b/vue.config.js
@@ -38,8 +38,8 @@ module.exports = {
         },
       }
 
-      config.output.filename = 'js/[name]-[hash]-js'
-      config.output.chunkFilename = 'js/[name]-[chunkhash]-js'
+      config.output.filename = 'js/[name]-js'
+      config.output.chunkFilename = 'js/[name]-js'
 
     }
   },


### PR DESCRIPTION
Removes hashes from webpack output config to force static names `app-js` and `vendor-js`

Should be merged with https://github.com/dod-ccpo/atat-snow/pull/246