### PR TITLE
bugfix/constant-truthy-on-the-left-ACORS-name

### DIFF
--- a/src/components/ATATSummaryItem.vue
+++ b/src/components/ATATSummaryItem.vue
@@ -24,6 +24,48 @@
               <template v-slot:content>
                 <div class="d-flex">
                   <div>
+                    <div v-if="
+                      item.showMoreData.name
+                    " class="d-flex align-start my-3">
+                      <ATATSVGIcon
+                        width="20"
+                        height="20"
+                        name="person"
+                        color="base-light"/>
+                      <span
+                        class="text-base ml-2"
+                        :class="[{'text-error': checkMissing(item.showMoreData.name)}]">
+                          {{item.showMoreData.name}}
+                      </span>
+                    </div>
+                    <div v-if="
+                      item.showMoreData.first_name && !item.showMoreData.name
+                    " class="d-flex align-start my-3">
+                      <ATATSVGIcon
+                        width="20"
+                        height="20"
+                        name="person"
+                        color="base-light"/>
+                      <span
+                        class="text-base ml-2"
+                        :class="[{'text-error': checkMissing(item.showMoreData.first_name)}]">
+                          {{item.showMoreData.first_name}}
+                      </span>
+                    </div>
+                    <div v-if="
+                      item.showMoreData.last_name && !item.showMoreData.name
+                    " class="d-flex align-start my-3">
+                      <ATATSVGIcon
+                        width="20"
+                        height="20"
+                        name="person"
+                        color="base-light"/>
+                      <span
+                        class="text-base ml-2"
+                        :class="[{'text-error': checkMissing(item.showMoreData.last_name)}]">
+                          {{item.showMoreData.last_name}}
+                      </span>
+                    </div>
                     <div v-if="item.showMoreData.address" class="d-flex align-start my-3">
                       <ATATSVGIcon
                         width="20"
@@ -34,7 +76,7 @@
                         class="text-base ml-2"
                         :class="[{'text-error': checkMissing(item.showMoreData.address)}]">
                           {{item.showMoreData.address}}
-                  </span>
+                      </span>
                     </div>
                     <div v-if="item.showMoreData.email" class="d-flex align-center my-3">
                       <ATATSVGIcon
@@ -217,7 +259,7 @@
     <ATATDialog
       id="RemoveMemberModal"
       :showDialog="showRemoveAcor"
-      :title="'Remove ' + ACORName +' ?'"
+      :title="'Remove ' + ACORName +'?'"
       no-click-animation
       okText="Delete ACOR"
       width="450"
