### PR TITLE
Bugfix/at 8637

### DIFF
--- a/src/api/acquisitionPackages/index.ts
+++ b/src/api/acquisitionPackages/index.ts
@@ -1,6 +1,6 @@
 import {AcquisitionPackageDTO, AcquisitionPackageSummaryDisplay} from "../models";
 import { TableApiBase } from "../tableApiBase";
-const TABLENAME = "x_g_dis_atat_acquisition_package";
+export const TABLENAME = "x_g_dis_atat_acquisition_package";
 export class AcquisitionPackagesApi extends TableApiBase<AcquisitionPackageDTO> {
   constructor() {
     super(TABLENAME);

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -85,7 +85,7 @@
       </v-file-input>
       <ATATErrorValidation
         class="file-upload-validation-messages"
-        :showAllErrors="true"
+        :showAllErrors="showAllErrors"
         :errorMessages="errorMessages"
       />
     </div>
@@ -141,6 +141,7 @@ export default class ATATFileUpload extends Vue {
   @Prop({ default: 15 }) private truncateLength!: string;
   @Prop({ default: "" }) private id!: string;
   @Prop({ default: true}) private multiplesAllowed!: boolean;
+  @Prop({ default: true}) private showAllErrors?: boolean;
   @Prop() private restrictedNames?: string[];
   @Prop({ default: "required"}) private requiredMessage!: string;
   @Prop({ default: 20 }) private maxNumberOfFiles!: number;

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -21,7 +21,7 @@
         ]"
         multiple
         prepend-icon=""
-        accept="application/pdf,application/vnd.ms-excel, .xlsx"
+        accept="application/pdf,application/vnd.ms-excel, .xlsx, .doc, .docx"
         :truncate-length="truncateLength"
         :clearable="true"
         @change="fileUploadChanged"
@@ -288,6 +288,14 @@ export default class ATATFileUpload extends Vue {
    */
   private removeInvalidFiles(files: FileList): void {
     let _validFiles = Array.from(files || []).filter((vFile) => {
+      const restrictedNames = [
+        "DescriptionOfWork.docx",
+        "IncrementalFundingPlan.docx",
+        "RequirementsChecklist.docx",
+        "IGCE.xlsx",
+        "EvaluationPlan.docx",
+      ]
+      const isRestrictedName = restrictedNames.includes(vFile.name)
       const thisFileFormat = vFile.name.substring(
         vFile.name.lastIndexOf(".") + 1
       );
@@ -304,6 +312,7 @@ export default class ATATFileUpload extends Vue {
       });
       const isFileSizeValid = vFile.size < this.maxFileSizeInBytes;
 
+
       //log Invalid Files
       if (!isValidFormat) {
         this.logInvalidFiles(vFile, doesFileExist);
@@ -314,8 +323,11 @@ export default class ATATFileUpload extends Vue {
       if (!isFileSizeValid) {
         this.logInvalidFiles(vFile, doesFileExist);
       }
+      if(isRestrictedName){
+        this.logInvalidFiles(vFile, doesFileExist);
+      }
       
-      return isValidFormat && !doesFileExist && isFileSizeValid;
+      return isValidFormat && !doesFileExist && isFileSizeValid && !isRestrictedName;
     });
 
    

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -141,6 +141,7 @@ export default class ATATFileUpload extends Vue {
   @Prop({ default: 15 }) private truncateLength!: string;
   @Prop({ default: "" }) private id!: string;
   @Prop({ default: true}) private multiplesAllowed!: boolean;
+  @Prop() private restrictedNames?: string[];
   @Prop({ default: "required"}) private requiredMessage!: string;
   @Prop({ default: 20 }) private maxNumberOfFiles!: number;
   @Prop({ default: false }) private startCompact?: boolean;
@@ -288,14 +289,8 @@ export default class ATATFileUpload extends Vue {
    */
   private removeInvalidFiles(files: FileList): void {
     let _validFiles = Array.from(files || []).filter((vFile) => {
-      const restrictedNames = [
-        "DescriptionOfWork.docx",
-        "IncrementalFundingPlan.docx",
-        "RequirementsChecklist.docx",
-        "IGCE.xlsx",
-        "EvaluationPlan.docx",
-      ]
-      const isRestrictedName = restrictedNames.includes(vFile.name)
+
+      const isRestrictedName = this.restrictedNames?.includes(vFile.name)
       const thisFileFormat = vFile.name.substring(
         vFile.name.lastIndexOf(".") + 1
       );

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -188,7 +188,7 @@ export default class ATATFileUpload extends Vue {
   }
 
   get setRules():((v: string) => string | true | undefined)[] {
-    return this._validFiles.length>0 ? [] : this._rules;
+    return this._validFiles.length>0 && this._invalidFiles.length<0 ? [] : this._rules;
   }
 
   //Events

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -188,7 +188,7 @@ export default class ATATFileUpload extends Vue {
   }
 
   get setRules():((v: string) => string | true | undefined)[] {
-    return this._validFiles.length>0 && this._invalidFiles.length<0 ? [] : this._rules;
+    return this._validFiles.length>0 && this._invalidFiles.length === 0 ? [] : this._rules;
   }
 
   //Events

--- a/src/plugins/validation.ts
+++ b/src/plugins/validation.ts
@@ -289,21 +289,21 @@ export class ValidationPlugin {
                 `.${validExtensions.slice(-1)} file.`
       }
       // list of names that a file can not have
-      else if(restrictedNames?.includes(file.name)){
+      if(restrictedNames?.includes(file.name)){
         return "File name already exist. Please rename the file."
       }
 
       // does file aleady exist?
-      else if (doesFileExist){
+      if (doesFileExist){
         return `'${fileName}' was already uploaded.`
       }
 
       // is file too big?
-      else if (fileSize>maxFileSize){
+      if (fileSize>maxFileSize){
         return `Your file '${fileName}' is too large. Please upload a file that is 1GB or less.`
       }
 
-      else if (SNOWError !== "" && SNOWError !== undefined){
+      if (SNOWError !== "" && SNOWError !== undefined){
         const error = SNOWError.toLowerCase();
         let invalidMessage = "";
 

--- a/src/plugins/validation.ts
+++ b/src/plugins/validation.ts
@@ -271,7 +271,7 @@ export class ValidationPlugin {
     doesFileExist: boolean,
     SNOWError?: string,
     statusCode?: number,
-    restrictNames?:boolean,
+    restrictedNames?:string[],
   ):((v: string) => string | true | undefined) => {
     return () => {
       const fileName = file.name.length>20
@@ -282,18 +282,14 @@ export class ValidationPlugin {
       const isValidExtension = validExtensions.some((ext)=>
         fileName.substring(fileName.lastIndexOf(".")+1).toLowerCase() === ext
       )
-      const restrictedNames = ["DescriptionOfWork.docx",
-        "IncrementalFundingPlan.docx",
-        "RequirementsChecklist.docx",
-        "IGCE.xlsx",
-        "EvaluationPlan.docx",]
+
       if (!isValidExtension){
         return `'${fileName}' is not a valid format or has been corrupted. ` +
                 `Please upload a valid .${validExtensions.slice(0, -1).join(", .")} or ` +
                 `.${validExtensions.slice(-1)} file.`
       }
       // list of names that a file can not have
-      else if(restrictNames && restrictedNames.includes(file.name)){
+      else if(restrictedNames?.includes(file.name)){
         return "File name already exist. Please rename the file."
       }
 

--- a/src/plugins/validation.ts
+++ b/src/plugins/validation.ts
@@ -273,10 +273,7 @@ export class ValidationPlugin {
     statusCode?: number,
     restrictNames?:boolean,
   ):((v: string) => string | true | undefined) => {
-    console.log()
-    debugger
     return () => {
-      debugger
       const fileName = file.name.length>20
         ? file.name.substring(0, 12) + '...'
             + file.name.substring(file.name.length-8, file.name.length)

--- a/src/plugins/validation.ts
+++ b/src/plugins/validation.ts
@@ -321,6 +321,7 @@ export class ValidationPlugin {
         }
         return invalidMessage;
       }
+      return true
     }
   };
 }

--- a/src/services/attachment/AcquisitionPackage/index.ts
+++ b/src/services/attachment/AcquisitionPackage/index.ts
@@ -1,0 +1,42 @@
+/* eslint-disable camelcase */
+import {AttachmentDTO, AcquisitionPackageDTO} from "@/api/models";
+import {AttachmentServiceCallbacks, RecordManager} from "..";
+import {AttachmentServiceBase} from "../base";
+import AcquisitionPackage from "@/store/acquisitionPackage/index";
+import {AcquisitionPackagesApi} from "@/api/acquisitionPackages";
+
+const recordManager : RecordManager<AcquisitionPackageDTO>= {
+  retrieveOrCreate: async function (): Promise<AcquisitionPackageDTO>{
+    return await AcquisitionPackage.getAcquisitionPackage() as AcquisitionPackageDTO;
+  },
+  save: async function (record: string): Promise<void> {
+    const data = JSON.parse(record) as AcquisitionPackageDTO;
+    AcquisitionPackage.setAcquisitionPackage(data);
+  },
+  updateRecord: function (record: string, attachmentSysId: string, fileName: string):
+      AcquisitionPackageDTO {
+    return JSON.parse(record) as AcquisitionPackageDTO;
+  }
+}
+
+export class AcquisitionPackageDocumentService extends
+  AttachmentServiceBase<AcquisitionPackagesApi, AcquisitionPackageDTO> {
+
+  constructor(serviceKey: string, tableName: string, tableApi: AcquisitionPackagesApi) {
+    super(serviceKey, tableName, tableApi);
+  }
+
+  protected recordManager: RecordManager<AcquisitionPackageDTO> = recordManager;
+
+  async remove(attachment: AttachmentDTO | undefined): Promise<void> {
+    if (!attachment) {
+      throw new Error("invalid request, attachment required");
+    }
+    //only delete the attachment
+    await this.attachmentApi.remove(attachment.sys_id || "");
+    AttachmentServiceCallbacks.invokeRemoveCallbacks(
+      this.serviceKey,
+      attachment
+    );
+  }
+}

--- a/src/services/attachment/index.ts
+++ b/src/services/attachment/index.ts
@@ -7,6 +7,7 @@ import { TABLENAME as FundingRequestMIPRFormTableName } from "@/api/fundingReque
 import { TABLENAME as RequirementsCostEstimateTableName } from "@/api/requirementsCostEstimate";
 import { TABLENAME as CurrentEnvironmentTableName } from "@/api/currentEnvironment";
 import { TABLENAME as FairOpportunityTableName } from "@/api/fairOpportunity";
+import { TABLENAME as AcquisitionPackageTableName } from "@/api/acquisitionPackages";
 import { FundingRequestFSAttachmentService } from "./fundingRequestFSForm";
 import { AttachmentServiceBase } from "./base";
 import { FundingRequestMIPRAttachmentService } from "./fundingRequestMIPRForm";
@@ -14,6 +15,7 @@ import {RequirementsCostEstimateAttachmentService} from
   "@/services/attachment/reqCostEstimateSupportingDocs";
 import {CurrentEnvironmentDocumentService} from "@/services/attachment/currentEnvironmentDocument";
 import {FairOpportunityDocumentService} from "@/services/attachment/fairOpportunity";
+import {AcquisitionPackageDocumentService} from "@/services/attachment/AcquisitionPackage";
 
 export const AttachmentServiceCallbacks = (() => {
   const uploadCallbacks: Record<
@@ -94,7 +96,8 @@ export const AttachmentServiceTypes = {
   FundingRequestMIPRForm: FundingRequestMIPRFormTableName,
   RequirementsCostEstimate: RequirementsCostEstimateTableName,
   CurrentEnvironment: CurrentEnvironmentTableName,
-  FairOpportunity: FairOpportunityTableName
+  FairOpportunity: FairOpportunityTableName,
+  AcquisitionPackage: AcquisitionPackageTableName
 };
 export const AttachmentServiceFactory = (
   attachmentServiceType: string
@@ -133,6 +136,12 @@ export const AttachmentServiceFactory = (
       attachmentServiceType,
       FairOpportunityTableName,
       api.fairOpportunityTable
+    );
+  case AttachmentServiceTypes.AcquisitionPackage:
+    return new AcquisitionPackageDocumentService(
+      attachmentServiceType,
+      AcquisitionPackageTableName,
+      api.acquisitionPackageTable
     );
   
   default:

--- a/src/steps/11-GeneratePackageDocuments/UploadJAMRRDocuments.vue
+++ b/src/steps/11-GeneratePackageDocuments/UploadJAMRRDocuments.vue
@@ -92,6 +92,7 @@
                 :invalidFiles.sync="invalidFiles"
                 :validFiles.sync="uploadedFiles"
                 :removeAll.sync="removeAll"
+                :showAllErrors="false"
                 @delete="onRemoveAttachment"
                 @uploaded="onUpload"
                 :rules="getRulesArray()"
@@ -182,8 +183,6 @@ export default class UploadJAMRRDocuments extends Mixins(SaveOnLeave) {
 
   private getRulesArray(): ((v: string) => string|true|undefined)[] {
     let rulesArr: ((v: string) => string | true | undefined)[] = [];
-
-    rulesArr.push(this.$validators.required(this.requiredMessage));
     this.invalidFiles.forEach((iFile) => {
       rulesArr.push(
         this.$validators.isFileValid(
@@ -197,6 +196,7 @@ export default class UploadJAMRRDocuments extends Mixins(SaveOnLeave) {
         )
       );
     });
+    rulesArr.push(this.$validators.required(this.requiredMessage));
     return rulesArr;
   }
 

--- a/src/steps/11-GeneratePackageDocuments/UploadJAMRRDocuments.vue
+++ b/src/steps/11-GeneratePackageDocuments/UploadJAMRRDocuments.vue
@@ -83,6 +83,7 @@
               <ATATFileUpload
                 id="JAMRRFiles"
                 tabindex="-1"
+                :restrictedNames="restrictedNames"
                 :maxNumberOfFiles="2"
                 :maxFileSizeInBytes="maxFileSizeInBytes"
                 :validFileFormats="validFileFormats"
@@ -147,7 +148,13 @@ export default class UploadJAMRRDocuments extends Mixins(SaveOnLeave) {
   private uploadedFiles: uploadingFile[] = [];
   public removeAll = false;
   public requiredMessage = "Please upload a file"
-
+  public restrictedNames = [
+    "DescriptionOfWork.docx",
+    "IncrementalFundingPlan.docx",
+    "RequirementsChecklist.docx",
+    "IGCE.xlsx",
+    "EvaluationPlan.docx",
+  ]
   private jaTemplateUrl = "";
   private mrrTemplateUrl = "";
 
@@ -186,7 +193,7 @@ export default class UploadJAMRRDocuments extends Mixins(SaveOnLeave) {
           iFile.doesFileExist,
           iFile.SNOWError,
           iFile.statusCode,
-          true
+          this.restrictedNames
         )
       );
     });

--- a/src/store/attachments/index.ts
+++ b/src/store/attachments/index.ts
@@ -13,6 +13,7 @@ import { TABLENAME as FUNDING_REQUEST_MIPRFORM_TABLE } from "@/api/fundingReques
 import { TABLENAME as REQUIREMENTS_COST_ESTIMATE_TABLE } from "@/api/requirementsCostEstimate";
 import { TABLENAME as CURRENT_ENVIRONMENT_TABLE } from "@/api/currentEnvironment";
 import { TABLENAME as FAIR_OPPORTUNITY_TABLE } from "@/api/fairOpportunity";
+import { TABLENAME as ACQUISITION_PACKAGE_TABLE } from "@/api/acquisitionPackages";
 import { AttachmentDTO } from "@/api/models";
 import {
   AttachmentServiceCallbacks,
@@ -41,13 +42,14 @@ export class AttachmentStore extends VuexModule {
   // store session properties
   protected sessionProperties: string[] = [FUNDING_REQUEST_FSFORM_TABLE,
     FUNDING_REQUEST_MIPRFORM_TABLE, REQUIREMENTS_COST_ESTIMATE_TABLE,
-    CURRENT_ENVIRONMENT_TABLE, FAIR_OPPORTUNITY_TABLE];
+    CURRENT_ENVIRONMENT_TABLE, FAIR_OPPORTUNITY_TABLE, ACQUISITION_PACKAGE_TABLE];
 
   public [FUNDING_REQUEST_FSFORM_TABLE]: AttachmentDTO[] = [];
   public [FUNDING_REQUEST_MIPRFORM_TABLE]: AttachmentDTO[] = [];
   public [REQUIREMENTS_COST_ESTIMATE_TABLE]: AttachmentDTO[] = [];
   public [CURRENT_ENVIRONMENT_TABLE]: AttachmentDTO[] = [];
   public [FAIR_OPPORTUNITY_TABLE]: AttachmentDTO[] = [];
+  public [ACQUISITION_PACKAGE_TABLE]: AttachmentDTO[] = [];
 
   @Mutation
   public setStoreData(sessionData: string): void {
@@ -186,6 +188,15 @@ export class AttachmentStore extends VuexModule {
         })
       }
     );
+    AttachmentServiceCallbacks.registerUploadCallBack(
+      ACQUISITION_PACKAGE_TABLE,
+      (attachment) => {
+        this.addAttachment({
+          key: ACQUISITION_PACKAGE_TABLE,
+          attachment
+        })
+      }
+    );
 
     const sessionRestored = retrieveSession(ATAT_ATTACHMENTS_KEY);
     if (sessionRestored) {
@@ -302,6 +313,7 @@ export class AttachmentStore extends VuexModule {
     this[REQUIREMENTS_COST_ESTIMATE_TABLE] = [];
     this[CURRENT_ENVIRONMENT_TABLE] = [];
     this[FAIR_OPPORTUNITY_TABLE] = [];
+    this[ACQUISITION_PACKAGE_TABLE] = [];
   }
 }
 


### PR DESCRIPTION
Currently any uploaded J&A and MRR document is not storing. On edit, the user have to re-upload J&A and MRR. Make sure to store upload J&A and MRR doucments so the user can view uploaded documents on edit.  
Please save docs to the Acquisition Package table row and instead of the Fair Opportunity table row.  (Correct row can be found with Acq package id)
Ensure docs can be saved as expected.
Doc names are to be stored in Acquisition Package.J&A and MRR Filenames as a comma delimited string - added in [AT-8636: J&A and MRR documents need to be be uploaded collectively, replaceable, but also included in download package documentsCCPO TECHNICAL REVIEW](https://ccpo.atlassian.net/browse/AT-8636)
Ensure docs can load as expected
Read doc names from AC 3.a then load those docs in the file component.  This necessary as multiple docs will be attached to the Acq package table record, so the correct docs need to be retrieved
Add supported file type .docx to the file upload component
Ensure user cannot upload more than 2 docs to the component