### PR TITLE
bugfix/AT-8697-Portability-IGCE-Duplication

### DIFF
--- a/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
@@ -382,8 +382,8 @@ export default class OtherOfferings extends Vue {
       const classificationObj = this.selectedClassificationLevelList[0];
       this._serviceOfferingData.classificationLevel
         = classificationObj.classification_level as string;
-      this._portabilityClassificationLevels.push(classificationObj.classification_level as string) ;
-      this.singleClassificationLevelName 
+      this._portabilityClassificationLevels[0] = classificationObj.classification_level as string;
+      this.singleClassificationLevelName
         = buildClassificationLabel(classificationObj, "short");
     }
   }


### PR DESCRIPTION
Make sure portability plan data is retrieving correctly
Make sure when the user is updating existing entry, not creating new entry every time the user makes the edit
Make sure there is one portability plan cost estimate in IGCE page for selected classification