### PR TITLE
feature/AT-9140-Disa-Orginizations

### DIFF
--- a/src/api/disaOrganization/index.ts
+++ b/src/api/disaOrganization/index.ts
@@ -1,0 +1,11 @@
+import { TableApiBase } from "../tableApiBase";
+import { DisaOrganizationDTO } from "@/api/models";
+
+export const TABLENAME = "x_g_dis_atat_disa_organization";
+
+export class DisaOrganizationApi extends TableApiBase<DisaOrganizationDTO> {
+  constructor() {
+    super(TABLENAME);
+  }
+
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -65,6 +65,7 @@ import { PackageDocumentsSignedAPI } from "@/api/packageDocumentsSigned";
 import { PackageDocumentsUnsignedAPI } from "@/api/packageDocumentsUnsigned";
 import { AddressApi } from "@/api/address";
 import { CostEstimateApi } from "@/api/costEstimate";
+import { DisaOrganizationApi } from "@/api/disaOrganization";
 
 export const api = {
 
@@ -134,6 +135,7 @@ export const api = {
   packageDocumentsSignedTable: new PackageDocumentsSignedAPI(),
   packageDocumentsUnsignedTable: new PackageDocumentsUnsignedAPI(),
   addressTable: new AddressApi(),
+  disaOrganizationTable: new DisaOrganizationApi(),
 }
 
 export default {

--- a/src/api/models/index.ts
+++ b/src/api/models/index.ts
@@ -347,6 +347,7 @@ export interface OrganizationDTO extends BaseTableDTO {
   street_address_2?: string;
   organization_name?: string;
   disa_organization?: string;
+  disa_organization_reference?: ReferenceColumn | string;
   agency?: string;
   state?: string;
   zip_code?: string;
@@ -1078,4 +1079,9 @@ export interface AddressDTO extends BaseTableDTO {
   state_province_state_code?: string
   name?: string
   aa_ae_ap?: string
+}
+export interface DisaOrganizationDTO extends BaseTableDTO {
+  full_name: string;
+  abbreviation: string;
+  css_id: number;
 }

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,11 +1,11 @@
-import { 
-  AgencyDTO, 
-  ClassificationLevelDTO, 
-  EvalPlanAssessmentAreaDTO, 
-  EvalPlanDifferentiatorDTO, 
-  PeriodDTO, 
-  ReferenceColumn, 
-  SystemChoiceDTO 
+import {
+  AgencyDTO,
+  ClassificationLevelDTO, DisaOrganizationDTO,
+  EvalPlanAssessmentAreaDTO,
+  EvalPlanDifferentiatorDTO,
+  PeriodDTO,
+  ReferenceColumn,
+  SystemChoiceDTO
 } from "@/api/models";
 import { Checkbox, RadioButton, SelectData, User } from "types/Global";
 import _ from "lodash";
@@ -42,6 +42,14 @@ export const convertSystemChoiceToSelect =
       const {value} = choice;
       return {
         text: choice.label,
+        value
+      }
+    });
+export const convertDisaOrgToSelect =
+    (data: DisaOrganizationDTO[]): SelectData[] => data.map(choice => {
+      const value = choice.sys_id;
+      return {
+        text: choice.full_name,
         value
       }
     });

--- a/src/steps/01-AcquisitionPackageDetails/Organization.vue
+++ b/src/steps/01-AcquisitionPackageDetails/Organization.vue
@@ -158,7 +158,11 @@
 /* eslint-disable camelcase */
 import { Component, Watch, Mixins } from "vue-property-decorator";
 import SaveOnLeave from "@/mixins/saveOnLeave";
-import {convertSystemChoiceToSelect, convertAgencyRecordToSelect } from "@/helpers";
+import {
+  convertSystemChoiceToSelect,
+  convertAgencyRecordToSelect,
+  convertDisaOrgToSelect
+} from "@/helpers";
 
 import ATATAddressForm from "@/components/ATATAddressForm.vue";
 import ATATAutoComplete from "@/components/ATATAutoComplete.vue";
@@ -308,7 +312,7 @@ export default class OrganizationInfo extends Mixins(SaveOnLeave) {
     }
 
     return {
-      disa_organization: this.selectedDisaOrg.value as string,
+      disa_organization_reference: this.selectedDisaOrg.value as string,
       organization_name: this.organizationName,
       dodaac: this.dodAddressCode,
       agency: this.selectedAgency.value as string,
@@ -324,6 +328,7 @@ export default class OrganizationInfo extends Mixins(SaveOnLeave) {
 
   private savedData = {
     disa_organization: "",
+    disa_organization_reference:"",
     organization_name: "",
     dodaac: "",
     agency: "",
@@ -351,7 +356,7 @@ export default class OrganizationInfo extends Mixins(SaveOnLeave) {
 
   public async loadOnEnter(): Promise<void> {
     this.agencyData = convertAgencyRecordToSelect(OrganizationData.agency_data);
-    this.disaOrgData = convertSystemChoiceToSelect(OrganizationData.disa_org_data);
+    this.disaOrgData = convertDisaOrgToSelect(OrganizationData.disa_org_data);
     this.stateListData = ContactData.stateChoices;
     const storeData = await AcquisitionPackage
       .loadData<OrganizationDTO>({storeProperty: 
@@ -361,6 +366,7 @@ export default class OrganizationInfo extends Mixins(SaveOnLeave) {
       const keys: string[] = [
         "disa_organization",
         "organization_name",
+        "disa_organization_reference",
         "dodaac",
         "agency",
         "address_type",
@@ -385,9 +391,8 @@ export default class OrganizationInfo extends Mixins(SaveOnLeave) {
         this.selectedAgency =
           this.agencyData[selectedAgencyIndex];
       }
-
       this.selectedDisaOrg = this.disaOrgData.find(
-        (disaOrg) => disaOrg.value === storeData.disa_organization
+        (disaOrg) => disaOrg.value === storeData.disa_organization_reference.value
       ) as SelectData
 
       this.organizationName = storeData.organization_name;

--- a/src/store/organizationData/index.ts
+++ b/src/store/organizationData/index.ts
@@ -5,7 +5,7 @@ import rootStore from "../index";
 import api from "@/api";
 import { AxiosRequestConfig } from "axios"
 import {TABLENAME as OrganizationTable} from "@/api/organization";
-import { AgencyDTO, SystemChoiceDTO } from "@/api/models";
+import { AgencyDTO, DisaOrganizationDTO, SystemChoiceDTO } from "@/api/models";
 import  {nameofProperty, storeDataToSession, retrieveSession} from "../helpers"
 import Vue from "vue";
 
@@ -27,7 +27,7 @@ export class OrganizationDataStore extends VuexModule {
   initialized = false;
   //keeps track of project title for global display
   public agency_data: AgencyDTO[] = [];
-  public disa_org_data: SystemChoiceDTO[] = [];
+  public disa_org_data: DisaOrganizationDTO[] = [];
 
   public get agencyData(): AgencyDTO[] {
     return this.agency_data;
@@ -63,16 +63,23 @@ export class OrganizationDataStore extends VuexModule {
   }
 
   @Mutation
-  public setDisOrgData(value: SystemChoiceDTO[]): void {
+  public setDisOrgData(value: DisaOrganizationDTO[]): void {
     this.disa_org_data = value;
   }
 
   @Action({rawError: true})
   private async getDisaOrgData():Promise<void> {
-    const disa_org_data = await api.systemChoices.getChoices(
-      OrganizationTable,
-      "disa_organization"
-    );
+    // const disa_org_data = await api.systemChoices.getChoices(
+    //   OrganizationTable,
+    //   "disa_organization"
+    // );
+    const disaOrgRequestConfig: AxiosRequestConfig = {
+      params: {
+        sysparm_query: "ORDERBYfull_name",
+        sysparm_fields: "full_name,abbreviation,css_id,sys_id",
+      },
+    };
+    const disa_org_data = await api.disaOrganizationTable.all(disaOrgRequestConfig)
     this.setDisOrgData(disa_org_data);
   }
 


### PR DESCRIPTION
Today, when users create a package and select DISA as the Agency, they must select a particular DISA Organization from a dropdown menu. This needs to be refactored to instead do the following:
Source the dropdown list from all records in the DISA Organization Table
Use the Full Name column
Save the referenced sys_id in the DISA Organization Reference column of the given package’s Organization record