### PR TITLE
Fixed classification level selection on other offering details forms

### DIFF
--- a/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
@@ -268,7 +268,6 @@ export default class OtherOfferings extends Vue {
   @PropSync("serviceOfferingData") public _serviceOfferingData!: OtherServiceOfferingData;
   @Prop() public isPeriodsDataMissing!: boolean;
   @Prop() public isClassificationDataMissing!: boolean;
-  @Prop() public avlClassificationLevelObjects!: ClassificationLevelDTO[];
   @Prop() public otherOfferingList!: string[];
 
   public firstTimeHere = false;
@@ -368,13 +367,11 @@ export default class OtherOfferings extends Vue {
     // classifications modal, set it as the "selected" classification level
     if (
       this.selectedClassificationLevelList.length === 1
-      && this.selectedClassificationLevelList[0].classification_level.value
+      && this.selectedClassificationLevelList[0].classification_level
     ) {
-      
-      //   EJY DOUBLE CHECK VALUE RED SQUIGGLES
-
       const classificationObj = this.selectedClassificationLevelList[0];
-      this._serviceOfferingData.classificationLevel = classificationObj.classification_level.value;
+      this._serviceOfferingData.classificationLevel 
+        = classificationObj.classification_level as string;
       this.singleClassificationLevelName 
         = buildClassificationLabel(classificationObj, "short");
     }
@@ -441,11 +438,8 @@ export default class OtherOfferings extends Vue {
       = await ClassificationRequirements.getSelectedClassificationLevels();
     // set checked items in modal to classification levels selected in step 4 Contract Details
     if (this.selectedClassificationLevelList) {
-      this.selectedClassificationLevelList.forEach((val) => {
-  
-        //   EJY DOUBLE CHECK VALUE RED SQUIGGLES
-        
-        this.modalSelectedOptions.push(val.classification_level.value || "")
+      this.selectedClassificationLevelList.forEach((val) => {      
+        this.modalSelectedOptions.push(val.classification_level as string)
       });
       this.checkSingleClassification();
     }


### PR DESCRIPTION
Resolve: Single classification selection has issues on "other offering" page (e.g., Compute).

Select single classification level, then complete an "other offering" like compute. you should see the selected classification level in the paragraph at the top. Click the "change classification levels" link. in the modal, you should see the one you had selected in step 3.