### PR TITLE
feature/AT-9719-cloud-distinguisher

### DIFF
--- a/src/portfolios/provisioning/PortfolioDetails.spec.ts
+++ b/src/portfolios/provisioning/PortfolioDetails.spec.ts
@@ -1,0 +1,61 @@
+/* eslint-disable camelcase */
+import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
+import Vuetify from "vuetify";
+import { DefaultProps } from "vue/types/options";
+import Vue from "vue";
+import PortfolioDetails from "./PortfolioDetails.vue";
+import validators from "@/plugins/validation";
+import PortfolioStore, { CSPProvisioningData } from "@/store/portfolio";
+import OrganizationData from "@/store/organizationData";
+
+const mockCspProvisionData = [
+  {
+    name: 'Test1',
+    classification_level: 'U',
+    cloud_distinguisher: "CloudDistinguisher1"
+  },
+  {
+    name: 'Test2',
+    classification_level: 'U',
+    cloud_distinguisher: "CloudDistinguisher2"
+  },
+]
+
+describe("Testing PortfolioDetails Component", () => {
+  const localVue = createLocalVue();
+  localVue.use(validators);
+  let vuetify: Vuetify;
+  let wrapper: Wrapper<DefaultProps & Vue>;
+
+  beforeEach(() => {
+    vuetify = new Vuetify();
+    wrapper = mount(PortfolioDetails, {
+      localVue,
+      vuetify,
+    });
+  });
+  it("tests that component renders successfully", async () => {
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it("tests loadOnEnter with more than one unclass CSP", async () => {
+    const mockBuildILCheckbox = jest.spyOn(wrapper.vm, 'buildILCheckboxItems').mockImplementation()
+    jest.spyOn(OrganizationData, 'getAgencyData').mockImplementation()
+    await PortfolioStore.doSetCSPProvisioningData({
+      cspData: mockCspProvisionData as CSPProvisioningData[],
+      hasCloudDistinguishers: true
+    })
+    await wrapper.setData({CSPProvisioningData: mockCspProvisionData})
+    await wrapper.vm.loadOnEnter()
+    expect(mockBuildILCheckbox).toHaveBeenCalled()
+  });
+  it("tests showCheckBox", async () => {
+    await PortfolioStore.doSetCSPProvisioningData({
+      cspData: mockCspProvisionData as CSPProvisioningData[],
+      hasCloudDistinguishers: true
+    })
+    await wrapper.setData({checkBoxItems: mockCspProvisionData})
+
+    expect(wrapper.vm.showCheckbox).toBe(true)
+  });
+});

--- a/src/portfolios/provisioning/PortfolioDetails.vue
+++ b/src/portfolios/provisioning/PortfolioDetails.vue
@@ -106,8 +106,7 @@ export default class PortfolioDetails extends Mixins(SaveOnLeave) {
   }
 
   public async buildILCheckboxItems(): Promise<void> {
-    const cspData = PortfolioStore.CSPProvisioningData;
-    cspData.forEach(obj => {
+    this.CSPProvisioningData.forEach(obj => {
       if (obj.classification_level === "U" && obj.cloud_distinguisher) {
         const checkboxItem: Checkbox = {
           id: obj.cloud_distinguisher.name as string,
@@ -126,7 +125,7 @@ export default class PortfolioDetails extends Mixins(SaveOnLeave) {
   }
 
   public get showCheckbox():boolean {
-    return PortfolioStore.doesCSPHaveImpactLevels;
+    return PortfolioStore.doesCSPHaveImpactLevels && this.checkboxItems.length > 0;
   }
   public get currentData(): PortfolioProvisioning {
     return {
@@ -171,12 +170,13 @@ export default class PortfolioDetails extends Mixins(SaveOnLeave) {
   }
 
   public async loadOnEnter(): Promise<void> {
+    const unclassCSPs = this.CSPProvisioningData.filter((csp) => csp.classification_level === 'U')
     if (!OrganizationData.agency_data || OrganizationData.agency_data.length === 0) {
       await OrganizationData.getAgencyData();
     }
     this.agencyData = convertAgencyRecordToSelect(OrganizationData.agency_data); 
     await this.setTaskOrderData();
-    if (PortfolioStore.CSPHasImpactLevels) {
+    if (PortfolioStore.CSPHasImpactLevels && unclassCSPs.length > 1) {
       await this.buildILCheckboxItems();
     }
   }


### PR DESCRIPTION
[Ticket](https://ccpo.atlassian.net/browse/AT-9719?atlOrigin=eyJpIjoiZjNlMmIxZjExYmIxNDZhMzk4NTc0NTYyMjcyZWNjZTMiLCJwIjoiaiJ9)
AC: If a user is attempting to create a portfolio from a task order that only contains a single impact level in UNCLASSIFIED, they should not be asked to select ‘What impact level(s) do you need to provision?’ on the ‘Now, let’s gather details about your portfolio.' screen.