### PR TITLE
PR 1722 - hotfix/travel-navigation-prevents-user-from-advancing

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -323,7 +323,10 @@ export const SummaryStepSevenRouteResolver = (current: string): string =>{
   if (isStepTouched(7)){
     return routeNames.SummaryStepSeven;
   }
-  return current;
+
+  return current === routeNames.Travel
+    ? routeNames.PII
+    : routeNames.Travel
 }
 
 export const PIIRecordResolver = (current: string): string => {

--- a/src/steps/04-ContractDetails/SummaryStepThree.vue
+++ b/src/steps/04-ContractDetails/SummaryStepThree.vue
@@ -40,7 +40,7 @@ export default class SummaryStepThree extends Mixins(SaveOnLeave){
   get headline():string{
     return (isStepComplete(3))
       ? "You are all done with this section, but you can come back at any time to edit "
-        + "details. When you are ready, we will move on to gather background information"
+        + "details. When you are ready, we will move on to gather background information."
       : "We need some more details for this section. You can add info now, or come back to "
         + "make edits at any time. When you are ready to wrap up this section, we will move "
         + "on to gather background information."

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1313,8 +1313,7 @@ export class AcquisitionPackageStore extends VuexModule {
         text += " by reviewing the JWCC contractor's catalogs to determine " +
           "if other similar offerings (to include: " + 
           this.fairOpportunity.cause_product_feature_name + ") " +
-          "meet or can be modified to satisfy the Government’s requirements. The results " + 
-          "have determined that no other offering is suitable as follows: " +
+          "meet or can be modified to satisfy the Government’s requirements. " +
           this.fairOpportunity.research_review_catalogs_review_results + " " +
           "Therefore, it was determined the " + 
           this.fairOpportunity.cause_product_feature_name + " " +

--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -446,7 +446,7 @@ export class SummaryStore extends VuexModule {
     let desc = "";
     if (sensitiveInfo.pii_present === "YES"
       && sensitiveInfo.system_of_record_name !== "" ){
-      desc = "System of records: [" + sensitiveInfo.system_of_record_name + "]"
+      desc = "System of records: " + sensitiveInfo.system_of_record_name
     } else if (sensitiveInfo.pii_present === "NO"){
       desc = "Effort does not include a system of records on individuals."
     }


### PR DESCRIPTION
**Issue**
User cannot advance past `Step 6/Substep 3 - Travel`.

To test issue
1. Create new package, toggle `Developer Navigation` to ON
2. In Step 3, add PoP and Classification Reqs
3. Advance to Step 6, Travel.
4. Toggle `Developer Navigation` to OFF
5. Add one travel item.
6. Click `Continue` to **ensure** user can successfully navigate to the next page, `Step 7 - PII`.
7. Click `Back` to **ensure** user can successfully navagate back to travel page.


