### PR TITLE
PR 1632 - hotfix/saving-acq-package-id-to-current-contract-tbl

### DIFF
--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
@@ -132,7 +132,9 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   protected async saveOnLeave(): Promise<boolean> {
     try {
       if (this.hasChanged()) {
-        this.currentData.current_contract_exists="YES"
+        this.currentData.current_contract_exists = "YES"
+        this.currentData.acquisition_package =
+          AcquisitionPackage.packageId as string;
         await AcquisitionPackage.saveData<CurrentContractDTO>({
           data: this.currentData,
           storeProperty: StoreProperties.CurrentContract,


### PR DESCRIPTION
- [ ] saves acqpackageId to SNOW/store if user selects `logicalfollowon` in exception to fair opportunity