### PR TITLE
PR 1790 - bugfix/resolve-breaking-current-contracts-if-no-listings

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --no-cache --watch src/steps/08-StandardsAndCompliance/BAA.spec.ts",
+    "test-file:watch": "jest --no-cache --watch src/steps/03-Background/CurrentContract/CurrentContractDetails.spec.ts",
     "test-files": "jest --no-cache src/steps/03-Background/components/",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",

--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.spec.ts
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.spec.ts
@@ -171,9 +171,12 @@ describe("Testing CurrentContractDetails Component", () => {
       expect(wrapper.vm.isExceptiontoFairOpp).toBe(true);
     })
 
-    it("currentData() => returns currentData obj", async () => {
-      wrapper.setData(isCurrent);
-      expect(wrapper.vm.currentData).toEqual(isCurrent.currentContract);
+    it("currentData() => returns currentContract obj", async () => {
+      wrapper.setData(
+        {currentContract: isCurrent.currentContract
+      });
+      expect(wrapper.vm.currentData)
+        .toEqual(wrapper.vm.$data.currentContract);
     })
 
     it("currentData() => returns initialCurrentContract()", async () => {

--- a/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
+++ b/src/steps/03-Background/CurrentContract/CurrentContractDetails.vue
@@ -366,7 +366,7 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
     const contractToLoadInstanceNumber = AcquisitionPackage.currentContractInstanceNumber;
     this.currentContracts = await AcquisitionPackage.currentContracts as CurrentContractDTO[];
     await this.sortDataSource();
-    this.currentContract = this.currentContracts.filter(
+    this.currentContract = this.currentContracts?.filter(
       (c) => {
         return c.instance_number?.toString()=== contractToLoadInstanceNumber.toString()
       }
@@ -378,11 +378,13 @@ export default class CurrentContract extends Mixins(SaveOnLeave) {
   }
 
   public async sortDataSource():Promise<void>{
-    this.currentContracts.sort((a,b)=> {
-      const dateA = new Date(a.sys_created_on || "");
-      const dateB = new Date(b.sys_created_on || "");
-      return dateA.getTime()-dateB.getTime()
-    })
+    if (this.currentContracts){
+      this.currentContracts.sort((a,b)=> {
+        const dateA = new Date(a.sys_created_on || "");
+        const dateB = new Date(b.sys_created_on || "");
+        return dateA.getTime()-dateB.getTime()
+      })
+    }
   }
 
   public setMinAndMaxDates():void{


### PR DESCRIPTION
**To test....**
- [ ] Open a new package
- [ ] Navigate to Step 2 and choose the 2nd option.
- [ ] Navigate to step 4.  Procurement history is displayed.
- [ ] Click `Add a contract`
- [ ] Ensure the screencap below, with console log errors and bad prefilled values in the `Contract number` and `Task order number` does not appear. (Figure 1.0)
- [ ] Ensure correct version of page appears. (Figure 1.1)
---
**Figure 1.0**
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/bb467c43-5e02-4ad8-b67b-69067a01fc6f)

---
**Figure 1.1**
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/a5560daf-dad6-403b-bef5-b675b3fea4b9)
