### PR TITLE
Bugfix/at 8579 igce routing

### DIFF
--- a/src/components/ATATSearch.vue
+++ b/src/components/ATATSearch.vue
@@ -195,7 +195,6 @@ export default class ATATSearch extends Vue {
   }
 
   private async search(): Promise<void> {
-    debugger;
     if (this.isSimulation && this.errorMessages.length === 0 && this._value) {
 
       // simulate success on first search, error on second.

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -111,6 +111,7 @@ import SupportingDocumentation from "@/steps/10-FinancialDetails/IGCE/Supporting
 import EstimatesDeveloped from "@/steps/10-FinancialDetails/IGCE/EstimatesDeveloped.vue";
 import SurgeCapabilities from "../steps/10-FinancialDetails/IGCE/SurgeCapabilities.vue";
 import MIPR from "../steps/10-FinancialDetails/MIPR.vue";
+import TraininigEstimates from "@/steps/10-FinancialDetails/IGCE/Training.vue";
 import SeverabilityAndIncrementalFunding 
   from "../steps/10-FinancialDetails/SeverabilityAndIncrementalFunding.vue";
 import IncrementalFunding 
@@ -162,10 +163,8 @@ import {
   UploadJAMRRDocumentsRouteResolver,
   AnticipatedUserAndDataNeedsResolver,
   DOWArchitecturalDesignResolver,
-  IGCETrainingPathResolver,
-  IGCEGatherPriceResolver,
+  IGCEPathResolver,
 } from "./resolvers";
-import TraininigEstimates from "@/steps/10-FinancialDetails/IGCE/Training.vue";
 
 export const routeNames = {
   ContractingShop: "Contracting_Shop",
@@ -924,7 +923,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.GatherPriceEstimates,
         completePercentageWeight: 1,
         component: GatherPriceEstimates,
-        routeResolver: IGCEGatherPriceResolver,
+        routeResolver: IGCEPathResolver,
       },
       {
         menuText: "Training",
@@ -933,16 +932,17 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.IGCETraining,
         completePercentageWeight: 1,
         component: IGCETraining,
-        routeResolver: IGCETrainingPathResolver,
+        routeResolver: IGCEPathResolver,
       },
-      // {
-      //   menuText: "Travel Estimates",
-      //   excludeFromMenu: true,
-      //   path: "travel-estimate",
-      //   name: routeNames.TravelEstimates,
-      //   completePercentageWeight: 1,
-      //   component: TravelEstimates
-      // },
+      {
+        menuText: "Travel Estimates",
+        excludeFromMenu: true,
+        path: "travel-estimate",
+        name: routeNames.TravelEstimates,
+        completePercentageWeight: 1,
+        component: TravelEstimates,
+        routeResolver: IGCEPathResolver,
+      },
       {
         menuText: "Surge Capacity",
         excludeFromMenu: true,
@@ -950,7 +950,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.SurgeCapacity,
         completePercentageWeight: 1,
         component: SurgeCapacity,
-        routeResolver: IGCETrainingPathResolver,
       },
       {
         menuText: "Surge Capabilities",

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -163,7 +163,7 @@ import {
   UploadJAMRRDocumentsRouteResolver,
   AnticipatedUserAndDataNeedsResolver,
   DOWArchitecturalDesignResolver,
-  IGCEPathResolver,
+  IGCETrainingPathResolver,
 } from "./resolvers";
 
 export const routeNames = {
@@ -923,7 +923,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.GatherPriceEstimates,
         completePercentageWeight: 1,
         component: GatherPriceEstimates,
-        routeResolver: IGCEPathResolver,
+        routeResolver: IGCETrainingPathResolver,
       },
       {
         menuText: "Training",
@@ -932,7 +932,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.IGCETraining,
         completePercentageWeight: 1,
         component: IGCETraining,
-        routeResolver: IGCEPathResolver,
+        routeResolver: IGCETrainingPathResolver,
       },
       {
         menuText: "Travel Estimates",
@@ -941,7 +941,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         name: routeNames.TravelEstimates,
         completePercentageWeight: 1,
         component: TravelEstimates,
-        routeResolver: IGCEPathResolver,
+        routeResolver: IGCETrainingPathResolver,
       },
       {
         menuText: "Surge Capacity",

--- a/src/steps/01-AcquisitionPackageDetails/ContractingShop.vue
+++ b/src/steps/01-AcquisitionPackageDetails/ContractingShop.vue
@@ -69,7 +69,8 @@ import ATATAlert from "@/components/ATATAlert.vue";
 import SlideoutPanel from "@/store/slideoutPanel/index";
 import { SlideoutPanelContent, RadioButton } from "../../../types/Global";
 import ContractingShopLearnMore from "./ContractingShopLearnMore.vue";
-import AcquisitionPackage from "@/store/acquisitionPackage";
+import AcquisitionPackage, { StoreProperties } from "@/store/acquisitionPackage";
+import { ProjectOverviewDTO } from "@/api/models";
 
 @Component({
   components: {
@@ -111,6 +112,11 @@ export default class ContractingShop extends Mixins(SaveOnLeave) {
       await AcquisitionPackage.setPackageId(packageId as string);
       await AcquisitionPackage.loadPackageFromId(packageId as string);
     }
+    // make sure package is initialized
+    const storeData = AcquisitionPackage.projectOverview
+      || await AcquisitionPackage.loadData<ProjectOverviewDTO>({
+        storeProperty: StoreProperties.ProjectOverview,
+      });
 
     this.contractingShop = AcquisitionPackage.contractingShop || "";
   }


### PR DESCRIPTION
### Also resolves [AT-8576]( https://ccpo.atlassian.net/browse/AT-8576) and [AT-8571](https://ccpo.atlassian.net/browse/AT-8571)

Original AC: "Please resolve the following issue sometimes, the Gather Price Estimates page is skipped when clicking through the application."

More detail: There are many conditions for routing in the IGCE first 6 pages, some of which will be skipped based on previous selections made throughout the app. 

1. **Replicate or Optimize** -- should show if selected in step 4 current environment
2. **Architectural Design** -- should show if EITHER arch design selected in step 4 currrent environment OR in step 5 on categories/table of contents first page.
3. **Gather Price Estimates** -- should show if at least 1 category other than Training selected in step 5.
4. **Training** -- should show ONLY if Training was selected in step 5 and at least one training instance created. 
    1. Training page should loop through the training page as many training instances created.
6. **Travel** -- should only show if Travel selected in step 6.

The PR for this ticket addresses all of these issues and possible combinations, navigating forward and backwards.