### PR TITLE
feature/AT-8807-TS-update-modal-test-results

### DIFF
--- a/src/components/ATATCheckboxGroup.vue
+++ b/src/components/ATATCheckboxGroup.vue
@@ -379,10 +379,12 @@ export default class ATATCheckboxGroup extends Vue {
   }
 
   private getPerformanceRequirementTotal(classLevelSysId: string): string{
-    const totalClassLevelInDOW = this.totalRequirementsInDOW.find(
-      req => req.classLevelSysId === classLevelSysId
-    )?.DOWObjectTotal || 0
-    return totalClassLevelInDOW > 0 
+    const totalClassLevelInDOW = ClassificationRequirements.classLevelsInDOWTotal.find(
+      cl => cl.classLevelSysId === classLevelSysId
+    )?.DOWObjectTotal || 0;
+    const hasBeenDeleted = totalClassLevelInDOW === 0;
+    if (hasBeenDeleted){ return ""; } 
+    return totalClassLevelInDOW > 0 && this._selected.includes(classLevelSysId)
       ? totalClassLevelInDOW + " " + setItemToPlural(totalClassLevelInDOW, 'requirement') 
       : "";
   }

--- a/src/steps/05-PerformanceRequirements/DOW/ClassificationsModal.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ClassificationsModal.vue
@@ -33,7 +33,7 @@
       />
       <ATATAlert
         id="ClassificationRequirementsAlert"
-        v-show="_isIL6Selected === true"
+        v-show="showClassificationRequirementsAlert"
         type="warning"
         class="copy-max-width mt-10"
       >
@@ -47,7 +47,7 @@
       </ATATAlert>
        <ATATAlert
         id="TSSecretAlert"
-        v-show="showTSSecretAlert===true"
+        v-show="showTSSecretAlert"
         type="warning"
         class="copy-max-width mt-10"
       >
