### PR TITLE
bugfix/AT-9911 Fix Release Version Number

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,13 +61,11 @@ jobs:
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
       - name: Set Version Variable - Release
-        uses: "WyriHaximus/github-action-get-previous-tag@v1"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }} 
-        env:
-          VERSION: ${{ steps.previoustag.outputs.tag }}
+        run: echo "VERSION=${{ steps.previoustag.outputs.tag }}" >> $GITHUB_ENV
       - name: Set Version Variable - Non-release
+        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}  
         run: echo "VERSION=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
       - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Simplified workflow to:
1. Call GH Action for getting previous tag
2. Setting Release version using output from #1
3. Setting version if not associated with a release

If running on a release, `VERSION` has been added to `app-js.html` according to the latest release tag.
![image](https://github.com/dod-ccpo/atat-web-ui/assets/77513554/93f3eb77-cf6e-40e1-a8c1-26cb0f8f03b6)
