### PR TITLE
Updated how SNOW archives portfolio

### DIFF
--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -909,7 +909,7 @@ export class PortfolioDataStore extends VuexModule {
   public async archivePortfolio(): Promise<void> {
     await api.portfolioTable.update(this.currentPortfolio.sysId as string,
       // eslint-disable-next-line max-len
-      {portfolio_status: "ARCHIVED", last_updated: format(new Date(), "yyyy-MM-dd HH:mm:ss")} as unknown as PortfolioSummaryDTO
+      {is_archived: true, last_updated: format(new Date(), "yyyy-MM-dd HH:mm:ss")} as unknown as PortfolioSummaryDTO
     )
     this.doSetCurrentPortfolioStatus("ARCHIVED");
   }


### PR DESCRIPTION
**Description**
SNOW is changing portfolio status to calculated field. Therefore, UI cannot simply set portfolio status to ARCHIVED - refactor UI codebase to set is_archived to true

**Acceptance Criteria**
1. When user selects menu option to archive a portfolio, is_archived is set to true in servicenow. 
2. UI behaves as expected (current behavior) - badge is flipped to “ARCHIVED” and if on Funding Tracker or Task Order details, the Title (top left) and Description (slideout panel) become read-only, if Manager/Owner, can no longer add members or edit members.