### PR TITLE
PR 1852 - hotfix/AT-9282-redirect-to-funding-subsection

### DIFF
--- a/src/steps/11-GeneratePackageDocuments/UploadSignedDocuments.vue
+++ b/src/steps/11-GeneratePackageDocuments/UploadSignedDocuments.vue
@@ -22,7 +22,7 @@
               <router-link 
                 class="my-2"
                 id="revisitFundingSection"
-                :to="{ name: routeNames.CreatePriceEstimate }"
+                :to="{ name: routeNames.FundingPlanType }"
                 >
                 revisiting the Funding section
                 </router-link>


### PR DESCRIPTION
To test....

- [x] Open an existing package
- [x] Turn on Developer Navigation at the bottom.
- [x] Click on Step 9.
- [x] Change the url from `#/upload-ja-mrr-documents/ready-to-generate-package` to `#/upload-ja-mrr-documents/upload-signed-documents` to view the `Upload Signed Documents` page (See Figure 1.0)
- [x] Click the link `revisiting the Funding section` in the yellow alert 
- [x] Ensure the link navigates to the funding substep of step 8 (See Figure 1.1)

---
**Figure 1.0**
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/061fd49a-b1bb-44b4-b59d-c8fee06c13c3)

---
**Figure 1.1**
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/c4540fc1-6a44-4e6c-b8d0-8c2d0ccbd22d)

