### PR TITLE
bugfix/promise-returned-in-foreach-documentReview

### DIFF
--- a/src/documentReview/Index.vue
+++ b/src/documentReview/Index.vue
@@ -157,7 +157,7 @@ export default class DocumentReview extends Mixins(SaveOnLeave){
 
   protected async saveOnLeave(): Promise<boolean> {
     await this.hasChanged();
-    this.docDataSectionsToSave.forEach(async(section)=>{
+    await Promise.all(this.docDataSectionsToSave.map(async(section)=>{
       switch(section) {
       case "projectOverview":
         await AcquisitionPackage.saveData({
@@ -202,7 +202,7 @@ export default class DocumentReview extends Mixins(SaveOnLeave){
       default:
         break;
       }
-    });
+    }))
     return true;
   }
 }


### PR DESCRIPTION
`This is a SonarCloud bug fix`

Changed .forEach to .map with Promise.all in documentReview/saveOnLeave

.forEach is not designed to handle async/promises, using it with promises makes the intended async handling ambiguous I changed it to await Promise.all assuming that we do want to wait for the promises to be fulfilled. The async functions inside the forEach are all individually awaited, but the main function passed to forEach is async, making it return a promise, which is then not awaited.