### PR TITLE
hotfix/set-test-env-like-prod

### DIFF
--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -372,7 +372,8 @@ export class AcquisitionPackageStore extends VuexModule {
   }
   @Mutation
   public async doSetIsProdEnv(): Promise<void> {
-    this.isProdEnv = window.location.hostname === "services.disa.mil";
+    this.isProdEnv = window.location.hostname === "services.disa.mil"
+      || window.location.hostname === "services-test.disa.mil";
   }
   
   emulateProdNav = false;


### PR DESCRIPTION
Test env UI should mirror what user sees on Prod. Updated logic for `isProdEnv` flag that is set during app initialization