### PR TITLE
feature/AT-8608

### DIFF
--- a/src/steps/04-ContractDetails/PeriodOfPerformance.vue
+++ b/src/steps/04-ContractDetails/PeriodOfPerformance.vue
@@ -497,7 +497,7 @@ export default class PeriodOfPerformance extends Mixins(SaveOnLeave) {
 
   private get currentData(): PeriodDTO[] {
 
-    const periods = this.optionPeriods.map(pop=>convertPoPToPeriod(pop));
+    const periods = this.optionPeriods.map(pop=>convertPoPToPeriod(pop))
     return periods;
   }
 
@@ -505,17 +505,16 @@ export default class PeriodOfPerformance extends Mixins(SaveOnLeave) {
 
   public async loadOnEnter(): Promise<void> {
     const periods = await Periods.getAllPeriods() as PeriodDTO[];
-    this.savedData = periods.map(period=> {
-
-      return {
-        option_order: period.option_order,
-        period_unit_count: period.period_unit_count,
-        period_unit: period.period_unit,
-        period_type: period.period_type,
-        sys_id: period.sys_id,
-      }
-    });
-
+    this.savedData = periods.sort((a, b) => a.option_order > b.option_order ? 1 : -1)
+      .map(period=> {
+        return {
+          option_order: period.option_order,
+          period_unit_count: period.period_unit_count,
+          period_unit: period.period_unit,
+          period_type: period.period_type,
+          sys_id: period.sys_id,
+        }
+      });
     this.optionPeriods = periods.length ? periods.map(period=> {
 
       const optionPeriod: PoP = {


### PR DESCRIPTION
Just noticed that the order of periods are changing on PoP screen. This was originally entered as 1 year, 1 year, 10 months, 65 days. When I Continued and went back, no change. When I went to the Dashboard and came back to the PoP screen, it was reordered like this.

fix: sort PoP by option_period