### PR TITLE
Resolved some money values were being

### DIFF
--- a/src/steps/10-FinancialDetails/IGCE/components/Card_Requirement.vue
+++ b/src/steps/10-FinancialDetails/IGCE/components/Card_Requirement.vue
@@ -99,7 +99,7 @@ export default class CardRequirement extends Vue {
 
   public checkMonthlyValue(): void {
     // eslint-disable-next-line camelcase
-    this._cardData.unit_price = parseFloat(this.estimate)|| 0;
+    this._cardData.unit_price = parseFloat(this.estimate.replaceAll(",", ""))|| 0;
     this.noMonthlyValue = this.moneyNumber < 1;
   }
   public async loadOnEnter(): Promise<void> {


### PR DESCRIPTION
some money values were being saved from the beginning of the value to the first comma.

**for instance** 
- 1,200.01 would save 1
- 10,345.25 would save 10
Have resolved this bugs


**Please test by ensuring correct values are being stored in the IGCE gather cost estimate page.**