@@ -268,9 +310,10 @@ export default class ATATSummaryItem extends Vue {
     this.showRemoveAcor = true;
   }
   public get ACORName():string {
-    return (AcquisitionPackage.acorInfo?.first_name && AcquisitionPackage.acorInfo?.last_name) ? 
-      `${AcquisitionPackage.acorInfo?.first_name}  ${AcquisitionPackage.acorInfo?.last_name}` :
-      "undefined"
+    return (AcquisitionPackage.acorInfo?.first_name || AcquisitionPackage.acorInfo?.last_name) ? 
+      `${AcquisitionPackage.acorInfo?.first_name}  ${AcquisitionPackage.acorInfo?.last_name}`
+        .trim() :
+      "Alternate Contracting Officer's Representative"
   }
   public get hasAcor():boolean {
     return AcquisitionPackage.hasAlternativeContactRep || false

--- a/src/components/ATATSummaryItem.vue
+++ b/src/components/ATATSummaryItem.vue
@@ -268,8 +268,9 @@ export default class ATATSummaryItem extends Vue {
     this.showRemoveAcor = true;
   }
   public get ACORName():string {
-    return `${AcquisitionPackage.acorInfo?.first_name}  ${AcquisitionPackage.acorInfo?.last_name}`
-      || "undefined"
+    return (AcquisitionPackage.acorInfo?.first_name && AcquisitionPackage.acorInfo?.last_name) ? 
+      `${AcquisitionPackage.acorInfo?.first_name}  ${AcquisitionPackage.acorInfo?.last_name}` :
+      "undefined"
   }
   public get hasAcor():boolean {
     return AcquisitionPackage.hasAlternativeContactRep || false

--- a/src/steps/01-AcquisitionPackageDetails/SummaryStepOne.spec.ts
+++ b/src/steps/01-AcquisitionPackageDetails/SummaryStepOne.spec.ts
@@ -1,0 +1,54 @@
+import Vue from "vue";
+import Vuetify from "vuetify";
+import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
+import { DefaultProps } from "vue/types/options";
+import SummaryStepOne from "@/steps/01-AcquisitionPackageDetails/SummaryStepOne.vue"
+import Summary, * as SummaryExportedFunctions from "@/store/summary";
+
+Vue.use(Vuetify);
+
+describe("Testing SummaryStepOne Component", () => {
+  const localVue = createLocalVue();
+  let vuetify: Vuetify;
+  let wrapper: Wrapper<DefaultProps & Vue, Element>;
+
+  beforeEach(() => {
+    vuetify = new Vuetify();
+    wrapper = mount(SummaryStepOne, {
+      vuetify,
+      localVue
+    });
+  });
+
+  describe("testing SummaryStepOne render", () => {
+    it("renders successfully", async () => {
+      expect(wrapper.exists()).toBe(true);
+    });
+  })
+
+  describe("GETTERS", () => {
+    describe("introParagraph()=> ", () => {
+      it("returns `We need some more details` statement", async () => {
+        jest.spyOn(SummaryExportedFunctions,"isStepComplete").mockReturnValueOnce(false);
+        wrapper.vm.setIntroParagraph()
+        expect(wrapper.vm.$data.introParagraph).toContain("We need some more details");
+      });
+      it("returns `You are all done` statement", async () => {
+        jest.spyOn(SummaryExportedFunctions,"isStepComplete").mockReturnValueOnce(true);
+        wrapper.vm.setIntroParagraph()
+        expect(wrapper.vm.$data.introParagraph).toContain("You are all done");
+      });
+    })
+  })
+
+  describe("FUNCTIONS", () => {
+    it("saveOnLeave()=> expect function to be called", async () => {
+      const toggleButtonColorMock = jest.spyOn(Summary, "toggleButtonColor").mockImplementation(
+        ()=> Promise.resolve()
+      );
+      await wrapper.vm.saveOnLeave();
+      expect(toggleButtonColorMock).toHaveBeenCalled();
+    });
+  })
+
+})

--- a/src/steps/01-AcquisitionPackageDetails/SummaryStepOne.spec.ts
+++ b/src/steps/01-AcquisitionPackageDetails/SummaryStepOne.spec.ts
@@ -2,53 +2,54 @@ import Vue from "vue";
 import Vuetify from "vuetify";
 import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import { DefaultProps } from "vue/types/options";
-import SummaryStepOne from "@/steps/01-AcquisitionPackageDetails/SummaryStepOne.vue"
+import SummaryStepOne from "@/steps/01-AcquisitionPackageDetails/SummaryStepOne.vue";
 import Summary, * as SummaryExportedFunctions from "@/store/summary";
 
 Vue.use(Vuetify);
 
 describe("Testing SummaryStepOne Component", () => {
   const localVue = createLocalVue();
-  let vuetify: Vuetify;
-  let wrapper: Wrapper<DefaultProps & Vue, Element>;
-
-  beforeEach(() => {
-    vuetify = new Vuetify();
-    wrapper = mount(SummaryStepOne, {
-      vuetify,
-      localVue
-    });
+  
+  const vuetify: Vuetify = new Vuetify();
+  const wrapper: Wrapper<DefaultProps & Vue, Element> = mount(SummaryStepOne, {
+    vuetify,
+    localVue,
   });
 
   describe("testing SummaryStepOne render", () => {
     it("renders successfully", async () => {
       expect(wrapper.exists()).toBe(true);
     });
-  })
+  });
 
   describe("GETTERS", () => {
     describe("introParagraph()=> ", () => {
       it("returns `We need some more details` statement", async () => {
-        jest.spyOn(SummaryExportedFunctions,"isStepComplete").mockReturnValueOnce(false);
-        wrapper.vm.setIntroParagraph()
-        expect(wrapper.vm.$data.introParagraph).toContain("We need some more details");
+        jest
+          .spyOn(SummaryExportedFunctions, "isStepComplete")
+          .mockReturnValueOnce(false);
+        wrapper.vm.setIntroParagraph();
+        expect(wrapper.vm.$data.introParagraph).toContain(
+          "We need some more details"
+        );
       });
       it("returns `You are all done` statement", async () => {
-        jest.spyOn(SummaryExportedFunctions,"isStepComplete").mockReturnValueOnce(true);
-        wrapper.vm.setIntroParagraph()
+        jest
+          .spyOn(SummaryExportedFunctions, "isStepComplete")
+          .mockReturnValueOnce(true);
+        wrapper.vm.setIntroParagraph();
         expect(wrapper.vm.$data.introParagraph).toContain("You are all done");
       });
-    })
-  })
+    });
+  });
 
   describe("FUNCTIONS", () => {
     it("saveOnLeave()=> expect function to be called", async () => {
-      const toggleButtonColorMock = jest.spyOn(Summary, "toggleButtonColor").mockImplementation(
-        ()=> Promise.resolve()
-      );
+      const toggleButtonColorMock = jest
+        .spyOn(Summary, "toggleButtonColor")
+        .mockImplementation(() => Promise.resolve());
       await wrapper.vm.saveOnLeave();
       expect(toggleButtonColorMock).toHaveBeenCalled();
     });
-  })
-
-})
+  });
+});

