### PR TITLE
Auto tag + release fixes (attempt 3)

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,9 +18,12 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: '0'
       - name: Bump version and push tag
-        uses: anothrNick/github-tag-action@1.64.0
+        uses: anothrNick/github-tag-action@1.67.0
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOWS_PAT }}
           WITH_V: true
-          DEFAULT_BUMP: patch # to use a different bump, include "#minor" or "#major" in the PR title/description
+          DEFAULT_BUMP: patch
           INITIAL_VERSION: 1.22.2
+          MAJOR_STRING_TOKEN: '#major_release'
+          MINOR_STRING_TOKEN: '#minor_release'
+          PATCH_STRING_TOKEN: '#patch_release'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -97,7 +97,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.WORKFLOWS_PAT }}
           files: |
             release.zip
 


### PR DESCRIPTION
- Setting specific STRING_TOKEN values
- Upgrading github-tag-action version
- Removing comment which includes the forbidden text
- Using a PAT to generate the release