### PR TITLE
feature/AT-9290-Accordion-text-update

### DIFF
--- a/src/steps/02-EvaluationCriteria/components/GoToQuestionnaire.vue
+++ b/src/steps/02-EvaluationCriteria/components/GoToQuestionnaire.vue
@@ -1,15 +1,14 @@
 <template>
   <ATATExpandableLink  aria-id="HelpReturnToQuestionnaire"
-    class="mt-5">
+                       class="mt-5">
     <template v-slot:header>
       I need help generating a response for this portion of the J&A. What do I do?
     </template>
     <template v-slot:content>
       <p class="copy-max-width">
-        Although you previously wrote a custom explanation, DAPPS can provide suggested
-        language for {{ forWhat }}, based on your responses
-        to a short questionnaire. You’ll be able to edit to our suggestion to meet your
-        requirements, or choose to restore your custom explanation.
+        DAPPS can provide suggested language for {{ forWhat }},
+        based on your responses to a short questionnaire. You’ll be able to edit our
+        suggestion to meet your requirements, if needed.
       </p>
       <v-btn
         class="secondary font-size-14 px-3 mb-1 mt-1"
@@ -49,7 +48,7 @@ import ATATExpandableLink from "@/components/ATATExpandableLink.vue"
 
 export default class GoToQuestionnaire extends Vue {
   @Prop() private section!: "soleSource" | "researchDetails" | "plansToRemoveBarriers";
- 
+
   public get forWhat(): string {
     switch (this.section) {
     case "soleSource":


### PR DESCRIPTION
Current “I need help generating a response for this portion of the J&A. What do I do?” accordion text is confusing to the user. We have modified the language to give better detail as the user is moving from custom to suggested language.

Accordion for Cause of Sole Source:
DAPPS can provide suggested language for the cause of your sole source situation, based on your responses to a short questionnaire. You’ll be able to edit our suggestion to meet your requirements, if needed.

For Market Research:
DAPPS can provide suggested language for the market research conducted, based on your responses to a short questionnaire. You’ll be able to edit our suggestion to meet your requirements, if needed.

For Barriers:
DAPPS can provide suggested language for removing barriers to fair opportunity, based on your responses to a short questionnaire. You’ll be able to edit our suggestion to meet your requirements, if needed.