### PR TITLE
feature AT-8825 textarea update

### DIFF
--- a/src/steps/02-EvaluationCriteria/JandA/SoleSourceReview.vue
+++ b/src/steps/02-EvaluationCriteria/JandA/SoleSourceReview.vue
@@ -276,6 +276,8 @@ export default class SoleSourceReview extends Mixins(SaveOnLeave) {
       this.writeOwnExplanation = storeData.write_own_sole_source_cause === "YES";
       if (!this.writeOwnExplanation) {
         this.generateSuggestion();
+      } else {
+        this.soleSourceCause = "";
       }
     }
   }


### PR DESCRIPTION
Added minor change to clear sole source review textarea If user navigates to page with some fields entered on previous form page and clicks Continue, which will autogenerate a suggestion in the review page text area. User then navigates back to the form, and clicks "I want to write my own explanation" button, OR clicks "NO" for all 3 sections and clicks Continue. Any previously entered text should be cleared from the textarea.

All previous work for [AT-8825](https://ccpo.atlassian.net/browse/AT-8825) was completed in ticket AT-8878

[AT-8825]: https://ccpo.atlassian.net/browse/AT-8825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