### PR TITLE
Feature/at 8761 portfolio slideout updates

### DIFF
--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -15,7 +15,8 @@ import {
   SingleMultiple,
   EstimateOptionValue,
   TrainingEstimate,
-  EstimateOptionValueObjectArray
+  EstimateOptionValueObjectArray,
+  Environment
 } from "../../../types/Global";
 
 export interface BaseTableDTO {
@@ -646,7 +647,8 @@ export interface PortfolioSummaryDTO extends BaseTableDTO{
   alerts: AlertDTO[];
   title?: string;
   description?: string;
-  environments?: EnvironmentDTO[];
+  environments?: Environment[];
+  last_updated?: string;
 }
 
 export interface PortfolioSummaryMetadataAndDataDTO {
@@ -662,11 +664,11 @@ export interface EnvironmentDTO extends BaseTableDTO {
   dashboard_link: string;
   pending_operators: string[];
   portfolio: string;
-  provisioned: YesNo;
+  provisioned: string;
   provisioned_date: string;
   provisioning_failure_cause: string;
   provisioning_request_date: string;
-  csp_admins?: OperatorDTO[]
+  csp_admins?: OperatorDTO[];
 }
 
 export interface CloudServiceProviderDTO extends BaseTableDTO{

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -301,6 +301,8 @@ export function getStatusChipBgColor(status: string): string {
   case Statuses.ExpiringPop.label.toLowerCase():
   case Statuses.FundingAtRisk.value.toLowerCase():
   case Statuses.FundingAtRisk.label.toLowerCase():
+  case Statuses.ProvisioningIssue.value.toLowerCase():
+  case Statuses.ProvisioningIssue.label.toLowerCase():
     return "bg-warning";
   case Statuses.Deleted.value.toLowerCase():
   case Statuses.Delinquent.value.toLowerCase():

--- a/src/packages/components/Card.vue
+++ b/src/packages/components/Card.vue
@@ -199,7 +199,6 @@ export default class Card extends Vue {
 
   public get statusChipBgColor(): string {
     const status = this.modifiedData.packageStatus
-
     return getStatusChipBgColor(status ? status : "");
   }
 
@@ -316,7 +315,7 @@ export default class Card extends Vue {
 
   public async loadOnEnter(): Promise<void> {
     this.currentUser = await UserStore.getCurrentUser();
-    this.reformatData(this.cardData)
+    this.reformatData(this.cardData);
     if(this.cardData.package_status?.value === 'DRAFT'){
       this.cardMenuItems = [
         {

--- a/src/portfolios/components/PortfolioCard.vue
+++ b/src/portfolios/components/PortfolioCard.vue
@@ -299,10 +299,12 @@ export default class PortfolioCard extends Vue {
   }
 
   public get statusChipBgColor(): string {
-    const status = this.cardData.status?.toLowerCase() === Statuses.Processing.value.toLowerCase()
-      ? this.cardData.status
-      : this.cardData.fundingAlertChipString;
-    return getStatusChipBgColor(status ? status : "");
+    // ATAT TODO - REVISIT WHEN WORKING WITH COST DATA NEXT RELEASE
+    // const status 
+    //   = this.cardData.status?.toLowerCase() === Statuses.Processing.value.toLowerCase()
+    //   ? this.cardData.status
+    //   : this.cardData.fundingAlertChipString;
+    return getStatusChipBgColor(this.cardData.status || "");
   }
 
   public leavePortfolio(): void {

--- a/src/portfolios/components/PortfoliosSummary.vue
+++ b/src/portfolios/components/PortfoliosSummary.vue
@@ -422,7 +422,7 @@ export default class PortfoliosSummary extends Vue {
 
       let cardData: PortfolioCardData = {};
       cardData.isManager = portfolio.portfolio_managers.indexOf(this.currentUserSysId) > -1;
-      
+      cardData.lastUpdated = portfolio.last_updated;
       cardData.csp = portfolio.vendor;
 
       cardData.sysId = portfolio.sys_id;

--- a/src/portfolios/portfolio/components/Index.vue
+++ b/src/portfolios/portfolio/components/Index.vue
@@ -47,7 +47,7 @@
 <script lang="ts">
 import Vue from "vue";
 
-import { Component } from "vue-property-decorator";
+import { Component, Watch } from "vue-property-decorator";
 import ATATFooter from "@/components/ATATFooter.vue";
 import SlideoutPanel from "@/store/slideoutPanel";
 import ATATSlideoutPanel from "@/components/ATATSlideoutPanel.vue";
@@ -91,6 +91,14 @@ export default class PortfolioSummary extends Vue {
   public portfolioStatus = ""
   public portfolioDescription = ""
   public portfolioCSP = ""
+ 
+  public get activeTabIndex(): number {
+    return AppSections.activeTabIndex;
+  }
+  @Watch("activeTabIndex")
+  public activeTabIndexChanged(newVal: number): void {
+    this.tabIndex = newVal;
+  }
 
   public async loadOnEnter(): Promise<void>  {
     const portfolio = PortfolioStore.currentPortfolio;

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -147,20 +147,33 @@
 
     <hr class="my-0" />
 
-    <div id="DatesSection" class="_portfolio-panel _portfolio-panel _panel-padding">
-      <!-- 
-        
-        TODO: refactor with environments after AT-8744 complete
-      
-      <div>
-        <span id="ProvisionedOnLabel">Provisioned on&nbsp;</span>
-        <span id="ProvisionedOnDate">{{ provisionedTime }}</span>
+
+    <div id="EnvironmentsSection" class="_portfolio-panel _panel-padding pb-8">
+      <div
+        id="EnvironmentsHeader"
+        class="d-flex flex-columm justify-space-between"
+      >
+        <div id="EnvironmentsTitle" class="d-flex">
+          <div class="h3 mr-2">Environments</div>
+          <div
+            id="EnvironmentsCount"
+            class="color-base font-size-20"
+            v-if="getPortfolioMembersCount() > 0"
+          >
+            ({{ getPortfolioMembersCount() }})
+          </div>
+        </div>
       </div>
+    </div>
+
+
+    <hr class="my-0" />
+
+    <div id="DatesSection" class="_portfolio-panel _portfolio-panel _panel-padding">
       <div>
         <span id="LastUpdatedLabel">Last updated&nbsp;</span>
         <span id="LastUpdatedDate">{{ updateTime }}</span>
       </div>
-      -->
     </div>
 
     <InviteMembersModal
@@ -235,7 +248,6 @@ import InviteMembersModal from "@/portfolios/portfolio/components/shared/InviteM
 export default class PortfolioDrawer extends Vue {
   public portfolio: Portfolio = {};
   public portfolioStatus: string = Statuses.Active.label;
-  public provisionedTime = "";
   public updateTime = "";
   public csp = "";
   public currentUser: User = {};
@@ -307,10 +319,8 @@ export default class PortfolioDrawer extends Vue {
     const storeData = await PortfolioStore.currentPortfolio;
     if (storeData) {
       this.portfolio = storeData;
+      debugger;
       this.csp = storeData.csp?.toLowerCase() as string;      
-      if (storeData.provisioned) {
-        this.provisionedTime = this.formatDate(storeData.provisioned);
-      }
       if (storeData.updated) {
         this.updateTime = this.formatDate(storeData.updated);
       }
@@ -318,7 +328,7 @@ export default class PortfolioDrawer extends Vue {
       this.portfolioStatus = PortfolioStore.getStatus;
     }
     this.currentUser = await CurrentUserStore.getCurrentUser();
-    // TODO AT-8747 - check if current user is Manager or Viewer
+    // ATAT TODO AT-8747 - check if current user is Manager or Viewer
     // TEMP HARDCODE ROLE
     this.currentUser.role = "Manager";
   }

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -16,7 +16,7 @@
           @blur="saveDescription"
         >
         </v-textarea>
-        <div class="d-flex justify-space-between pb-4">
+        <div class="d-flex justify-space-between pb-2">
           <span id="StatusLabel">Status</span>
           <v-chip id="StatusChip" :color="getBgColor()" label>
             {{ portfolioStatus }}
@@ -62,7 +62,7 @@
           <div class="h3 mr-2">Portfolio members</div>
           <div
             id="MemberCount"
-            class="color-base font-size-20"
+            class="color-base font-size-20 _condensed-font"
             v-if="getPortfolioMembersCount() > 0"
           >
             ({{ getPortfolioMembersCount() }})
@@ -147,25 +147,52 @@
 
     <hr class="my-0" />
 
-
-    <div id="EnvironmentsSection" class="_portfolio-panel _panel-padding pb-8">
-      <div
-        id="EnvironmentsHeader"
-        class="d-flex flex-columm justify-space-between"
+    <div id="EnvironmentsSection" class="_portfolio-panel _panel-padding pb-4">
+      <div id="EnvironmentsTitle" class="d-flex">
+        <div class="h3 mr-2">Environments</div>
+        <div
+          id="EnvironmentsCount"
+          class="color-base font-size-20 _condensed-font"
+          v-if="getEnironmentCount() > 0"
+        >
+          ({{ getEnironmentCount() }})
+        </div>
+      </div>
+    </div>
+    <div id="EnvironmentsList" class="_hoverable-rows">
+      <div 
+        class="_hover-row d-flex align-center justify-space-between" 
+        v-for="(env, index) of portfolio.environments" 
+        :key="index"
+        tabindex="0"
+        @click="goToCSPAdmin(env.sys_id)"
       >
-        <div id="EnvironmentsTitle" class="d-flex">
-          <div class="h3 mr-2">Environments</div>
+        <div class="font-weight-500"> 
+          {{ getClassificationLevel(env.classification_level) }}
+        </div>
+        <div class="d-flex align-center">
+          <div class="text-right mr-2">
+            <span class="font-weight-500 d-block" style="line-height: 1;">
+              {{ getEnvStatus(env) }}
+            </span>
+            <span class="font-size-12 text-base">
+              {{ getEnvDateStr(env) }}
+            </span>
+          </div>
           <div
-            id="EnvironmentsCount"
-            class="color-base font-size-20"
-            v-if="getPortfolioMembersCount() > 0"
+            class="_icon-circle"
+            :class="statusImg[env.environmentStatus].bgColor"
           >
-            ({{ getPortfolioMembersCount() }})
+            <ATATSVGIcon
+              :name="statusImg[env.environmentStatus].name"
+              :width="statusImg[env.environmentStatus].width"
+              :height="statusImg[env.environmentStatus].height"
+              :color="statusImg[env.environmentStatus].color"
+            />
           </div>
         </div>
       </div>
     </div>
-
 
     <hr class="my-0" />
 
@@ -220,19 +247,28 @@ import SlideoutPanel from "@/store/slideoutPanel";
 import Toast from "@/store/toast";
 
 import {
+  Environment,
   Portfolio,
   SelectData,
   SlideoutPanelContent,
   ToastObj,
   User
 } from "types/Global";
-import { format, parseISO } from "date-fns";
+import { 
+  differenceInDays, 
+  differenceInHours,
+  differenceInMinutes, 
+  format,
+  parseISO 
+} from "date-fns";
 import _ from "lodash";
 import MemberCard from "@/portfolios/portfolio/components/shared/MemberCard.vue";
-import {getStatusChipBgColor, hasChanges} from "@/helpers";
+import {createDateStr, getStatusChipBgColor, hasChanges} from "@/helpers";
 import { Statuses } from "@/store/acquisitionPackage";
 import CurrentUserStore from "@/store/user";
 import InviteMembersModal from "@/portfolios/portfolio/components/shared/InviteMembersModal.vue";
+import { EnvironmentDTO } from "@/api/models";
+import AppSections from "@/store/appSections";
 
 @Component({
   components: {
@@ -246,8 +282,9 @@ import InviteMembersModal from "@/portfolios/portfolio/components/shared/InviteM
 })
 
 export default class PortfolioDrawer extends Vue {
+
   public portfolio: Portfolio = {};
-  public portfolioStatus: string = Statuses.Active.label;
+  public portfolioStatus = "";
   public updateTime = "";
   public csp = "";
   public currentUser: User = {};
@@ -284,6 +321,31 @@ export default class PortfolioDrawer extends Vue {
     { text: "About Roles", value: "AboutRoles", isSelectable: false },
   ];
 
+  public statusImg = {
+    [Statuses.ProvisioningIssue.value]: {
+      name: "warningAmber",
+      width: "15",
+      height: "13",
+      color: "warning-dark2",
+      bgColor:"bg-warning-lighter"
+    },
+    [Statuses.Provisioned.value]: {
+      name: "provisioned",
+      width: "20",
+      height: "13",
+      color: "success-dark",
+      bgColor:"bg-success-lighter"
+    },
+    [Statuses.Processing.value]: {
+      name: "processing",
+      width: "20",
+      height: "13",
+      color: "info-dark",
+      bgColor:"bg-info-lighter"
+    }
+  };
+
+
   public get showMembersModal(): boolean {
     return PortfolioStore.getShowAddMembersModal;
   }
@@ -315,17 +377,27 @@ export default class PortfolioDrawer extends Vue {
     return getStatusChipBgColor(this.portfolioStatus);
   }
 
+  public getStatusKey(str: string): string {
+    return _.startCase(str.toLowerCase().replaceAll("_", " ")).replaceAll(" ", "");
+
+  }
+
   public async loadPortfolio(): Promise<void> {
     const storeData = await PortfolioStore.currentPortfolio;
+ 
     if (storeData) {
-      this.portfolio = storeData;
-      debugger;
+      this.portfolio = _.cloneDeep(storeData);
       this.csp = storeData.csp?.toLowerCase() as string;      
-      if (storeData.updated) {
-        this.updateTime = this.formatDate(storeData.updated);
+      if (storeData.lastUpdated) {
+        this.updateTime = createDateStr(storeData.lastUpdated, true, true);
       }
       this.portfolioMembers = storeData.members || [];
-      this.portfolioStatus = PortfolioStore.getStatus;
+      if (storeData.status) {
+        const statusKey = this.getStatusKey(storeData.status);
+        this.portfolioStatus = storeData.status 
+          ? Statuses[statusKey].label
+          : "";
+      }
     }
     this.currentUser = await CurrentUserStore.getCurrentUser();
     // ATAT TODO AT-8747 - check if current user is Manager or Viewer
@@ -347,6 +419,52 @@ export default class PortfolioDrawer extends Vue {
       ? member.firstName + " " + member.lastName
       : member.email || "";
   }
+
+  public getEnironmentCount(): number {
+    return this.portfolio.environments?.length || 0;
+  }
+  public classificationLevels: Record<string, string> = {
+    U: "Unclassified",
+    S: "Secret",
+    TS: "Top Secret",
+  }
+  public getClassificationLevel(abbr: string): string {
+    return this.classificationLevels[abbr];
+  }
+
+  public async goToCSPAdmin(envSysId: string): Promise<void> {
+    // go to CSP Admin page showing correct environment tab    
+    await PortfolioStore.setCurrentEnvSysId(envSysId);
+    AppSections.setActiveTabIndex(2);
+  }
+  public getEnvStatus(env: Environment): string {
+    if (env.environmentStatus) {
+      const statusKey = this.getStatusKey(env.environmentStatus);
+      return Statuses[statusKey].label;
+    } 
+    return "";
+  }
+
+  public getEnvDateStr(env: Environment): string {
+    if (env.environmentStatus === Statuses.Processing.value && env.sys_created_on) {
+      // return "Started x ago"
+      const now = new Date();
+      const created = new Date(env.sys_created_on);
+      const diffInMinutes = differenceInMinutes(now, created);
+      const diffInHours = differenceInHours(now, created);
+      if (diffInMinutes < 60) {
+        return "Started " +  differenceInMinutes(now, created) + " minutes ago";
+      } else if (diffInHours <= 72) {
+        const plural = diffInHours > 1 ? "s" : "";
+        return "Started " + diffInHours + ` hour${plural} ago`;
+      } 
+      const diffInDays = differenceInDays(now, created);
+      return "Started " + diffInDays + " days ago";
+    }
+
+    return createDateStr(env.provisioned_date, true, true);
+  }
+
 
   public portfolioMembers: User[] = [];
 

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -379,7 +379,6 @@ export default class PortfolioDrawer extends Vue {
 
   public getStatusKey(str: string): string {
     return _.startCase(str.toLowerCase().replaceAll("_", " ")).replaceAll(" ", "");
-
   }
 
   public async loadPortfolio(): Promise<void> {

--- a/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioSummaryPageHead.vue
@@ -29,11 +29,12 @@
             v-if="!isPortfolioProvisioning"
           >
             <v-tab
-              v-for="tab in items"
-              :key="tab"
+              v-for="(tab, index) in items"
+              :key="index"
               :id="getIdText(tab) + '_Tab'"
-              class="font-size-14 pa-1 pt-2  pb-5 mr-3">{{tab}}</v-tab>
-
+              class="font-size-14 pa-1 pt-2  pb-5 mr-3"
+              @click="tabClicked(index)"
+            >{{tab}}</v-tab>
           </v-tabs>
         </div>
       </div>
@@ -169,7 +170,9 @@ export default class PortfolioSummaryPageHead extends Vue {
   public openModal():void {
     PortfolioStore.setShowAddMembersModal(true);
   }
-
+  public tabClicked(index: number): void {0
+    AppSections.setActiveTabIndex(index);
+  }
   public saveTitle(): void {
     if(hasChanges(PortfolioStore.currentPortfolio.title, this._title)) {
       PortfolioStore.updatePortfolioTitle(this._title);

--- a/src/sass/components/ATATSlideoutPanel.scss
+++ b/src/sass/components/ATATSlideoutPanel.scss
@@ -166,3 +166,13 @@
     }
   }
 }
+
+._hoverable-rows {
+  ._hover-row {
+    padding: 12px 16px 12px 24px;
+    &:hover {
+      cursor: pointer;
+      background-color: $base-lightest;
+    }
+  }
+}

--- a/src/sass/utils/typography.scss
+++ b/src/sass/utils/typography.scss
@@ -53,6 +53,10 @@ h4, .h4 {
   }
 }                 
 
+._condensed-font {
+  font-family: $condensed-font;
+}
+
 p {
   margin-bottom: 2.4rem !important;
 }

--- a/src/sass/utils/variables.scss
+++ b/src/sass/utils/variables.scss
@@ -1,4 +1,5 @@
 //fonts
 $base-font: Roboto, sans-serif;
 $heading-font: "Roboto Condensed", sans-serif;
+$condensed-font: "Roboto Condensed", sans-serif;
 $icon-font: "Material Icons"

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -91,6 +91,8 @@ export const Statuses: Record<string, Record<string, string>> = {
   OptionExercised: { label: "Option Exercised", value: "OPTION_EXERCISED" }, // CLIN
   OptionPending: { label: "Option Pending", value: "OPTION_PENDING" }, // CLIN  
   Processing: { label: "Processing", value: "PROCESSING" }, // PORT
+  Provisioned: { label: "Provisioned", value: "PROVISIONED" }, // ENV
+  ProvisioningIssue: { label: "Provisioning issue", value: "PROVISIONING_ISSUE" }, // PORT, ENV  
   TaskOrderAwarded: { label: "Task Order Awarded", value: "TASK_ORDER_AWARDED" }, // ACQ
   Upcoming: { label: "Upcoming", value: "UPCOMING" }, // TO
   WaitingForSignatures: { label: "Waiting For Signatures", value: "WAITING_FOR_SIGNATURES" }, // ACQ

--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -221,8 +221,22 @@ export class PortfolioDataStore extends VuexModule {
     provisioned: "",
     members: [],
     taskOrderNumber: "",
+    environments: [],
+    lastUpdated: "",
   }
-   
+
+  public currentEnvironmentSysId = "";
+  @Action({rawError: true})
+  public async setCurrentEnvSysId(sysId: string): Promise<void> {
+    this.doSetCurrentEnvSysId(sysId);
+  }
+  @Mutation
+  public doSetCurrentEnvSysId(sysId: string): void {
+    this.currentEnvironmentSysId = sysId;
+  }
+  
+
+
   public summaryFilterRoles: FilterOption[] = [
     {
       label: "All of my portfolios",
@@ -390,7 +404,8 @@ export class PortfolioDataStore extends VuexModule {
       portfolio_viewers: portfolioData.portfolio_viewers,
       portfolio_viewers_detail: portfolioData.portfolio_viewers_detail,
       members: portfolioData.members,
-      environments: portfolioData.environments
+      environments: portfolioData.environments,
+      lastUpdated: portfolioData.lastUpdated,
     };
     Object.assign(this.currentPortfolio, dataFromSummaryCard);
     this.activeTaskOrderNumber = portfolioData.taskOrderNumber 

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -124,9 +124,13 @@ export class UserStore extends VuexModule {
       offset: 0
     };
 
-    const portfolioData = await PortfolioSummary
-      .searchPortfolioSummaryList(searchDTO);
-    const hasPortfolios = portfolioData.total_count > 0;
+    
+    // EJY is this causing so many multiple calls?????
+
+    // const portfolioData = await PortfolioSummary
+    //   .searchPortfolioSummaryList(searchDTO);
+    // const hasPortfolios = portfolioData.total_count > 0;
+    const hasPortfolios = true;
     await this.doSetUserHasPortfolios(hasPortfolios);
     return this.userHasPortfolios;
   }

--- a/src/store/user/index.ts
+++ b/src/store/user/index.ts
@@ -123,14 +123,10 @@ export class UserStore extends VuexModule {
       limit: 1,
       offset: 0
     };
-
-    
-    // EJY is this causing so many multiple calls?????
-
-    // const portfolioData = await PortfolioSummary
-    //   .searchPortfolioSummaryList(searchDTO);
-    // const hasPortfolios = portfolioData.total_count > 0;
-    const hasPortfolios = true;
+   
+    const portfolioData = await PortfolioSummary
+      .searchPortfolioSummaryList(searchDTO);
+    const hasPortfolios = portfolioData.total_count > 0;
     await this.doSetUserHasPortfolios(hasPortfolios);
     return this.userHasPortfolios;
   }

--- a/types/Global.ts
+++ b/types/Global.ts
@@ -498,6 +498,10 @@ export interface Operator {
   provisioningRequestDate?: string;
 }
 
+export interface Environment extends EnvironmentDTO {
+  environmentStatus?: string;
+}
+
 export interface Portfolio extends BaseTableDTO {
   sysId?: string;
   title?: string;
@@ -515,8 +519,9 @@ export interface Portfolio extends BaseTableDTO {
   portfolio_viewers_detail?: User[];
   updated?: string;
   taskOrderNumber?: string;
-  environments?: EnvironmentDTO[];
+  environments?: Environment[];
   taskOrderSysId?: string;
+  lastUpdated?: string;
 }
 
 export interface PortfolioCardData extends Portfolio {


### PR DESCRIPTION
1. Add Environments section to bottom of side panel below Portfolio Managers section.
    1. For each environment, indicate status with text, icon, and date/time. environment_status of: 
        1. Processing – show processing icon with blue background and “Started ____ ago” text using date-fns: 
            1. Under 1 hour, show number of minutes (e.g., “Started 24 minutes ago”) using formatDistanceToNow.
            1. At or over 1 hour to 72 hours, show number of hours (e.g., “Started 4 hours ago”) using distanceInHours
            1. Over 72 hours, show number of days (e.g., “Started 5 days ago”) using formatDistanceToNow
        1. Provisioning issue – show orange warning icon with yellow background and a date/time stamp.
        1. Provisioned - show green cloud checkmark icon with green background and date/time stamp.
    1. Environment has light gray background hover state, clickable to CSP Admin
1. Portfolio status updates: Portfolio status should come from portfolio_status column in the portfolio table based on the following rules:
    1. For single-environment portfolios, Environment status of:
        1. Processing - portfolio status: Processing
        1. Provisioning Issue - portfolio status: Provisioning Issue
        1. Provisioned - portfolio status: Active
    1. For multi-environment portfolios:
        1. Provisioning Issue - if any environment has this status, so does portfolio.
        1. Processing - if any environment has this status, so does portfolio.
        1. Active - if all environments have status Provisioned
1. Remove “Provisioned on _____” text from bottom of side panel. Only show “Last Updated …” date/time.