### PR TITLE
PR 1649 - hotfix/save-barrier-generated-text-to-SNOW

### DIFF
--- a/src/steps/02-EvaluationCriteria/MRR/ReviewBarriers.vue
+++ b/src/steps/02-EvaluationCriteria/MRR/ReviewBarriers.vue
@@ -222,9 +222,9 @@ export default class ReviewBarriers extends Mixins(SaveOnLeave){
   protected async saveOnLeave(): Promise<boolean> {
     if(this.docgenType === "GENERATED"){
       this.plansToRemoveGenerated = this.barriersToOpportunity
-      if(this.plansToRemoveGenerated === this.defaultSuggestion){
-        this.plansToRemoveGenerated = ""
-      }
+      // if(this.plansToRemoveGenerated === this.defaultSuggestion){
+      //   this.plansToRemoveGenerated = ""
+      // }
     }else{
       this.plansToRemoveCustom = this.barriersToOpportunity
     }


### PR DESCRIPTION
Ensure that this field `barriers_plans_to_remove_generated` field value (see screenshot) saves as expected to both 
- [ ] the vue store `AcquisitionPackage.fairopportunity.barriers_plans_to_remove_generated` &&
- [ ] `DAPPS:Fair Opportunity.Barriers Plans to Remove - Generated` column 
---
- [ ] Please test the two items above on a new acquistion package and an existing acquisition package.
- [ ] Also, please ensure that both custom text and the `Restore to suggestion` text saves as expected to both the store & SNOW.

---
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/621eced0-5c93-4ea6-a05b-d2831d141786)
