### PR TITLE
Bugfix/at 9703 step4 no description

### DIFF
--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -1263,7 +1263,6 @@ export class SummaryStore extends VuexModule {
     const prevContracts = currentContracts?.length === 1
       ? `${currentContracts?.length} previous contract:\n${contractNumbers}`
       : `${currentContracts?.length} previous contracts:\n${contractNumbers}`
-    debugger
     const description = isTouched && currentContracts && currentContracts.length > 0?
       hasCurrentOrPreviousContract === "YES"
         ? prevContracts

--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -1263,9 +1263,8 @@ export class SummaryStore extends VuexModule {
     const prevContracts = currentContracts?.length === 1
       ? `${currentContracts?.length} previous contract:\n${contractNumbers}`
       : `${currentContracts?.length} previous contracts:\n${contractNumbers}`
-
-    const description = isTouched && currentContracts && currentContracts.length > 0
-      && currentContracts[0].contract_number ?
+    debugger
+    const description = isTouched && currentContracts && currentContracts.length > 0?
       hasCurrentOrPreviousContract === "YES"
         ? prevContracts
         : "No previous contracts"


### PR DESCRIPTION
Customer Impact: Users may become confused when the description details is blank.
Description: When "No" is selected on the Previous Contract page, the description is not being displayed

Steps to Reproduce:
In Step2 exception to fair opp, select the 1st, option/3rd option or none, continue the follow the workflow.
In step4, enter all the required fields in the “Let’s gather some details about your current contract” screen continue.
In the step4 Summary page, under Procurement History you''ll see the description details as blank.