### PR TITLE
bugfix/resolve-step-9-animation-not-stopping

### DIFF
--- a/src/steps/11-GeneratePackageDocuments/GeneratePackageDocuments.vue
+++ b/src/steps/11-GeneratePackageDocuments/GeneratePackageDocuments.vue
@@ -76,7 +76,7 @@ export default class GeneratingPackageDocuments extends Mixins(SaveOnLeave) {
 
     const checkDocJobStatus: unknown = (async ()=> {
       await this.getDocJobStatus();
-      ["COMPLETE", "FAILED"].some(
+      ["SUCCESS", "FAILURE"].some(
         (status)=>{
           if (status === this.docJobStatus.toUpperCase()){
             clearInterval(intervalId);


### PR DESCRIPTION
updating both statuses to `failure` and `success`
to accommodate using the `jobtype` choice field
that NOW populates the docgenstatus column in
AcquistionPackage tbl