### PR TITLE
PR 1800 - Hotfix/at 9535 resolving ifp from advancing

### DIFF
--- a/src/steps/10-FinancialDetails/IncrementalFunding.vue
+++ b/src/steps/10-FinancialDetails/IncrementalFunding.vue
@@ -166,8 +166,8 @@
               <div
                 class="d-flex justify-end align-center"
                 :class="[
-                {'error--text': this.isIFPOverfunded},
-                {'error--text': this.isIFPUnderfunded},
+                {'error--text': isOverfunded},
+                {'error--text': isUnderfunded},
                  ]">
                 <label for="TotalAmount" class="mr-4"> Total </label>
 
@@ -179,7 +179,7 @@
                   width="190"
                   style="margin-right: -10px;"
                   :disabled="true"
-                  :isManuallyErrored="isIFPUnderfunded||isIFPOverfunded"
+                  :isManuallyErrored="isUnderfunded || isOverfunded"
                 />
                 <span class="d-block" style="width: 36px"></span>
               </div>
@@ -242,12 +242,12 @@
         <ATATAlert
           id="OverUnderFundedAlert"
           class="width-70 mt-5"
-          v-if=" isIFPOverfunded|| isIFPUnderfunded "
+          v-if=" isOverfunded || isUnderfunded "
         >
           <template slot="content">
             <p class="mb-0">
               Based on your requirement’s cost estimate, your plan is
-              <strong>{{ isIFPOverfunded ? 'over' : 'under'}}funded</strong>. 
+              <strong>{{ isOverfunded ? 'over' : 'under'}}funded</strong>. 
               Please adjust your increments to ensure the total equals ${{ costEstimateStr }} 
             </p>
           </template>
@@ -273,7 +273,7 @@ import PeriodOfPerformance from "@/store/periods";
 
 import { CostEstimateDTO, PeriodDTO, PeriodOfPerformanceDTO } from "@/api/models";
 import { SelectData, fundingIncrement, IFPData } from "../../../types/Global";
-import { toCurrencyString, currencyStringToNumber } from "@/helpers";
+import { toCurrencyString, currencyStringToNumber, roundDecimal } from "@/helpers";
 
 import SaveOnLeave from "@/mixins/saveOnLeave";
 import { hasChanges } from "@/helpers";
@@ -284,6 +284,7 @@ import _ from "lodash";
 import { api } from "@/api";
 import acquisitionPackage from "@/store/acquisitionPackage";
 import AcquisitionPackage from "@/store/acquisitionPackage";
+import { MarketResearchTechniquesApi } from "@/api/fairOpportunity";
 
 @Component({
   components: {
@@ -321,8 +322,6 @@ export default class IncrementalFunding extends Mixins(SaveOnLeave) {
   public initialAmount = 0;
   public initialAmountStr = "";
   private currentSelectedValue = "";
-  private isIFPUnderfunded = false;
-  private isIFPOverfunded = false;
   public costData: CostEstimateDTO = {packageId:"",payload:{}}
   public baseYear = 0
 
@@ -373,10 +372,8 @@ export default class IncrementalFunding extends Mixins(SaveOnLeave) {
   public async validateOnContinue(): Promise<void> {
     this.calcAmounts("initialIncrement");
     this.calcAmounts("increment0");
-    this.isUnderfunded();
-    this.isOverfunded();
     if (!this.hasValidatedOnContinue && (this.outOfRangeIndex && this.outOfRangeIndex >= 0
-      || this.isIFPUnderfunded || this.isIFPOverfunded)
+      || this.isUnderfunded || this.isOverfunded)
     ) {
       this.allowContinue = false;
     } else {
@@ -482,14 +479,14 @@ export default class IncrementalFunding extends Mixins(SaveOnLeave) {
     this.shouldShowAddIncrementButton();
   }
 
-  public isOverfunded():void{
-    this.isIFPOverfunded = this.costEstimate < this.totalAmount;
+  get isOverfunded():boolean{
+    return this.costEstimate < roundDecimal(this.totalAmount,2)
+  }
+  get isUnderfunded():boolean{
+    return this.costEstimate > roundDecimal(this.totalAmount,2)
   }
 
-  public isUnderfunded():void{
-    this.isIFPUnderfunded = this.costEstimate > this.totalAmount;
-  }
-
+  
   public showAddIncrementButton = true;
 
   public shouldShowAddIncrementButton(): void {
@@ -614,7 +611,7 @@ export default class IncrementalFunding extends Mixins(SaveOnLeave) {
       amt = parseFloat(this.fundingIncrements[0].amt);
       this.errorMissingFirstIncrement = amt === 0 || isNaN(amt);
     }
-    this.isOverfunded();
+    this.isOverfunded;
   }
 
   public checkIfHasPeriodGap(index: number): boolean {


### PR DESCRIPTION
To test:
- [ ] Open an existing package or create a new one.
- [ ] Ensure necessary data is entered for steps 1-5 and step 8 in order to generate a cost estimate number IGCE cost summary table.  Ensure cents numbers are entered for each cost estimate in step 8, not `.00`.
- [ ] Ensure a legitimate IGCE cost estimate exists on the step 8 ICGE cost summary table that does NOT have `.00`
- [ ] Navigate to IFP in step 8.
- [ ] Input dollars and cents into the IFP (Figure 1.0).  When the total amount matches the cost estimate, ensure NO overfunded or underfunded validation (Figure 1.1)  is displayed.
---
Figure 1.0 (no validation present and cents are not listed as `.00`)
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/e25979e9-4915-4464-8122-b4e4811f4c9b)

---
Figure 1.1 (Bug screencap > validation that persists when numbers match)
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/9c7b73e4-83e2-4c95-84ba-8555039c8506)



