### PR TITLE
Feature/at 8745 portfolio csp admins load sort add

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -61,6 +61,7 @@ import { RegionsAPI } from "./regions";
 import {EnvironmentApi} from "@/api/environment";
 import { PackageDocumentsSignedAPI } from "@/api/packageDocumentsSigned";
 import { PackageDocumentsUnsignedAPI } from "@/api/packageDocumentsUnsigned";
+import {OperatorAPI} from "@/api/operator";
 
 
 export const api = {
@@ -128,6 +129,7 @@ export const api = {
   regionsTable: new RegionsAPI(),
   packageDocumentsSignedTable: new PackageDocumentsSignedAPI(),
   packageDocumentsUnsignedTable: new PackageDocumentsUnsignedAPI(),
+  operatorTable: new OperatorAPI()
 }
 
 export default {

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -665,6 +665,7 @@ export interface EnvironmentDTO extends BaseTableDTO {
   provisioned_date: string;
   provisioning_failure_cause: string;
   provisioning_request_date: string;
+  csp_admins?: OperatorDTO[]
 }
 
 export interface CloudServiceProviderDTO extends BaseTableDTO{
@@ -771,6 +772,17 @@ export interface UserManagementDTO extends BaseTableDTO {
   email?: string;
   phone?: string;
   department?: DisplayColumn;
+}
+
+export interface OperatorDTO extends BaseTableDTO{
+  environment?: string;
+  email?: string;
+  dod_id?: string;
+  added_by?: string;
+  provisioned_date?: string;
+  provisioned?: string;
+  provisioning_failure_cause?: string;
+  provisioning_request_date?: string;
 }
 
 export interface TrainingEstimateDTO extends BaseTableDTO{

--- a/src/api/operator/index.ts
+++ b/src/api/operator/index.ts
@@ -1,0 +1,10 @@
+import {TableApiBase} from "@/api/tableApiBase";
+import {OperatorDTO} from "@/api/models";
+
+export const TABLENAME = "x_g_dis_atat_operator";
+
+export class OperatorAPI extends TableApiBase<OperatorDTO> {
+  constructor() {
+    super(TABLENAME);
+  }
+}

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -301,16 +301,26 @@ export function getStatusChipBgColor(status: string): string {
 
 const monthAbbreviations = ATATCharts.monthAbbreviations;
 
-export function createDateStr(dateStr: string, period: boolean): string {
+export function createDateStr(dateStr: string, period: boolean, hours?: boolean): string {
+  hours = hours ? hours : false;
   const parsedDate = parseISO(dateStr, { additionalDigits: 1 });
-  const date = new Date(parsedDate.setHours(0, 0, 0, 0));
+  const date = hours? new Date(parsedDate) : new Date(parsedDate.setHours(0, 0, 0, 0));
   const m = monthAbbreviations[date.getMonth()];
   const y = date.getFullYear();
   const d = date.getUTCDate();
   const neverPeriodMonths = ["March", "April", "May", "June", "July"];
   const noPeriodMonth = neverPeriodMonths.indexOf(m) !== -1;
   const p = period && !noPeriodMonth ? "." : "";
-  return m + p + " " + d + ", " + y;
+  let formattedDate = m + p + " " + d + ", " + y;
+  if (hours) {
+    let h = (date.getHours()).toString();
+    h = h.length === 1 ? "0" + h : h;
+    let m = (date.getMinutes()).toString();
+    m = m.length === 1 ? "0" + m : m;
+    formattedDate += " " + h + m;
+  }
+  return formattedDate;
+
 }
 
 export function differenceInDaysOrMonths(

--- a/src/portfolios/components/PortfoliosSummary.vue
+++ b/src/portfolios/components/PortfoliosSummary.vue
@@ -427,6 +427,7 @@ export default class PortfoliosSummary extends Vue {
 
       cardData.agency = portfolio.agency;
       cardData.agencyDisplay = portfolio.agency_display;
+      cardData.environments = portfolio.environments;
       const activeTaskOrderSysId = portfolio.active_task_order.value as string;
       const activeTaskOrder = portfolio.task_orders.find(
         obj => obj.sys_id === activeTaskOrderSysId

--- a/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
+++ b/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
@@ -105,11 +105,10 @@
     >
       <template #content>
         <p class="body">
-          This individual will be granted full access to your cloud resources within the
-          selected {{serviceProvider[portfolioCSP]}} portal, enabling them to manage user accounts
-          and configure workspace settings.
+          This individual will be granted full access to the {{serviceProvider[portfolioCSP]}} 
+          portal to manage user accounts and configure workspace settings. 
           <a id="LearnMoreLink" role="button" @click="openLearnMoreDrawer">
-            Learn more about CSP administrators
+            Learn more
           </a>
         </p>
         <v-form ref="modalForm" v-model="formIsValid" lazy-validation>

--- a/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
+++ b/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
@@ -379,7 +379,7 @@ export default class CSPPortalAccess extends Vue {
       Portfolio.currentPortfolio.environments[0] :
         {sys_id: "7aafda19073121106417fa4d7c1ed04a"} as EnvironmentDTO;
     await Portfolio.loadAllOperatorsOfPortfolioEnvironment(this.environment);
-    this.tableData = _.cloneDeep(this.environment.csp_admins) as Operator[];
+    this.tableData = this.environment.csp_admins as Operator[];
     this.isLoading = false;
     this.transitionGroup = "transition-group";
   }

--- a/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
+++ b/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
@@ -70,8 +70,8 @@
                   </div>
 
                 </td>
-                <td>{{item.createdBy}}</td>
-                <td>{{item.created}}</td>
+                <td>{{item.addedBy}}</td>
+                <td>{{item.provisionedDate}}</td>
               </tr>
             </template>
             </tbody>
@@ -157,16 +157,19 @@
 </template>
 
 <script lang="ts">
+/* eslint-disable camelcase */
 import Vue from "vue";
 
 import { Component, Prop, Watch } from "vue-property-decorator";
 import CSPCard from "@/portfolios/portfolio/components/shared/CSPCard.vue";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
-import format from "date-fns/format"
 import ATATTextField from "@/components/ATATTextField.vue";
 import ATATDialog from "@/components/ATATDialog.vue";
 import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
 import AddAdminSlideOut from "@/portfolios/portfolio/components/shared/AddAdminSlideOut.vue";
+import {Operator} from "../../../../../types/Global";
+import Portfolio from "@/store/portfolio";
+import {EnvironmentDTO, OperatorDTO} from "@/api/models";
 
 @Component({
   components: {
@@ -191,6 +194,9 @@ export default class CSPPortalAccess extends Vue {
   };
 
   @Prop({ default: "" }) private portfolioCSP!: string;
+  // TODO: defaults to the first environment (during loadOnEnter) from current portfolio until
+  //  portfolio env tabs based display gets implemented and environment gets passed as a property
+  public environment!: EnvironmentDTO;
 
   public page = 1;
   public today = new Date();
@@ -209,12 +215,14 @@ export default class CSPPortalAccess extends Vue {
   public transitionGroup = ""
   public modalSlideoutComponent = AddAdminSlideOut
   private modalDrawerIsOpen = false
+  private adminAlreadyExists = false;
+  private isLoading = false;
 
   public tableHeaders: Record<string, string>[] = [
     { text: "Administrator email", value: "email" },
     { text: "Status", value: "status" },
-    { text: "Added by", value: "createdBy" },
-    { text: "Processed on", value: "created" },
+    { text: "Added by", value: "addedBy" },
+    { text: "Processed on", value: "provisionedDate" },
   ];
 
   public serviceProvider = {
@@ -224,27 +232,10 @@ export default class CSPPortalAccess extends Vue {
     Oracle:"Oracle Cloud"
   }
 
-  public tableData: {
-    email:string,status:string,createdBy:string,created:string
-  }[] = [];
-  public emails = [
-    "tyrone.brown@example.mil",
-    "kim.bryant@example.mil",
-    "burt.baxter@example.mil",
-  ];
-  public statuses = [
-    "Processing",
-    "Provisioned",
-    "Failed",
-  ];
-  public createdBy = [
-    "Maria Missionowner",
-    "Sam Something",
-    "Carl Contractor",
-  ];
+  public tableData: Operator[] = [];
 
   public maxPerPage = 10;
-  public numberOfPages = Math.ceil(this.emails.length/this.maxPerPage);
+  public numberOfPages = Math.ceil(this.tableData.length/this.maxPerPage);
 
   @Watch("tableData")
   public tableDataUpdated(): void {
@@ -261,22 +252,6 @@ export default class CSPPortalAccess extends Vue {
   get startingNumber():number {
     const starting = (this.page - 1) * this.maxPerPage + 1;
     return starting;
-  }
-  public createTableData(): void {
-    for (let i = 0; i < this.emails.length; i++) {
-      const admin = {
-        email:"",
-        status:"",
-        createdBy:"",
-        created:""
-      };
-      let idx = i;
-      admin.email = this.emails[idx];
-      admin.status = this.statuses[idx];
-      admin.createdBy = this.createdBy[idx];
-      admin.created = admin.status !== "Processing" ? format(this.today,"MMM. dd, yyy hhmm") : "";
-      this.tableData.push(admin);
-    }
   }
 
   get okDisabled(): boolean {
@@ -329,17 +304,25 @@ export default class CSPPortalAccess extends Vue {
   };
 
   public addCSPMember():void {
-    const member = {
-      email:this.adminEmail,
-      status: "Processing",
-      createdBy:"Maria Missionowner",
-      created:""
-    };
-    this.tableData.unshift(member);
-    this.adminEmail = "";
-    this.dodID = "";
-    this.emailIsValid = false;
-    this.$refs.modalForm.reset();
+    const existingOperator = this.environment.csp_admins
+      ?.find(cspAdmin => cspAdmin.email === this.adminEmail);
+    if (!existingOperator) {
+      this.adminAlreadyExists = false;
+      const operator: Operator = {
+        email:this.adminEmail,
+        dodId: this.dodID
+      };
+      Portfolio.addCSPOperator({
+        environment: this.environment,
+        operator: operator
+      })
+      this.adminEmail = "";
+      this.dodID = "";
+      this.emailIsValid = false;
+      this.$refs.modalForm.reset();
+    } else {
+      this.adminAlreadyExists = true;
+    }
   }
 
   public openLearnMoreDrawer(): void {
@@ -381,7 +364,14 @@ export default class CSPPortalAccess extends Vue {
   }
   
   public async loadOnEnter(): Promise<void> {
-    await this.createTableData();
+    this.isLoading = true; // TODO: this can be used to show the spinner
+    // TODO: remove below 3 lines after environment tabs based display is implemented
+    this.environment = Portfolio.currentPortfolio.environments ?
+      Portfolio.currentPortfolio.environments[0] :
+        {sys_id: "7aafda19073121106417fa4d7c1ed04a"} as EnvironmentDTO;
+    await Portfolio.loadAllOperatorsOfPortfolioEnvironment(this.environment);
+    this.tableData = this.environment.csp_admins as Operator[];
+    this.isLoading = false;
     this.transitionGroup = "transition-group";
   }
   public  mounted(): void {

--- a/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
+++ b/src/portfolios/portfolio/components/CSPPortalAccess/CSPPortalAccess.vue
@@ -380,15 +380,6 @@ export default class CSPPortalAccess extends Vue {
         {sys_id: "7aafda19073121106417fa4d7c1ed04a"} as EnvironmentDTO;
     await Portfolio.loadAllOperatorsOfPortfolioEnvironment(this.environment);
     this.tableData = _.cloneDeep(this.environment.csp_admins) as Operator[];
-    // this.tableData.forEach(row => {
-    //   debugger;
-    //   if (row.provisioned === "false" && row.provisionedDate === "") {
-    //     row.provisionedDate = ;
-    //   }
-    // })
-    
-    // debugger;
-
     this.isLoading = false;
     this.transitionGroup = "transition-group";
   }

--- a/src/portfolios/portfolio/components/shared/AddAdminSlideOut.vue
+++ b/src/portfolios/portfolio/components/shared/AddAdminSlideOut.vue
@@ -19,15 +19,28 @@
       Once processed, your administrator will receive an email from the CSP with login credentials.
     </p>
     <p class="mb-4">
-      Portfolio managers will not be able to cancel this process or revoke access from within ATAT.
-      CSP accounts can only be changed or revoked by another administrator directly within the
-      cloud console.
+      <strong>Portfolio managers will not be able to cancel this process or revoke access from 
+      within ATAT.</strong> CSP accounts can only be changed or revoked by another administrator 
+      directly within the cloud console.
     </p>
     <p class="mb-4">
       Please note that ATAT is not a system of record. We keep a log of the administrators granted
       CSP access within the system, but any changes to users accounts made directly in the cloud
       portal are not reflected within your ATAT portfolio details.
     </p>
+
+    <ATATAlert
+      id="AdminAlert"
+      type="info"
+    > 
+      <template v-slot:content>
+        Administrators will only be granted access to the cloud provider’s console. 
+        In order to view portfolio details or track funding within ATAT, you can 
+        invite people as portfolio members and assign user roles.
+      </template>
+
+    </ATATAlert>
+
   </div>
 </template>
 

--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -653,8 +653,7 @@ export class PortfolioDataStore extends VuexModule {
         environment: newOperatorToAdd.environment,
         operatorDTO: operatorResponse
       });
-    // leave below line commented out if newly added csp admins need to be displayed at the top
-    // await this.sortPortfolioEnvironmentOperators(newOperatorToAdd.environment);
+    await this.sortPortfolioEnvironmentOperators(newOperatorToAdd.environment);
   }
 
   @Action({rawError: true})

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -16,7 +16,7 @@ import {
   BaseTableDTO,
   ClinDTO,
   EDAResponse,
-  ReferenceColumn,
+  ReferenceColumn, EnvironmentDTO,
 } from "@/api/models";
 
 export interface DocReviewData {
@@ -479,6 +479,19 @@ export interface User {
   sys_id?: string;
 }
 
+export interface Operator {
+  sysId?: string;
+  environment?: string;
+  email?: string;
+  dodId?: string;
+  status?: "Processing" | "Failed" | "Provisioned" | "";
+  addedBy?: string;
+  provisionedDate?: string;
+  provisioned?: string;
+  provisioningFailureCause?: string;
+  provisioningRequestDate?: string;
+}
+
 export interface Portfolio extends BaseTableDTO {
   sysId?: string;
   title?: string;
@@ -496,6 +509,7 @@ export interface Portfolio extends BaseTableDTO {
   portfolio_viewers_detail?: User[];
   updated?: string;
   taskOrderNumber?: string;
+  environments?: EnvironmentDTO[];
 }
 
 export interface PortfolioCardData extends Portfolio {


### PR DESCRIPTION
1. The CSP Portal Access page lists a given portfolio environment’s CSP Administrators as depicted
    1. Make API call to table atat_operators to retrieve all operator (CSP admin) records in the environment (use environment sys_id).
    1. In PortfolioSummary store, in portfolioSummaryList.environments  create an array of cspAdmins which will be used for the CSP Administrators table on page load. cspAdmin object should contain:
        1. Email
        1. Status
            1. Processing = provisioned col is false and provisioning_failure_cause is empty.
            1. Failed = provisioned col is false and provisioning_failure_cause has any value.
            1. Provisioned = provisioned col is true
        1. Added by (user first/last name)
        1. Processed on date
    1. Default sort: Processed on descending. BUT must list all with status Processing first alphabetically, then sort by Provisioned on date. Vue table sorting puts null values at bottom when descending, which is the opposite of the desired result. Possible solution: if Processing status, add a date in the future and use logic to hide the contents of that cell. 
1. The Add a CSP Administrator button on that same page works and allows adding additional CSP Administrators after initial provisioning
    1. When clicking “Add administrator” from the Add a CSP administrator  modal, create a record in the atat_operators table with the correct environment sys_id. Fields to send:
        1. dod_id - string from form on modal
        1. email - string from form on modal
        1. added_by - current user sys_id
        1. environment - the currently viewed Environment sys_id