### PR TITLE
DAPPS - Bug - DOCGEN - If there is no procurement history, display Not applicable on MRR and J&A

### DIFF
--- a/src/steps/03-Background/CurrentContract/CurrentContract.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContract.vue
@@ -113,14 +113,6 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
       if (this.hasChanged()) {
         // always clear existing Contracts if form value has changed
         await AcquisitionPackage.clearCurrentContractInfo();
-        if (hasCurrentContract==="NO"){
-          // update store && snow
-          const noContract = initialCurrentContract();
-          noContract.current_contract_exists = "NO";
-          noContract.instance_number= 0;
-          noContract.acquisition_package = AcquisitionPackage.packageId;
-          AcquisitionPackage.updateCurrentContractsSNOW([noContract]);
-        }
       }
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
https://ccpo.atlassian.net/browse/AT-9394?atlOrigin=eyJpIjoiZDM5ZDhhODRlZmM1NDU2ZGEyMmZlOTgyNTNmNTRkZTgiLCJwIjoiaiJ9

Removing code that makes a post call when the user selects "No" for current contract, as the lack of existence of a current contract should not reflect as a row in the table. This allows the table to be empty when intended, which in turn allows document generation to show "not applicable" when appropriate for sections of the J&A and MRR documents that expect `procurementHistory.length` to be 0 to determine generation text.