### PR TITLE
bugfix/9830-searchOrder-function-name

### DIFF
--- a/src/api/gInvoicing/index.spec.ts
+++ b/src/api/gInvoicing/index.spec.ts
@@ -64,7 +64,7 @@ describe("GInvoicingApi ", () => {
           acquisitionPackageId: packageId 
         }
       }).reply(200, { result: "Order valid" });
-      const data = await ginvoicingApi.search(orderNumber, packageId);
+      const data = await ginvoicingApi.searchOrder(orderNumber, packageId);
       expect(data).toEqual(expectedResponse);
     });
   

--- a/src/api/gInvoicing/index.ts
+++ b/src/api/gInvoicing/index.ts
@@ -42,7 +42,7 @@ export class GInvoicingApi extends ApiBase{
     return response;
   }
 
-  public async search(orderNumber: string, acqPackageId: string): Promise<GInvoicingResponse> {
+  public async searchOrder(orderNumber: string, acqPackageId: string): Promise<GInvoicingResponse> {
     let response: GInvoicingResponse = {
       valid: true,
       message:""

--- a/src/components/ATATSearch.spec.ts
+++ b/src/components/ATATSearch.spec.ts
@@ -324,7 +324,7 @@ describe("Testing ATATSearch Component", () => {
           gInvoicingSearchType: "OrderNumber",
         })
 
-        jest.spyOn(api.gInvoicingApi, 'search').mockImplementation(() => { throw Error })
+        jest.spyOn(api.gInvoicingApi, 'searchOrder').mockImplementation(() => { throw Error })
 
         try {
           wrapper.vm.search();


### PR DESCRIPTION
This fixes a function name issue with the order number search, relating to AT-9830 and AT-9831