### PR TITLE
hotfix - enable continue

### DIFF
--- a/src/action-handlers/index.ts
+++ b/src/action-handlers/index.ts
@@ -166,6 +166,7 @@ async function startNewPortfolio(): Promise<void> {
   if (packageCount && (!acqPkgSysId || showPackageSelection)) {
     routeName = provWorkflowRouteNames.GeneratedFromPackage;
   }
+  AcquisitionPackage.setDisableContinue(false);
 
   router.push({
     name: routeName,


### PR DESCRIPTION
Changed logic to enable continue button if skipping existing portfolio page when user HAS existing ACTIVE portfolios, and NO acquisition packages in "waiting for task order" status