### PR TITLE
bugfix/AT-8639-training-cost-estimate

### DIFF
--- a/src/store/IGCE/index.ts
+++ b/src/store/IGCE/index.ts
@@ -164,15 +164,15 @@ export class IGCEStore extends VuexModule {
   public async saveTrainingEstimate(value: TrainingEstimate): Promise<string> {
     let objSysId = "";
 
-    const packageId = AcquisitionPackage.acquisitionPackage?.sys_id;
-
     const trainingDTOItem: TrainingEstimateDTO = {
-      acquisition_package: packageId || "",
+      acquisition_package: AcquisitionPackage.packageId,
       estimated_price_per_training_unit: value.estimatedTrainingPrice,
       training_option: value.trainingOption,
       training_estimated_values: value.estimate.estimated_values || "",
       training_unit: value.costEstimateType
     };
+
+    console.log(trainingDTOItem.acquisition_package);
 
     if(value.sysId){
       await api.trainingEstimateTable.update(

--- a/src/store/IGCE/index.ts
+++ b/src/store/IGCE/index.ts
@@ -171,9 +171,7 @@ export class IGCEStore extends VuexModule {
       training_estimated_values: value.estimate.estimated_values || "",
       training_unit: value.costEstimateType
     };
-
-    console.log(trainingDTOItem.acquisition_package);
-
+    
     if(value.sysId){
       await api.trainingEstimateTable.update(
         value.sysId,


### PR DESCRIPTION
- [x]  acq package id was not saving to the `DAPPS: Training Estimate` table.  The code update in this PR resolves that.