### PR TITLE
PR 1651 - hotfix/g-invoicing-not-updating-order-number

### DIFF
--- a/src/api/gInvoicing/index.ts
+++ b/src/api/gInvoicing/index.ts
@@ -23,13 +23,10 @@ export class GInvoicingApi extends ApiBase{
       const apiResponse = await this.instance.get(this.endPoint,
         requestConfig
       );
-
       if(apiResponse.status === 200){
-        const { result } = apiResponse.data;
-
         const response: GInvoicingResponse = {
-          valid: result.valid,
-          message: result.message
+          valid: true,
+          message: apiResponse.data.result
         };
 
         return response;

--- a/src/api/gInvoicing/index.ts
+++ b/src/api/gInvoicing/index.ts
@@ -11,12 +11,13 @@ export class GInvoicingApi extends ApiBase{
     super(ENDPOINTNAME);
   }
 
-  public async search(orderNumber: string): Promise<GInvoicingResponse> {
+  public async search(orderNumber: string, acqPackageId: string): Promise<GInvoicingResponse> {
     try {
 
       const requestConfig: AxiosRequestConfig = {
         params: {
-          orderNumber: orderNumber
+          orderNumber: orderNumber,
+          acquisitionPackageId: acqPackageId
         }
       };
 

--- a/src/components/ATATSearch.vue
+++ b/src/components/ATATSearch.vue
@@ -131,6 +131,7 @@ import api from "@/api";
 import { mask } from "types/Global";
 import Inputmask from "inputmask/";
 import PortfolioStore from "@/store/portfolio";
+import AcquisitionPackage from "@/store/acquisitionPackage";
 
 @Component({
   components: {
@@ -254,7 +255,9 @@ export default class ATATSearch extends Vue {
       }
     } else if (this.searchType === "G-Invoicing") {
       try {
-        const gInvoicingResponse = await api.gInvoicingApi.search(this._value);
+        const gInvoicingResponse = await api.gInvoicingApi.search(
+          this._value, AcquisitionPackage.packageId
+        );
         if (gInvoicingResponse.valid){
           this.showSuccessAlert = true;
         } else {

--- a/src/store/financialDetails/index.ts
+++ b/src/store/financialDetails/index.ts
@@ -641,11 +641,11 @@ export class FinancialDetailsStore extends VuexModule {
      const getFundingRequestFSForm = await api.fundingRequestFSFormTable.getQuery(
        {
          params: {
-           sysparm_query: "^sys_Id=" + data.sys_id
+           sysparm_query: "^sys_id=" + data.sys_id
          }
        }
      )
-
+     const isUsingGInvoicing = data.use_g_invoicing === "YES";
      const savedFundingRequestFSForm =
       await api.fundingRequestFSFormTable.update(data.sys_id as string, 
         {
@@ -654,8 +654,12 @@ export class FinancialDetailsStore extends VuexModule {
           fs_form_7600b_attachment: data.fs_form_7600b_attachment,
           fs_form_7600b_filename: data.fs_form_7600b_filename,
           use_g_invoicing: data.use_g_invoicing,
-          order_number: getFundingRequestFSForm[0].order_number,
-          gt_c_number: getFundingRequestFSForm[0].gt_c_number
+          order_number: isUsingGInvoicing 
+            ? getFundingRequestFSForm[0].order_number
+            : "",
+          gt_c_number:  isUsingGInvoicing 
+            ? getFundingRequestFSForm[0].gt_c_number
+            : "",
         });
      this.setFundingRequestFSForm(savedFundingRequestFSForm);
      return savedFundingRequestFSForm;

--- a/src/store/financialDetails/index.ts
+++ b/src/store/financialDetails/index.ts
@@ -174,8 +174,7 @@ export class FinancialDetailsStore extends VuexModule {
 
     const formToSave = {
       ...fsForm,
-      use_g_invoicing: data.useGInvoicing,
-      gt_c_number: data.gInvoiceNumber,
+      use_g_invoicing: data.useGInvoicing
     }
 
     const savedForm = await this.saveFundingRequestFSForm(formToSave);
@@ -639,8 +638,25 @@ export class FinancialDetailsStore extends VuexModule {
  public async saveFundingRequestFSForm(data:
   FundingRequestFSFormDTO): Promise<FundingRequestFSFormDTO>{
    try {
+     const getFundingRequestFSForm = await api.fundingRequestFSFormTable.getQuery(
+       {
+         params: {
+           sysparm_query: "^sys_Id=" + data.sys_id
+         }
+       }
+     )
+
      const savedFundingRequestFSForm =
-       await api.fundingRequestFSFormTable.update(data.sys_id as string, data);
+      await api.fundingRequestFSFormTable.update(data.sys_id as string, 
+        {
+          fs_form_7600a_filename: data.fs_form_7600a_filename,
+          fs_form_7600a_attachment: data.fs_form_7600a_attachment,
+          fs_form_7600b_attachment: data.fs_form_7600b_attachment,
+          fs_form_7600b_filename: data.fs_form_7600b_filename,
+          use_g_invoicing: data.use_g_invoicing,
+          order_number: getFundingRequestFSForm[0].order_number,
+          gt_c_number: getFundingRequestFSForm[0].gt_c_number
+        });
      this.setFundingRequestFSForm(savedFundingRequestFSForm);
      return savedFundingRequestFSForm;
    } catch (error) {


### PR DESCRIPTION
- [ ] log onto DSP dev
- [ ] use this Order Number `O2208-097-097-596561` in the Funding > Ginvoicing page to successfully retrieve the order number
- [ ] hit continue and view the row in the database.  Both the `order_number` and the `gt_c-number` should be populated.
- [ ] revisit Ginvoicing page and view the database row to make sure both values did not get overwritten.
- [ ] revisit Ginvoicing page and click NO.  Click to continue.  
- [ ] Check the database row to ensure that both the `order_number` and the `gt_c-number` are empty.