### PR TITLE
Release/1.23.0 (attempt #2)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Bump version and push tag
         uses: anothrNick/github-tag-action@1.64.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.WORKFLOWS_PAT }}
           WITH_V: true
           DEFAULT_BUMP: patch # to use a different bump, include "#minor" or "#major" in the PR title/description
           INITIAL_VERSION: 1.22.2

--- a/src/portfolios/portfolio/components/TaskOrder/TaskOrderCard.vue
+++ b/src/portfolios/portfolio/components/TaskOrder/TaskOrderCard.vue
@@ -134,7 +134,7 @@ export default class TaskOrderCard extends Vue {
     if (status !== "Expired") {
       dropDownItems.splice(1,0, {
         title: "Request to modify task order",
-        hidden: false
+        hidden: true
       });
     }
     return dropDownItems;


### PR DESCRIPTION
Switching to a PAT should ensure that our tag creation will kick off the release correctly. Also, since we no longer have the "magic" text (which I will NOT include here) in our commit text, we _should_ be creating a patch tag.