### PR TITLE
bugfix/AT-9756-IL-checkboxes

### DIFF
--- a/src/store/portfolio/index.ts
+++ b/src/store/portfolio/index.ts
@@ -193,7 +193,7 @@ export class PortfolioDataStore extends VuexModule {
         const csp: CSPProvisioningData = { 
           name: obj.name, 
           classification_level: obj.classification_level,
-          cloud_distinguisher: {} 
+          cloud_distinguisher: undefined
         };
         const cd = obj.cloud_distinguisher;
         if (cd && cd.length) {


### PR DESCRIPTION
Bug causing the issue was an unclass csp with no cloud distinguisher data was created. By setting the cloud_distinguisher to an empty object when the checkboxes were created in the image below, even though the data wasnt there the empty object passes a null/undefined check causing issues later in the data path with checkboxItem object.
![image](https://github.com/dod-ccpo/atat-web-ui/assets/139161354/6279d576-1382-48a4-a284-8d98725d02c5)

This change to initializing it as undefined saves us from this happening again. 
![image](https://github.com/dod-ccpo/atat-web-ui/assets/139161354/ce180591-10f6-49dc-b364-225a46c06447)