### PR TITLE
Fixing auto tag + release creation

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.64.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOWS_PAT }}
           WITH_V: true
           DEFAULT_BUMP: patch # to use a different bump, include "#minor" or "#major" in the PR title/description
           INITIAL_VERSION: 1.22.2


### PR DESCRIPTION
Switching from GITHUB_TOKEN (which cannot trigger a new workflow) to Jeff's WORKFLOWS_PAT token, which can. This allows us to automatically create releases.