### PR TITLE
Added current member back to manager list if is owner

### DIFF
--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -729,6 +729,13 @@ export default class PortfolioDrawer extends Vue {
         if (member.role === "Viewer" && member.sys_id) viewers.push(member.sys_id);
         if (member.role === "Manager" && member.sys_id) managers.push(member.sys_id);
       });
+      if (this.currentUserIsOwner) {
+        if (PortfolioStore.currentUserIsManager) {
+          managers.push(this.currentUser.sys_id as string);
+        } else if (PortfolioStore.currentUserIsViewer) {
+          viewers.push(this.currentUser.sys_id as string);
+        }
+      }
       /* eslint-disable camelcase */
       this.portfolio.portfolio_viewers = viewers.join(",");
       this.portfolio.portfolio_managers = managers.join(",");

--- a/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
+++ b/src/portfolios/portfolio/components/shared/PortfolioDrawer.vue
@@ -729,13 +729,13 @@ export default class PortfolioDrawer extends Vue {
         if (member.role === "Viewer" && member.sys_id) viewers.push(member.sys_id);
         if (member.role === "Manager" && member.sys_id) managers.push(member.sys_id);
       });
-      if (this.currentUserIsOwner) {
-        if (PortfolioStore.currentUserIsManager) {
-          managers.push(this.currentUser.sys_id as string);
-        } else if (PortfolioStore.currentUserIsViewer) {
-          viewers.push(this.currentUser.sys_id as string);
-        }
+
+      // ATAT TODO - remove conditional below if servicenow resolves issue on PROD
+      // where owners can't view portfolios unless also a manager
+      if (this.currentUserIsOwner && PortfolioStore.currentUserIsManager) {
+        managers.push(this.currentUser.sys_id as string);
       }
+
       /* eslint-disable camelcase */
       this.portfolio.portfolio_viewers = viewers.join(",");
       this.portfolio.portfolio_managers = managers.join(",");


### PR DESCRIPTION
This hotfix branch keeps current user as a manager to prevent a servicenow bug where if user is ONLY an owner on a portfolio, it's not showing, but if also a manager, they can see the portfolio.