### PR TITLE
PR 1631 - hotfix/ensuring-current-contract-exists-is-updated

### DIFF
--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
@@ -132,6 +132,7 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.hasChanged()) {
+        this.currentData.current_contract_exists="YES"
         await AcquisitionPackage.saveData<CurrentContractDTO>({
           data: this.currentData,
           storeProperty: StoreProperties.CurrentContract,


### PR DESCRIPTION
 - [x]  resolves if users selects logical-follow-on (item 2) in Exception To Fair opportunity, ensure that `YES` is saved to `DAPPS:Current Contract Information:Current Contract Exists` column