### PR TITLE
PR 1853 - hotfix/AT-9632-correcting-step-7-summary-page-descriptions

### DIFF
--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -1014,7 +1014,7 @@ export class SummaryStore extends VuexModule {
     let desc = "";
     if (sensitiveInfo.baa_required === "YES" ){
       desc = "Effort requires a BAA to safeguard e-PHI."
-    } else if (sensitiveInfo.pii_present === "NO"){
+    } else if (sensitiveInfo.baa_required === "NO"){
       desc = "Effort does not require a BAA to safeguard e-PHI."
     }
     return desc;
@@ -1052,7 +1052,7 @@ export class SummaryStore extends VuexModule {
       && sensitiveInfo.foia_email !== "" ){
       desc = "FOIA Coordinator: " + sensitiveInfo.foia_full_name + "<br />"  
         + sensitiveInfo.foia_email 
-    } else if (sensitiveInfo.pii_present === "NO"){
+    } else if (sensitiveInfo.potential_to_be_harmful === "NO"){
       desc = "Disclosure is not harmful to the government."
     }
     return desc;


### PR DESCRIPTION
To test:
- [ ] Open a new or existing package.
- [ ] Navigate to step 7
- [ ] Select `Yes` for `PII`, `BAA`, `Public Disclosure of Information` substeps.  Add a `FOIA Coordinator`.
- [ ] Navigate to Step 7 summary page.
- [ ] Ensure there are 3 descriptions below the headings of the first three sections.
- [ ] Click the `PII` `View/Edit` button 
- [ ] Change `Yes` to `No`. Click `Continue` to advance to the summary page.
- [ ] Ensure the descriptions for `BAA`, and `Public Disclosure of Information` sections remain and did NOT disappear. (Figure 1.0)
---
**Figure 1.0**
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/392db599-f7be-4996-ab55-02bf0336d883)

