### PR TITLE
AT-9339-fix-task-order-date

### DIFF
--- a/src/portfolios/provisioning/AwardedTaskOrder.vue
+++ b/src/portfolios/provisioning/AwardedTaskOrder.vue
@@ -90,7 +90,7 @@ import ATATExpandableLink from "@/components/ATATExpandableLink.vue";
 import TaskOrderSearchModal from "@/portfolios/components/TaskOrderSearchModal.vue";
 
 import PortfolioStore from "@/store/portfolio";
-import { format } from 'date-fns';
+import { format, parseISO } from 'date-fns';
 import AcquisitionPackage from "@/store/acquisitionPackage";
 import AcquisitionPackageSummary from "@/store/acquisitionPackageSummary";
 
@@ -148,9 +148,12 @@ export default class AwardedTaskOrder extends Vue {
   public async setTaskOrderData(): Promise<void> {
     const data = PortfolioStore.portfolioProvisioningObj;
     if (data) {
-      const popEnd = data.popEndDate ? format(new Date(data.popEndDate), "MM/dd/yyyy") : "";
-      const popStart = data.popStartDate ? format(new Date(data.popStartDate), "MM/dd/yyyy") : "";
-      const pop = popEnd && popStart ? popStart + " — " + popEnd : "";
+      const popEnd = data.popEndDate ? parseISO(data.popEndDate) : new Date();
+      const popEndDateStr = format(popEnd, "MM/dd/yyyy");
+      const popStart = data.popStartDate ? parseISO(data.popStartDate) : new Date();
+      const popStartDateStr = format(popStart, "MM/dd/yyyy");
+
+      const pop = `${popStartDateStr} — ${popEndDateStr}`;
 
       this.awardedTaskOrder = {
         taskOrderNumber: data.taskOrderNumber as string,


### PR DESCRIPTION
fix for task order date parsing
![at_9339](https://github.com/dod-ccpo/atat-web-ui/assets/137221342/911dd73a-bbcf-4eee-9f41-43878a721e37)
