### PR TITLE
hotfix AT-9701 azure alert

### DIFF
--- a/src/portfolios/provisioning/AwardedTaskOrder.vue
+++ b/src/portfolios/provisioning/AwardedTaskOrder.vue
@@ -168,8 +168,7 @@ export default class AwardedTaskOrder extends Vue {
   };
 
   public get isAzure(): boolean {
-    debugger;
-    return this.awardedTaskOrder.csp === "Azure";
+    return this.awardedTaskOrder.csp.toLowerCase() === "azure";
   }
 
   public resetAwardedTaskOrderData(): void {


### PR DESCRIPTION
Because ATAT does not support migrating existing Azure tenants to JWCC billing, user needs to see an alert when CSP is Azure.