### PR TITLE
AT-9520 adjusted character limit for GT&C and Order number

### DIFF
--- a/src/steps/10-FinancialDetails/Upload7600.vue
+++ b/src/steps/10-FinancialDetails/Upload7600.vue
@@ -16,11 +16,9 @@
             :rules="[
               $validators.required('Please enter your GT&C Number.'),
               $validators.isMaskValid(
-                ['A[0-9]{4}\-[0-9]{3}-[0-9]{3}-[0-9]{6}(\.[0-9])?$'],
-                `Your GT&C Number should be 20 or 22 characters (including hyphens
-                    and periods) and use the format:<ul>
-                    <li>AYYMM-000-000-000000</li>
-                    <li>AYYMM-000-000-000000.0 (with version number)</li></ul>`,
+                ['A[0-9]{4}\-[0-9]{3}-[0-9]{3}-[0-9]{6}$'],
+                `Your GT&C Number should be 20 characters (including hyphens
+                    and periods) and use the format: AYYMM-000-000-000000`,
                 true
               ),
             ]"
@@ -38,11 +36,9 @@
             :rules="[
               $validators.required('Please enter your Order Number.'),
               $validators.isMaskValid(
-                ['O[0-9]{4}\-[0-9]{3}-[0-9]{3}-[0-9]{6}(\.[0-9])?$'],
-                `Your Order Number should be 20 or 22 characters (including hyphens 
-                    and periods) and use the format:<ul>
-                    <li>OYYMM-000-000-000000</li>
-                    <li>OYYMM-000-000-000000.0 (with version number)</li></ul>`,
+                ['O[0-9]{4}\-[0-9]{3}-[0-9]{3}-[0-9]{6}$'],
+                `Your Order Number should be 20 characters (including hyphens 
+                    and periods) and use the format: OYYMM-000-000-000000`,
                 true
               ),
             ]"


### PR DESCRIPTION
Both numbers only allow 20 characters only now.

https://ccpo.atlassian.net/jira/software/c/projects/AT/boards/47?modal=detail&selectedIssue=AT-9520


<img width="806" alt="image" src="https://github.com/dod-ccpo/atat-web-ui/assets/137221301/fad82925-e745-4dbc-8dd2-c933cb381fdb">
