### PR TITLE
Added logic for CSP short and long names

### DIFF
--- a/src/api/eda/index.ts
+++ b/src/api/eda/index.ts
@@ -70,6 +70,7 @@ export class EDAApi extends ApiBase{
           taskOrderNumber: taskOrderNumber,
           contractor: "Microsoft Corporation",
           csp: "Azure",
+          cspLong: "Microsoft Azure",
           contractIssuingOffice: "DITCO",
           totalObligatedAmount: 10000000,
           totalAmount: 50000000,
@@ -79,18 +80,21 @@ export class EDAApi extends ApiBase{
         }
         if (taskOrderNumber === "4000000000001") {
           tempEdaResponse.classificationLevels = ["Unclassified"];
-          tempEdaResponse.csp = "GCP"
-          tempEdaResponse.contractor = "Google Support Services LLC"
+          tempEdaResponse.csp = "GCP";
+          tempEdaResponse.cspLong = "Google Cloud Platform (GCP)";
+          tempEdaResponse.contractor = "Google Support Services LLC";
         }     
         if (taskOrderNumber === "4000000000002") {
           tempEdaResponse.classificationLevels = ["Secret"];
-          tempEdaResponse.csp = "AWS"
-          tempEdaResponse.contractor = "Amazon Web Services Inc."
+          tempEdaResponse.csp = "AWS";
+          tempEdaResponse.cspLong = "Amazon Web Services (AWS)";
+          tempEdaResponse.contractor = "Amazon Web Services Inc.";
         }     
         if (taskOrderNumber === "4000000000003") {
           tempEdaResponse.classificationLevels = ["Secret"];
-          tempEdaResponse.csp = "Oracle"
-          tempEdaResponse.contractor = "Oracle America Inc."
+          tempEdaResponse.csp = "Oracle";
+          tempEdaResponse.cspLong = "Oracle Cloud";
+          tempEdaResponse.contractor = "Oracle America Inc.";
         }     
       } else {
         let tempErrorCode = "";

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -528,6 +528,7 @@ export interface EDAResponse {
   taskOrderNumber?: string;
   contractor?: string; // "Microsoft Corporation",
   csp?: string; // "Azure",
+  cspLong?: string; // "Microsoft Azure"
   contractIssuingOffice?: string; // "DITCO",
   totalObligatedAmount?: number | null;
   totalAmount?: number | null;

--- a/src/portfolios/portfolio/components/Index.vue
+++ b/src/portfolios/portfolio/components/Index.vue
@@ -99,8 +99,9 @@ export default class PortfolioSummary extends Vue {
       this.portfolioDescription = portfolio.description || "";
       this.portfolioCSP = portfolio.csp || "";
     } else {
+      const provisioningData = await PortfolioStore.getPortfolioProvisioningObj();
       this.isPortfolioProvisioning = true;
-      this.title = "Hosting and Compute Center (HaCC)"
+      this.title = provisioningData.portfolioTitle || "Untitled Portfolio"
     }
   }
   public async mounted(): Promise<void>{

--- a/src/portfolios/provisioning/AddCSPAdmin.vue
+++ b/src/portfolios/provisioning/AddCSPAdmin.vue
@@ -8,7 +8,7 @@
         <p class="page-intro">
           Before we can start provisioning, you need to add at least one Cloud 
           Service Provider (CSP) administrator. These individuals will be granted 
-          full access to your cloud resources within the {{ csp }} portal, enabling 
+          full access to your cloud resources within the {{ cspLong }} portal, enabling 
           them to manage user accounts and configure workspace settings. 
           <a
             role="button"
@@ -250,7 +250,7 @@ import AcquisitionPackage from "@/store/acquisitionPackage";
 
 export default class AddCSPAdmin extends Mixins(SaveOnLeave) {
   public admins: PortfolioAdmin[] = [];
-  public csp = "";
+  public cspLong = "";
   public classificationLevels: string[] = [];
   public openModal = false;
   public modalSlideoutComponent = CSPAdminLearnMoreText;
@@ -446,7 +446,7 @@ export default class AddCSPAdmin extends Mixins(SaveOnLeave) {
       this.admins = _.cloneDeep(storeData.admins) || [];
 
       this.savedData = _.cloneDeep(this.admins);
-      this.csp = storeData.csp as string;
+      this.cspLong = storeData.cspLong as string;
       this.classificationLevels = storeData.classificationLevels || [];
       if (this.classificationLevels.length === 1) {
         this.selectedClassificationLevels.push(this.classificationLevels[0])

--- a/src/portfolios/provisioning/AwardedTaskOrder.vue
+++ b/src/portfolios/provisioning/AwardedTaskOrder.vue
@@ -22,7 +22,7 @@
               <h2 class="mb-4">Task Order #{{ awardedTaskOrder.taskOrderNumber }} </h2>
               <dl class="d-flex flex-wrap">
                 <dt class="text-base">Cloud Service Provider (CSP)</dt>
-                <dd>{{ awardedTaskOrder.contractor }}</dd>
+                <dd>{{ awardedTaskOrder.cspLong }}</dd>
                 <dt class="text-base">Contract Issuing Office</dt>
                 <dd>{{ awardedTaskOrder.contractIssuingOffice }}</dd>
               </dl>
@@ -127,6 +127,8 @@ export default class AwardedTaskOrder extends Vue {
   public awardedTaskOrder: AwardedTaskOrderDetails = {
     taskOrderNumber: "",
     contractor: "",
+    csp: "",
+    cspLong: "",
     contractIssuingOffice: "",
     periodOfPerformance: "",
     totalObligatedAmount: 0,
@@ -153,6 +155,8 @@ export default class AwardedTaskOrder extends Vue {
       this.awardedTaskOrder = {
         taskOrderNumber: data.taskOrderNumber as string,
         contractor: data.contractor as string,
+        csp: data.csp as string,
+        cspLong: data.cspLong as string,
         contractIssuingOffice: data.contractIssuingOffice as string,
         periodOfPerformance: pop,
         totalObligatedAmount: data.totalObligatedAmount as number,

--- a/src/portfolios/provisioning/Provisioned.vue
+++ b/src/portfolios/provisioning/Provisioned.vue
@@ -6,7 +6,7 @@
           <h1 class="page-header mb-3 mt-5">Your portfolio is being provisioned!</h1>
           <div class="copy-max-width">
             <p class="mb-6">
-              We’re working with {{ provisioningData.contractor }} to provision your cloud
+              We’re working with {{ provisioningData.cspLong }} to provision your cloud
               resources. This process can take up to {{ processLength }}. We’ll email you
               when the process is complete, but you can come back here anytime
               for an up-to-date status of your portfolio and funding details.
@@ -81,7 +81,7 @@ export default class Provisioned extends Vue {
         iconWidth: "33",
         iconHeight: "21",
         headline: "CSP portal access",
-        text: `Once provisioned, ${this.provisioningData.contractor} will notify your 
+        text: `Once provisioned, ${this.provisioningData.csp} will notify your 
           administrators with instructions for obtaining access to the cloud console.`
       },  {
         icon: "HelpOutline",

--- a/src/portfolios/provisioning/ReadyToProvision.vue
+++ b/src/portfolios/provisioning/ReadyToProvision.vue
@@ -8,7 +8,7 @@
         <p class="page-intro copy-max-width">
           Review your provisioning details below to ensure information is accurate. 
           When you are ready, click “Start provisioning” and we’ll submit this 
-          information to  {{ provisioningData.contractor }} to create your portfolio. 
+          information to  {{ provisioningData.cspLong }} to create your portfolio. 
           <strong>The provisioning process cannot be undone.</strong>    
         </p>
 
@@ -46,7 +46,7 @@
                   <span class="_line-height-1 font-size-12 font-weight-700 text-base-light d-block">
                     CLOUD SERVICE PROVIDER
                   </span>
-                  {{ provisioningData.contractor }}
+                  {{ provisioningData.cspLong }}
                 </div>                
               </div>
               <div class="d-flex">
@@ -84,7 +84,7 @@
                   anytime for an up-to-date status of your portfolio and funding details.
                 </p>
                 <p>
-                  Once complete, {{ provisioningData.contractor }} will notify your CSP 
+                  Once complete, {{ provisioningData.csp }} will notify your CSP 
                   administrators with instructions for obtaining access to the cloud console.
                 </p>
                 <p>

--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -62,6 +62,7 @@ const initialPortfolioProvisioningObj = (): PortfolioProvisioning => {
     taskOrderNumber: "",
     contractor: "",
     csp: "",
+    cspLong: "",
     contractIssuingOffice: "",
     totalObligatedAmount: null,
     totalAmount: null,
@@ -99,6 +100,9 @@ export class PortfolioDataStore extends VuexModule {
   @Action({rawError: true})
   public async setDidNotUseDAPPS(bool: boolean): Promise<void> {
     this.doSetDidNotUseDAPPS(bool);
+    if (bool) {
+      await AcquisitionPackage.setDisableContinue(false);
+    }
   }
   @Mutation
   public doSetDidNotUseDAPPS(bool: boolean): void {

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -539,6 +539,8 @@ export interface TaskOrderCardData {
 export interface AwardedTaskOrderDetails {
   taskOrderNumber: string,
   contractor: string,
+  csp: string,
+  cspLong: string,
   contractIssuingOffice: string,
   periodOfPerformance: string,
   totalObligatedAmount: number,


### PR DESCRIPTION
Change usage of csp company name to long and short versions in copy - e.g., `Amazon Web Services (AWS)` and `AWS`
