### PR TITLE
CD update to address missing PR SHA build variable for VERSION variable.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           VERSION: ${{ steps.previoustag.outputs.tag }}
       - name: Set Version Variable - Non-release
-        run: echo "VERSION=$(git rev-parse --short "${{ github.event.pull_request.head.sha }}")" >> $GITHUB_ENV
+        run: echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       - name: Setup NodeJS
         uses: actions/setup-node@v3


### PR DESCRIPTION
Fixed non-release version number population to point to HEAD instead of empty PR SHA.