### PR TITLE
feature/AT-8855 FR update

### DIFF
--- a/src/steps/11-GeneratePackageDocuments/ReadyToSubmit.vue
+++ b/src/steps/11-GeneratePackageDocuments/ReadyToSubmit.vue
@@ -51,7 +51,7 @@
         </div>
 
       </div>
-      <CompletePackageCard v-if="currentUserIsMissionOwner" />
+      <CompletePackageCard />
 
     </div>
   </div>


### PR DESCRIPTION
Removed conditional that hid completed package download for contributors

This package status is `Waiting for signatures`
![Screen Shot 2023-04-13 at 8 26 40 PM](https://user-images.githubusercontent.com/90333349/231912102-9c8b172c-9249-4978-9220-e899f26f46c6.png)

Current user is a contributor (Eric Youngquist)
![Screen Shot 2023-04-13 at 8 41 02 PM](https://user-images.githubusercontent.com/90333349/231912418-a3b23807-cfd5-4bf0-876d-75a554ed8aea.png)

Contributor uploads files
![Screen Shot 2023-04-13 at 8 29 33 PM](https://user-images.githubusercontent.com/90333349/231912162-fe439ec5-fcc0-4e8d-ba25-c469b8b188df.png)

Contributor sees "package ready to submit" page with owner name bolded in first sentence, sees completed package download card/button.
![Screen Shot 2023-04-13 at 8 32 10 PM](https://user-images.githubusercontent.com/90333349/231912186-fda1740b-e9ca-45c9-8c5a-661d9801d365.png)


