### PR TITLE
bugfix/AT-9704-step4-currentEnv-table

### DIFF
--- a/src/steps/03-Background/CurrentEnvironment/CurrentEnvironmentLocation.vue
+++ b/src/steps/03-Background/CurrentEnvironment/CurrentEnvironmentLocation.vue
@@ -169,12 +169,12 @@ export default class CurrentEnvironmentLocation extends Mixins(SaveOnLeave) {
     const instancesToDelete = this.envInstances.filter(
       obj => obj.instance_location === this.deleteInstanceType
     );
-    instancesToDelete.forEach(async (instance) => {
+    for (const instance of instancesToDelete) {
       if (instance.sys_id) {
         await CurrentEnvironment.deleteEnvironmentInstance(instance.sys_id);
         await CurrentEnvironment.clearEnvClassifications(this.deleteInstanceType);
       }
-    });
+    }
     this.showConfirmDialog = false;
     const instanceTypeDeleted = this.changeToEnv === "CLOUD" ? "On-premise" : "Cloud";
     this.instanceRemovedToast.message = instanceTypeDeleted + " instances deleted";

--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -207,7 +207,6 @@ export class SummaryStore extends VuexModule {
 
   @Mutation
   public doRemoveSummaryItem(step:number,subStep:number):void{
-    debugger
     const newSummaryItem = this.summaryItems
       .filter(item => item.step !== step && item.substep !== subStep)
     this.summaryItems = newSummaryItem
@@ -333,7 +332,6 @@ export class SummaryStore extends VuexModule {
     ${organization.city}, ${organization.state} ${organization.zip_code} ${organization?.country}`}
       : {address: "Missing Address"}
     const monitor = {object: organization, keysToIgnore};
-    debugger
     const organizationDetails: SummaryItem = {
       title,
       description,


### PR DESCRIPTION
In Step 4, create an environment flow for the Cloud Environment with multiple instances.
Navigate to the” Where is your Current Environment Located” Uncheck the cloud option, user will see a confirmation modal that all the instances will be removed.
continue the flow. in the Environment summary grid, User will see the environment instance that were created for cloud. the existing instance remain in the gris.
Actual Result: All the existing instance remains visible in the grid and is not being deleted in the current environment summary & Background summary page under current environment.
Expected Result: All the instances should be removed from the current environment summary grid and should update in the background summary page