### PR TITLE
Update IgceEstimateDTO to match SNOW table

### DIFF
--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -824,13 +824,14 @@ export interface IgceEstimateDTO extends BaseTableDTO {
   classification_instance: ReferenceColumn | string;
   environment_instance: ReferenceColumn | string;
   cross_domain_solution: ReferenceColumn | string;
-  contract_type: "" | "FFP" | "T&M" | "TBD";
+  contract_type: "FFP" | "T&M" | "TBD"; //zach note -> contract_type should never be "", only choices in DB are FFP, T&M, TBD
   title: string;
   description: string;
   unit: string;
-  unit_price: number | null;
+  unit_price: number; // zach note -> unit price can never be null on the excel page
   unit_quantity: string;
-  dow_task_number?: string;
+  dow_task_number: string; //zach note -> DOW task number is required on the excel page, not optional.
+  idiq_clin_type: "CLOUD" | "CLOUD_SUPPORT"; //zach note -> added idiq_clin_type
 }
 
 export interface RegionsDTO extends BaseTableDTO {


### PR DESCRIPTION
# Overview
This Draft PR is a starting point for resolving several Igce issues I identified on 1/10/2023.
I noticed some discrepancy between the `IgceEstimateDTO` and the `x_g_dis_atat_igce_estimate` on ServiceNow, and updated
the data model to reflect these changes.

There are also some issues in `saveIgceEstimates` that may require deeper refactoring.

## Bugs observed
### Classification Levels are always empty
![image](https://user-images.githubusercontent.com/84199040/211683099-ae0d6b0a-15b9-490e-a46e-7ca9da2296b0.png)
### Options for instance data for Cross Domain Solution populating always includes an Environment Instance
![image](https://user-images.githubusercontent.com/84199040/211683691-44af7527-2ae3-4969-b3b1-b027deffa74a.png)
Only 1 option should be included, populating both breaks the DB design.
### Options for instance data is filled with invalid sys_ids
![image](https://user-images.githubusercontent.com/84199040/211684083-db646091-2385-4fd5-bea2-2c6f41298f2c.png)
The sys_ids provided for the `classification_instance`, `environment_instance`, and `cross_domain_solution` reference non-existent records. 
For `classification_instance`, the following sys_ids are repeated for all 232 records.

- 405b52af87970590ec3b777acebb3556
- cc3b52af87970590ec3b777acebb3581
- d84b1a6f87970590ec3b777acebb3566
- 0f3bde6f87970590ec3b777acebb35d0

If these records were generated using the frontend, shouldn't they reference the actual sys_id of the appropriate `classification_instance` record? Are these being filled in manually somewhere?
