### PR TITLE
AT-9470: updating the menu items on task order card

### DIFF
--- a/src/portfolios/portfolio/components/TaskOrder/TaskOrderCard.vue
+++ b/src/portfolios/portfolio/components/TaskOrder/TaskOrderCard.vue
@@ -134,7 +134,7 @@ export default class TaskOrderCard extends Vue {
     if (status !== "Expired") {
       dropDownItems.splice(1,0, {
         title: "Request to modify task order",
-        hidden: false
+        hidden: true
       });
     }
     return dropDownItems;


### PR DESCRIPTION
Updating meatball menu on Task order card to only have access to "View task order details" button