### PR TITLE
bugfix/constant-truthy-on-the-left-DoDAAC

### DIFF
--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -462,7 +462,7 @@ export class SummaryStore extends VuexModule {
         address:"",
         email:contactInfo.email || "Missing email address",
         phone:contactInfo.phone || "Missing phone number",
-        dodaac:`DoDAAC - ${contactInfo.dodaac}` || "Missing DoDAAC",
+        dodaac:contactInfo.dodaac ? `DoDAAC - ${contactInfo.dodaac}` : "Missing DoDAAC",
         role:contactInfo.role || "Missing role"
       }
       title =contactInfo.first_name && contactInfo.last_name?


### PR DESCRIPTION
``` ts
`a ${b}` || c
```
c will never be used since when b is undefined, the string is still "a ", which is not falsy
So I changed it to:
``` ts
b ? `a ${b}` : c
```