### PR TITLE
Feature/AT-9212

### DIFF
--- a/.github/workflows/create-patch.yml
+++ b/.github/workflows/create-patch.yml
@@ -1,0 +1,26 @@
+name: Bump version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: '0'
+      - name: Bump version and push tag
+        uses: anothrNick/github-tag-action@1.64.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch # to use a different bump, include "#minor" or "#major" in the PR title/description
+          INITIAL_VERSION: 1.22.1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,13 +1,15 @@
 ---
-name: Run checks on PRs
+name: Run checks on PRs, build and upload app, conditionally create release (on tags only)
 
 on:
   pull_request:
   push:
+    tags:
+      - '**'
     branches:
       - main
       - develop
-
+      - release
 permissions:
   contents: read
 
@@ -15,6 +17,7 @@ jobs:
   assertPackageLockVersion:
     name: Ensure package-lock lockfileVersion has not changed
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }} # don't need this for tag pushes
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -32,6 +35,7 @@ jobs:
   lint:
     name: Run linter
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }} # don't need this for tag pushes
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -84,10 +88,21 @@ jobs:
         with:
           path: coverage/lcov-report/
           name: lcov-report
+      - name: Zip dist folder
+        run: zip -r release.zip dist
+        if: startsWith(github.ref, 'refs/tags/')
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: |
+            release.zip
 
   secretScan:
     name: Scan for secrets
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.ref, 'refs/tags/') }} # don't need this for tag pushes
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
* Added new workflow to automatically create patch tags
* Modified `pr.yml` to optionally create official GitHub releases when new tags are created.

Note that the default tag "bump" is `patch` - this means we go from 1.2.3 to 1.2.4. If we want to bump to 1.3, we need to include `#minor` in the PR title and the workflow will automatically handle it.

I configured several steps in `build` within `pr.yml` _not_ to run for tag pushes since they won't be necessary and cause unnecessary slowdowns.