--- a/src/store/summary/index.spec.ts
+++ b/src/store/summary/index.spec.ts
@@ -1,0 +1,207 @@
+/* eslint-disable camelcase */
+
+import Vuex, { Store } from 'vuex';
+import { createLocalVue } from "@vue/test-utils";
+import AcquisitionPackage from "@/store/acquisitionPackage";
+import  { SummaryStore } from "../summary/index";
+import { getModule } from 'vuex-module-decorators';
+import validators from "../../plugins/validation";
+import { ContactDTO } from "@/api/models";
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+localVue.use(validators);
+
+const _summaryItem = {
+  title: "",
+  description: "",
+  isComplete: false,
+  isTouched: false,
+  hasDelete:false,
+  hasShowMore:false,
+  routeName: "",
+  step: 0,
+  substep: 0
+}
+
+const contactAcorValid: ContactDTO = {
+  type: 'ACOR', // Mission Owner, COR, ACOR
+  role: 'Military', // Military, Civilian, Contractor
+  rank_components: '',
+  salutation: '',
+  first_name: 'John',
+  last_name: 'Smith',
+  middle_name: 'T',
+  suffix: '',
+  title: '',
+  phone: '555-555-1234',
+  phone_extension: '1234',
+  email: 'john.smith.tester@mail.mil',
+  grade_civ: '',
+  dodaac: '',
+  can_access_package: '',
+  manually_entered: '',
+  acquisition_package: '',
+}
+
+const contactAcorMissingFullName: Partial<ContactDTO> = {
+  type: 'ACOR', // Mission Owner, COR, ACOR
+  role: 'Military', // Military, Civilian, Contractor
+  rank_components: '',
+  salutation: '',
+  middle_name: 'T',
+  suffix: '',
+  title: '',
+  phone: '555-555-1234',
+  phone_extension: '1234',
+  email: 'john.smith.tester@mail.mil',
+  grade_civ: '',
+  dodaac: '',
+  can_access_package: '',
+  manually_entered: '',
+  acquisition_package: '',
+}
+
+const contactAcorMissingFirstName: Partial<ContactDTO> = {
+  type: 'ACOR', // Mission Owner, COR, ACOR
+  role: 'Military', // Military, Civilian, Contractor
+  rank_components: '',
+  salutation: '',
+  middle_name: 'T',
+  suffix: '',
+  title: '',
+  first_name: 'John',
+  phone: '555-555-1234',
+  phone_extension: '1234',
+  email: 'john.smith.tester@mail.mil',
+  grade_civ: '',
+  dodaac: '',
+  can_access_package: '',
+  manually_entered: '',
+  acquisition_package: '',
+}
+
+describe("Summary Store", () => {
+  let summaryStore: SummaryStore;
+
+  beforeEach(async () => {
+    const createStore = (
+      storeOptions = {}
+    ): Store<{ summaryStore: SummaryStore['summaryItems'] }> => (
+      new Vuex.Store({ ...storeOptions })
+    );
+    summaryStore = getModule(SummaryStore, createStore());
+
+    AcquisitionPackage.reset();
+    await summaryStore.clearSummaryItems();
+  })
+  afterEach(async () => {
+    jest.clearAllMocks();
+    jest.clearAllTimers();
+  })
+
+  it('Test summary item manipulation functions, clear + set + remove', async () => {
+    // clear
+    await summaryStore.clearSummaryItems();
+    expect(summaryStore.summaryItems).toEqual([]);
+    // set
+    await summaryStore.doSetSummaryItem(_summaryItem);
+    expect(summaryStore.summaryItems).toEqual([_summaryItem]);
+    // remove
+    summaryStore.removeSummaryItem(_summaryItem);
+    expect(summaryStore.summaryItems).toEqual([]);
+  })
+
+  it('Test assessACOR function - Valid data', async () => {
+    expect(summaryStore.summaryItems).toEqual([]);
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([]);
+    AcquisitionPackage.setHasAlternateCOR(true);
+    AcquisitionPackage.setContact({ data: contactAcorValid, type: "ACOR"});
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([
+      {
+        "description": "Alternate Contracting Officer's Representative",
+        "hasDelete": true,
+        "hasShowMore": true,
+        "isComplete": false,
+        "isTouched": true,
+        "routeName": "AcorInformation",
+        "showMoreData": {
+          "address": "",
+          "dodaac": "Missing DoDAAC",
+          "email": "john.smith.tester@mail.mil",
+          "phone": "555-555-1234",
+          "role": "Military",
+        },
+        "step": 1,
+        "substep": 5,
+        "title": "John Smith",
+      },
+    ]);
+  });
+
+  it('Test assessACOR function - Missing full name data', async () => {
+    expect(summaryStore.summaryItems).toEqual([]);
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([]);
+    AcquisitionPackage.setHasAlternateCOR(true);
+    // @ts-expect-error we're testing for when the data is incomplete
+    AcquisitionPackage.setContact({ data: contactAcorMissingFullName, type: "ACOR"});
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([
+      {
+        "description": "Alternate Contracting Officer's Representative",
+        "hasDelete": true,
+        "hasShowMore": true,
+        "isComplete": false,
+        "isTouched": true,
+        "routeName": "AcorInformation",
+        "showMoreData": {
+          "address": "",
+          "dodaac": "Missing DoDAAC",
+          "email": "john.smith.tester@mail.mil",
+          "name": "Missing name",
+          "phone": "555-555-1234",
+          "role": "Military",
+        },
+        "step": 1,
+        "substep": 5,
+        "title": "Alternate Contracting Officer's Representative",
+      },
+    ]);
+  });
+
+  it('Test assessACOR function - Missing first name data', async () => {
+    expect(summaryStore.summaryItems).toEqual([]);
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([]);
+    AcquisitionPackage.setHasAlternateCOR(true);
+    // @ts-expect-error we're testing for when the data is incomplete
+    AcquisitionPackage.setContact({ data: contactAcorMissingFirstName, type: "ACOR"});
+    await summaryStore.assessACOR();
+    expect(summaryStore.summaryItems).toEqual([
+      {
+        "description": "Alternate Contracting Officer's Representative",
+        "hasDelete": true,
+        "hasShowMore": true,
+        "isComplete": false,
+        "isTouched": true,
+        "routeName": "AcorInformation",
+        "showMoreData": {
+          "address": "",
+          "dodaac": "Missing DoDAAC",
+          "email": "john.smith.tester@mail.mil",
+          "last_name": "Missing last name",
+          "phone": "555-555-1234",
+          "role": "Military",
+        },
+        "step": 1,
+        "substep": 5,
+        "title": "Alternate Contracting Officer's Representative",
+      },
+    ]);
+  });
+})
+
+

