### PR TITLE
PR 1763 - bugfix/AT-9395-Current-Contract-Not-Retrieving

### DIFF
--- a/src/steps/02-EvaluationCriteria/Exceptions.vue
+++ b/src/steps/02-EvaluationCriteria/Exceptions.vue
@@ -170,7 +170,7 @@ export default class Exceptions extends Mixins(SaveOnLeave) {
   }
 
   public hasChangedFromToNoNone():boolean{
-    return this.savedData.exception_to_fair_opportunity === "NO_NONE" ||
+    return this.savedData.exception_to_fair_opportunity !== "NO_NONE" &&
       this.currentData.exception_to_fair_opportunity === "NO_NONE";
   }
 

--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
@@ -393,7 +393,7 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   }
 
   public async loadOnEnter(): Promise<void> {
-    await this.loadContract();    
+    await this.loadContract();
     if (this.currentContract) {
       const keys: string[] = [
         "incumbent_contractor_name",

--- a/src/store/acquisitionPackage/index.ts
+++ b/src/store/acquisitionPackage/index.ts
@@ -1076,6 +1076,7 @@ export class AcquisitionPackageStore extends VuexModule {
   
   @Mutation
   public async doSetFairOpportunity(value: FairOpportunityDTO): Promise<void> {
+
     this.fairOpportunity = this.fairOpportunity
       ? Object.assign(this.fairOpportunity, value)
       : value;


### PR DESCRIPTION
fixed logic to only clear out current contract if value was changed to none