### PR TITLE
Bugfix/igce single and multiple text disappear

### DIFF
--- a/src/components/ATATSingleAndMultiplePeriods.vue
+++ b/src/components/ATATSingleAndMultiplePeriods.vue
@@ -16,7 +16,6 @@
         id="SingleAmount"
         width="190"
         class="mr-2"
-        type="number"
         :alignRight="true"
         :value.sync="_values[0]"
         :isCurrency="textboxSuffix === ''"
@@ -56,7 +55,6 @@
         <div>
           <ATATTextField
             :id="period.period_type + '_' + idx"
-            type="number"
             width="190"
             class="ml-5"
             :alignRight="true"

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -905,6 +905,16 @@ export const IGCETrainingPathResolver = (current: string, direction: string): st
     : basePath + gatherPriceEstimatesPath;
 }
 
+export const IGCEGatherPriceResolver = (current: string): string => {
+  const hasOffering = DescriptionOfWork.DOWObject.length >= 1
+
+  if (hasOffering) {
+    return routeNames.GatherPriceEstimates;
+  }
+  return current === routeNames.CreatePriceEstimate ? routeNames.IGCETraining 
+    : routeNames.CreatePriceEstimate;
+}
+
 const isFirstIGCETraining = (): boolean => {
   const trainingIndex = IGCE.igceTrainingIndex;
 
@@ -1153,6 +1163,7 @@ const routeResolvers: Record<string, StepRouteResolver> = {
   UploadJAMRRDocumentsRouteResolver,
   AnticipatedUserAndDataNeedsResolver,
   DOWArchitecturalDesignResolver,
+  IGCEGatherPriceResolver,
   // IGCETrainingResolver
 };
 

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -163,6 +163,7 @@ import {
   AnticipatedUserAndDataNeedsResolver,
   DOWArchitecturalDesignResolver,
   IGCETrainingPathResolver,
+  IGCEGatherPriceResolver,
 } from "./resolvers";
 import TraininigEstimates from "@/steps/10-FinancialDetails/IGCE/Training.vue";
 
@@ -923,7 +924,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.GatherPriceEstimates,
         completePercentageWeight: 1,
         component: GatherPriceEstimates,
-        routeResolver: IGCETrainingPathResolver,
+        routeResolver: IGCEGatherPriceResolver,
       },
       {
         menuText: "Training",


### PR DESCRIPTION
Fixed an issue in the ATATSingleAndMultiplePeriods component that would make any amount over 1,000 disappear but still save the value.

Fixed an issue with the IGCE Gather Price Estimates sharing the route resolver with IGCE Training, causing the Gather Price Estimates page to be skipped when clicking through the application.