--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -465,6 +465,14 @@ export class SummaryStore extends VuexModule {
         dodaac:contactInfo.dodaac ? `DoDAAC - ${contactInfo.dodaac}` : "Missing DoDAAC",
         role:contactInfo.role || "Missing role"
       }
+      // first_name && last_name will only show in "Show more" if they're missing
+      // since they're already included in the title when they're present
+      if (!contactInfo.first_name && !contactInfo.last_name) {
+        showMoreData['name'] = "Missing name"
+      } else {
+        if (!contactInfo.first_name) showMoreData['first_name'] = "Missing first name"
+        if (!contactInfo.last_name) showMoreData['last_name'] = "Missing last name"
+      }
       title =contactInfo.first_name && contactInfo.last_name?
         `${contactInfo.first_name} ${contactInfo.last_name}`
         : "Alternate Contracting Officer's Representative"


### PR DESCRIPTION
``` ts
`${a} ${b}` || c
```
"c" will never be used since when a + b are undefined, the string is still " " <- a space, instead of an empty string
So I changed it to:
``` ts
(a && b) ? `${a} ${b}` : c
```
Note: My assumption is that if "a" is undefined and "b" is defined (or vice versa) we want to show "c" still. This could be a bad assumption, so if we want one to still display if the other is undefined, lmk and I'll make it so.

