### PR TITLE
Feature/at 8521 csp calculator links

### DIFF
--- a/src/sass/components/ATATStepper.scss
+++ b/src/sass/components/ATATStepper.scss
@@ -60,7 +60,7 @@
 // requirements cost estimate csp cards
 ._calculator-card {
   width: 169px !important;
-  height: 205px;
+  height: 245px;
   max-width: 169px;
   margin: 10px 16px 20px 0px;
   box-sizing: border-box;
@@ -80,29 +80,27 @@
     flex-direction: column !important;
     align-items: center !important;
     justify-content: center !important;
-    height: 45%;
+    height: 84px;
   }
   ._csp-name {
-    position: absolute;
-    top: 45%;
     font-weight: 500;
     text-align: center;
     font-family: $heading-font;
-   
+    height: 52px;
   }
+
   ._csp-link-div {
     ._csp-link{
       display: flex !important;
       justify-content: center !important;
       align-items: center;
       text-decoration: none;
+      margin: 8px 0;
       &:hover {
         text-decoration: underline;
       }
     }
     width: 100%;
-    margin-top: auto !important;
-    position: absolute;
-    bottom: 16px;
+    margin-top: 8px;
   }
 }

--- a/src/steps/10-FinancialDetails/IGCE/CreatePriceEstimate.vue
+++ b/src/steps/10-FinancialDetails/IGCE/CreatePriceEstimate.vue
@@ -22,6 +22,7 @@
             </p>
           </div>
         <ATATAlert
+          id="CalculatorCallout"
           type="callout"
           :showIcon="false"
           class="pa-8"
@@ -100,6 +101,7 @@
         </ATATAlert>
 
         <ATATAlert 
+          id="EstimateAlert"
           type="warning"
           class="mt-10"
         >

--- a/src/steps/10-FinancialDetails/IGCE/CreatePriceEstimate.vue
+++ b/src/steps/10-FinancialDetails/IGCE/CreatePriceEstimate.vue
@@ -34,9 +34,10 @@
                 <v-list-item>
                   <span class="_step-circle">1</span>
                   <v-list-item-content>
-                    Choose one or more of the CSP pricing calculators below to
-                    help you calculate your estimated price for JWCC cloud
-                    services and support.
+                    Choose one or more of the Cloud Service Provider (CSP) pricing 
+                    calculators below to help you calculate your estimated price 
+                    for JWCC cloud services and support. Depending on your selection, 
+                    you may need to register for an account to view the pricing calculator.
                     <v-card 
                       v-for="(csp,idx) in csps" 
                       :key="idx" 
@@ -52,10 +53,15 @@
                       </div>
                       <h3 class="_csp-name"> {{ csp.name }}</h3>
                       <div class="_csp-link-div">
-                        <a :id="csp.iconName.toUpperCase() + 'CalculatorLink'"
-                          class="_csp-link"
-                          @click="showAlert(csp.name)"> 
-                          View calculator
+
+                        <a v-for="(link, index) in csp.links"
+                          :key="index" 
+                          :id="csp.iconName.toUpperCase() + 'CalculatorLink'"
+                          class="_csp-link d-block"
+                          :href="link.url"
+                          target="_blank"
+                        >
+                          {{ link.text }}
                           <span class="_text-decoration-none ml-1">
                           <ATATSVGIcon
                             :id="csp.iconName.toUpperCase() + 'LaunchIcon'"
@@ -92,6 +98,19 @@
             </v-list>
           </template>
         </ATATAlert>
+
+        <ATATAlert 
+          type="warning"
+          class="mt-10"
+        >
+          <template v-slot:content>
+            JWCC CSP’s Pricing Calculator provides estimates for services only. 
+            Final pricing for services, including potential additional discounts, 
+            will be provided during the Task Order competition process.
+          </template>
+
+        </ATATAlert>
+
       </v-col>
     </v-row>
   </v-container>
@@ -120,25 +139,57 @@ export default class CreatePriceEstimate extends Vue {
       name: "Amazon Web Services (AWS)",
       iconName: "aws",
       width: "64",
-      height: "39" 
+      height: "39",
+      links: [
+        {
+          text: "View calculator",
+          url: "https://calculator.aws/#/?token=4ec5ddaefb8454253ef740c67969aae0&volume_discount=0"
+        }
+      ]
     },
     {
       name: "Google Cloud Platform (GCP)",
       iconName: "gcp",
       width: "64",
-      height: "57 " 
+      height: "57",
+      links: [
+        {
+          text: "IL2 calculator",
+          url: "https://portal.gov.gss.google/il2/",
+        },
+        {
+          text: "IL4 calculator",
+          url: "https://portal.gov.gss.google/il4/calc.html",
+        },
+        {
+          text: "IL6 calculator",
+          url: "https://portal.gov.gss.google/il5/calc.html",
+        }
+      ] 
     },
     {
       name: "Microsoft Azure",
       iconName: "azure",
       width: "64",
-      height: "50" 
+      height: "50",
+      links: [
+        {
+          text: "View calculator",
+          url: "https://azure.microsoft.com/en-us/pricing/calculator/",
+        }
+      ]
     },                
     {
       name: "Oracle Cloud",
       iconName: "oracle",
       width: "64",
-      height: "41" 
+      height: "41",
+      links: [
+        {
+          text: "View calculator",
+          url: "https://cloud.nsg.oracle.com/ce/jwcc/index.html",
+        }
+      ]
     }
   ]
   public showAlert(csp: string):void {


### PR DESCRIPTION
No UI changes expect for…
- change in  Step 1 paragraph text 
- adding warning message panel (AC1) 
- linking CSPs calculator link (AC 2)

1. Changed in Step 1 text (Figure 1.1)
    1. Choose one or more of the Cloud Service Provider (CSP) pricing calculators below to help you calculate your estimated price for JWCC cloud services and support. Depending on your selection, you may need to register for an account to view the pricing calculator.
1. Warning Message panel (Figure 1.2)
    1. Text: JWCC Cost Calculators identify the baseline discounts for estimation; further discounts may be realized through the TO award process
1. Here are CSPs Calculator link that needs to be linked
    1. AWS Calculator link:
        1. https://calculator.aws/#/?token=4ec5ddaefb8454253ef740c67969aae0&volume_discount=0
    1. GCP Calculator link:
        1. IL2: https://portal.gov.gss.google/il2/
        1. IL4: https://portal.gov.gss.google/il4/calc.html
        1. IL5: https://portal.gov.gss.google/il5/calc.html
    1. Azure Calculator link:
        1. https://azure.microsoft.com/en-us/pricing/calculator
    1. Oracle Calculator link:
        1. https://cloud.nsg.oracle.com/ce/jwcc/index.html