### PR TITLE
feature/AT-9714-Wrap-up-section-step-7-fix

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -440,7 +440,7 @@ export const TravelRouteResolver = (current: string): string => {
 }
 
 export const PIIResolver = (current: string): string =>{
-
+  Summary.setHasCurrentStepBeenVisited(isStepTouched(7))
   return current === routeNames.SummaryStepSix
     ? Summary.hasCurrentStepBeenVisited ? routeNames.SummaryStepSeven : routeNames.PII
     : routeNames.SummaryStepSix


### PR DESCRIPTION
Create a new acquisition and proceed to complete steps 2, 3, 4, and 5.
Next, click on Step 1 and follow the workflow. Upon completing Step 1, click on "Continue." The expected behavior is for the user to be directed to the Step 2 summary page, given that Step 2 has been completed. However, the actual behavior is that the system loops through all the pages within Step 2.
Similarly, when clicking on the "Wrap-up This Section" button on the Step 2 summary page, the intended outcome is for the user to be taken to the Step 3 summary page, since Step 3 has been interacted with. the actual behavior is that the system loops through all the pages within Step 3.