### PR TITLE
PR 1646 - hotfix/restoring-purple-accordion-if-no-cds-exists

### DIFF
--- a/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
+++ b/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
@@ -185,7 +185,9 @@ export default class GatherPriceEstimates extends Mixins(SaveOnLeave) {
     const existingClassLevels = Object.keys(this.tempEstimateDataSource);
     const doesTSExist = existingClassLevels.includes("Top Secret");
     const doesSecretExist = existingClassLevels.includes("Secret - IL6") && !doesTSExist;
-    const cdsTransfers = JSON.parse(this.cdsSNOWRecord?.traffic_per_domain_pair||"")
+    const cdsTransfers = this.cdsSNOWRecord?.traffic_per_domain_pair !== undefined  
+      ? JSON.parse(this.cdsSNOWRecord?.traffic_per_domain_pair)
+      : undefined
     let hasTSTransfer = false
     let hasSTransfer = false
     let classificationLvl = ""

--- a/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
+++ b/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
@@ -176,7 +176,8 @@ export default class GatherPriceEstimates extends Mixins(SaveOnLeave) {
 
   async addCDSEntry():Promise<void>{
     this.cdsSNOWRecord = await IGCE.getCDSRecord();
-    if(this.cdsSNOWRecord?.cross_domain_solution_required === "NO"){
+    if(this.cdsSNOWRecord?.cross_domain_solution_required !== "YES"
+      || ClassificationRequirements.cdsSolution === null){
       return;
     }
     const existingCDSIGCERecord = await IGCE.igceEstimateList.find(


### PR DESCRIPTION
- [ ] Ensure that Gather Price Estimates page in Step 8 (the purple accordion) page displays if user has NOT selected Cross Domain Solution
- [ ] Ensure that Gather Price Estimates page in Step 8 (the purple accordion) page displays if user has selected Cross Domain Solution.
- [ ] Ensure that if user skips CDS (after selected `Top Secret` or `Secret`) that NO CDS entry appears on the Gather Price Estimates page