@@ -91,7 +91,6 @@ export default class ClassificationsModal extends Vue {
   @PropSync("modalSelectedOptions") public _modalSelectedOptions!: string[];
   @PropSync("isIL6Selected") public _isIL6Selected?: boolean;
   @PropSync("showDialog") public _showModal?: boolean;
-  public showTSSecretAlert = false;
   public selectedValue = "";
   public isItemAdded: boolean | null = null;
 
@@ -99,8 +98,6 @@ export default class ClassificationsModal extends Vue {
   public async modalSelectedOptionsChange(updated: string[], current: string[]): Promise<void> {
     this.isItemAdded = updated.length>current.length;
     await this.setSelectedValue(updated,current);
-    await this.setShowTSSecretAlert(updated);
-    await this.showClassificationRequirementsAlert(updated);  
   }
 
   public async setSelectedValue(
@@ -112,21 +109,17 @@ export default class ClassificationsModal extends Vue {
       : current.find(c=>updated.indexOf(c)===-1) as string
   }
 
-  public async setShowTSSecretAlert(updated: string[]): Promise<void>{
-    this.showTSSecretAlert = 
-      (this.modalSelectionsOnOpen.some(v => this.isSelectionOnHighSide(v)) 
-        || updated.some(o => this.isSelectionOnHighSide(o)));
+  get showTSSecretAlert(): boolean{
+    return this._modalSelectedOptions.some(o => 
+      ClassificationRequirements.highSideSysIds.indexOf(o)>-1);
   }
 
-  public async showClassificationRequirementsAlert(updated:string[]): Promise<void>{
-    this._isIL6Selected = updated.includes(this.IL6SysId || "");
+  get showClassificationRequirementsAlert(): boolean{
+    this._isIL6Selected = this._modalSelectedOptions.includes(
+      ClassificationRequirements.classificationSecretSysId);
+    return this._isIL6Selected
   }
 
-  private isSelectionOnHighSide(selectedSysId: string): boolean {
-    return ClassificationRequirements.classificationLevels.filter(
-      cl => cl.classification!=="U"&&cl.sys_id===selectedSysId
-    ).length>0;
-  }
 
   private hasChangedPackageClassificationLevels(): boolean {
     const arr1 = [...this.modalSelectionsOnOpen].sort();
@@ -146,12 +139,12 @@ export default class ClassificationsModal extends Vue {
   }
 
   public cleanUp(): void{
-    this.showTSSecretAlert = this._isIL6Selected as boolean;
     this._showModal = false;
   }
 
   public async mounted(): Promise<void>{
-    await this.showClassificationRequirementsAlert(this.modalSelectionsOnOpen);
+    this.showClassificationRequirementsAlert;
+    this.showTSSecretAlert;
   }
 }
 

--- a/src/steps/05-PerformanceRequirements/DOW/ClassificationsModal.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ClassificationsModal.vue
@@ -92,12 +92,19 @@ export default class ClassificationsModal extends Vue {
   @PropSync("isIL6Selected") public _isIL6Selected?: boolean;
   @PropSync("showDialog") public _showModal?: boolean;
   public selectedValue = "";
-  public isItemAdded: boolean | null = null;
+  public isItemAdded = false;
+  public isTSSelected = false;
 
   @Watch("modalSelectedOptions")
   public async modalSelectedOptionsChange(updated: string[], current: string[]): Promise<void> {
     this.isItemAdded = updated.length>current.length;
     await this.setSelectedValue(updated,current);
+    this._isIL6Selected =  updated.includes(
+      ClassificationRequirements.classificationSecretSysId
+    ) 
+    this.isTSSelected = updated.includes(
+      ClassificationRequirements.classificationTopSecretSysId
+    )
   }
 
   public async setSelectedValue(
@@ -110,16 +117,28 @@ export default class ClassificationsModal extends Vue {
   }
 
   get showTSSecretAlert(): boolean{
-    return this._modalSelectedOptions.some(o => 
-      ClassificationRequirements.highSideSysIds.indexOf(o)>-1);
-  }
+    /**ensure that when selected, the ts or secret checkbox  is 
+     * not in the this.modalSelectionsOnOpen as the alert should 
+     * display when ts or s is selected and not if either of those options
+     * are in this.modalSelectionsOnOpen
+     *  */
 
+    return (this.isTSSelected && 
+      this.modalSelectionsOnOpen.indexOf(
+        ClassificationRequirements.classificationTopSecretSysId
+      ) === -1) 
+      ||  (this._isIL6Selected && 
+      this.modalSelectionsOnOpen.indexOf(
+        ClassificationRequirements.classificationSecretSysId
+      ) === -1) as boolean
+  }
+  
   get showClassificationRequirementsAlert(): boolean{
-    this._isIL6Selected = this._modalSelectedOptions.includes(
-      ClassificationRequirements.classificationSecretSysId);
-    return this._isIL6Selected
+    return (this._isIL6Selected && 
+      this.modalSelectionsOnOpen.indexOf(
+        ClassificationRequirements.classificationSecretSysId
+      ) === -1) as boolean
   }
-
 
   private hasChangedPackageClassificationLevels(): boolean {
     const arr1 = [...this.modalSelectionsOnOpen].sort();
@@ -142,10 +161,7 @@ export default class ClassificationsModal extends Vue {
     this._showModal = false;
   }
 
-  public async mounted(): Promise<void>{
-    this.showClassificationRequirementsAlert;
-    this.showTSSecretAlert;
-  }
+ 
 }
 
 </script>

--- a/src/store/classificationRequirements/index.ts
+++ b/src/store/classificationRequirements/index.ts
@@ -314,7 +314,6 @@ export class ClassificationRequirementsStore extends VuexModule {
     newSelectedClassLevelList: SelectedClassificationLevelDTO[])
    : Promise<boolean> {
     try {
-      const itemsToBeDeleted:SelectedClassificationLevelDTO[] = [];
       await this.getTotalClassLevelsInDOW();
       const markedForCreateList = newSelectedClassLevelList
         .filter(newSelected => newSelected.sys_id ? newSelected.sys_id.length === 0 : true);
@@ -333,15 +332,15 @@ export class ClassificationRequirementsStore extends VuexModule {
             markedForCreate.classification_level as string
         )
       })
-      this.doSetClassLevelsToBeDeleted([]);
+      
       await markedForDeleteList.forEach(async markedForDelete => {
-        itemsToBeDeleted.push(markedForDelete);
         const deleteItemSysId = markedForDelete.classification_level as string;
         await this.removeClassificationLevelsFromDBGlobally(deleteItemSysId);
         await this.removeClassificationLevelsFromStoreGlobally(markedForDelete);
       })
-      this.doSetClassLevelsToBeDeleted(itemsToBeDeleted);
-    
+      this.doSetClassLevelsToBeDeleted(markedForDeleteList);
+      
+      
       return true;
     } catch (error) {
       throw new Error(`an error occurred saving selected classification levels ${error}`);
@@ -661,8 +660,6 @@ export class ClassificationRequirementsStore extends VuexModule {
     await this.removeClassificationLevelsFromIGCECostEstimate(
       classLevelItemToBeDeleted.sys_id as string
     )
-
-    await this.getTotalClassLevelsInDOW();
   }
 
   @Action({rawError: true})

--- a/src/store/classificationRequirements/index.ts
+++ b/src/store/classificationRequirements/index.ts
@@ -662,6 +662,7 @@ export class ClassificationRequirementsStore extends VuexModule {
       classLevelItemToBeDeleted.sys_id as string
     )
 
+    await this.getTotalClassLevelsInDOW();
   }
 
   @Action({rawError: true})


### PR DESCRIPTION
- [x] ClassificationsModal ALWAYS reflects the correct number of PerformanceRequirements
- [x] successfully show both alerts on ClassificationsModal as necessary, when necessary
AT-8807

Please review the first comment on [task 8807](https://ccpo.atlassian.net/browse/AT-8807) for additional clarifications on the task. 