### PR TITLE
PR 2044 - bugfix/step-8-navigation-and-cost-estimate

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --no-cache --watch /src/router/resolvers/__test__/index.spec.ts",
+    "test-file:watch": "jest --no-cache --watch /src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.spec.ts",
     "test-files": "jest --no-cache src/steps/03-Background/components/",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",

--- a/src/router/resolvers/index.spec.ts
+++ b/src/router/resolvers/index.spec.ts
@@ -4,17 +4,24 @@ import DescriptionOfWork from "@/store/descriptionOfWork";
 import Periods from "@/store/periods";
 import {
   AcorsRouteResolver,
-  BVTOResolver,
   EvalPlanDetailsRouteResolver,
-  CurrentlyHasFundingResolver, GTCInformationResolver, Upload7600Resolver, MIPRResolver
+  CurrentlyHasFundingResolver, 
+  GTCInformationResolver, 
+  Upload7600Resolver, 
+  MIPRResolver, 
+  IGCESupportingDocumentationResolver,
+  AppropriationOfFundsResolver,
+  SeverabilityAndIncrementalFundingResolver,
+  
 } from "./index"
-import { routeNames } from "@/router/stepper"
+import * as ExportedResolverFunctions from "./index";
+import { routeNames } from "@/router/stepper";
 import Vue from "vue";
 import EvaluationPlan from "@/store/acquisitionPackage/evaluationPlan";
 import Summary from "@/store/summary";
 import FinancialDetails from "@/store/financialDetails";
 import {FundingRequirementDTO} from "@/api/models";
-
+import { isStepComplete } from "../../store/summary/index";
 
 const acquisitionPackage = {
   acor: "",
@@ -59,11 +66,17 @@ const fundingReq: FundingRequirementDTO = {
   pop_start_date: "",
   task_order_number: ""
 };
-jest.mock('@/store/summary', () => ({
-  Summary: {
-    hasCurrentStepBeenVisited: false,
-  },
-}));
+const summaryItem = {
+  title:"",
+  description:"",
+  isComplete:true,
+  isTouched:false,
+  hasDelete:false,
+  hasShowMore:false,
+  routeName:"",
+  step:0,
+  substep:0
+}
 
 describe("testing route resolvers", () => {
   afterEach(()=>{
@@ -101,148 +114,272 @@ describe("testing route resolvers", () => {
     });
   });
 
+  describe("RequirementCostEstimates Resolvers", () => {
+    describe('IGCESupportingDocumentationResolver()', () => {
+      
+      const POPSummaryItem = {
+        ...summaryItem,
+        "step":3,
+        "substep":1
+      }
+      const DOWSummaryItem = {
+        ...summaryItem,
+        "step":5,
+      }
+      Summary.doSetSummaryItem(POPSummaryItem);
+      Summary.doSetSummaryItem(DOWSummaryItem)
+     
+      it('returns SupportingDocumentation if current is EstimatesDeveloped', async () =>
+      {
+        expect(IGCESupportingDocumentationResolver(routeNames.EstimatesDeveloped))
+          .toBe(routeNames.SupportingDocumentation)
+      }
+      );
+
+      it('returns SupportingDocumentation if current is '
+         + 'SeverabilityAndIncrementalFunding && (isSubStepComplete(3,1) && '
+         + 'isStepComplete(5)) ', async () =>
+      {
+        expect(IGCESupportingDocumentationResolver(
+          routeNames.SeverabilityAndIncrementalFunding
+        )).toBe(routeNames.SupportingDocumentation)
+      }
+      );
+
+      it('returns Cannot Proceed if current is '
+      + 'SeverabilityAndIncrementalFunding && !(isSubStepComplete(3,1) && '
+      + 'isStepComplete(5)) ', async () =>
+      {
+        DOWSummaryItem.isComplete = false;
+        POPSummaryItem.isComplete = false;
+        expect(IGCESupportingDocumentationResolver(
+          routeNames.SeverabilityAndIncrementalFunding
+        )).toBe(routeNames.CannotProceed)
+      });
+    })
+
+    describe('AppropriationOfFundsResolver()', () => {
+      let RCESummaryItem = summaryItem;
+      beforeEach(()=>{
+        RCESummaryItem = {
+          ...summaryItem,
+          "step":8,
+          "isTouched": true
+        }
+        Summary.doSetSummaryItem(RCESummaryItem);
+      })
+      
+      it('returns SummaryStepEight if (StepHasBeenVisited && if current === '
+          + 'routeNames.SeverabilityAndIncrementalFunding) ', async () =>{
+        expect(AppropriationOfFundsResolver(
+          routeNames.SeverabilityAndIncrementalFunding
+        )).toBe(routeNames.SummaryStepEight)
+      });
+
+      it('returns SeverabilityAndIncrementalFunding if (!StepHasBeenVisited && '
+      + 'if current === routeNames.SeverabilityAndIncrementalFunding) ', async () =>{
+        RCESummaryItem.isTouched = false;
+        expect(AppropriationOfFundsResolver(
+          routeNames.SeverabilityAndIncrementalFunding
+        )).toBe(routeNames.SeverabilityAndIncrementalFunding)
+      });
+
+      it('returns AppropriationOfFunds if hasExceptionToFairOpp', async () =>{
+        AcquisitionPackage.doSetFairOpportunity({
+          exception_to_fair_opportunity: "C"
+        })
+        expect(AppropriationOfFundsResolver(routeNames.EstimatesDeveloped))
+          .toBe(routeNames.AppropriationOfFunds)
+      });
+
+      it('returns SummaryStepEight if !hasExceptionToFairOpp', async () =>{
+        AcquisitionPackage.doSetFairOpportunity({
+          exception_to_fair_opportunity: "NO_NONE"
+        })
+        expect(AppropriationOfFundsResolver(routeNames.EstimatesDeveloped))
+          .toBe(routeNames.SummaryStepEight)
+      });
+    })
+
+    describe('SeverabilityAndIncrementalFundingResolver()', () => {
+      let RCESummaryItem = summaryItem;
+      beforeEach(()=>{
+        RCESummaryItem = {
+          ...summaryItem,
+          "step":8,
+          "isTouched": true
+        }
+        Summary.doSetSummaryItem(RCESummaryItem);
+      })
+      
+      it('returns SummaryStepEight if Summary.hasCurrentStepBeenVisited && '
+          +'current === routeNames.AppropriationOfFunds', async () =>{
+        expect(SeverabilityAndIncrementalFundingResolver(
+          routeNames.AppropriationOfFunds
+        )).toBe(routeNames.SummaryStepEight)
+      });
+
+      it('returns SummaryStepEight if Summary.hasCurrentStepBeenVisited && '
+          +'current !== routeNames.AppropriationOfFunds', async () =>{
+        
+        expect(SeverabilityAndIncrementalFundingResolver(
+          'Some Different Route'
+        )).toBe(routeNames.SeverabilityAndIncrementalFunding)
+      });
+    })
+  })
+
   describe("FundingStep Resolvers", () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      acquisitionPackage.contracting_shop_require_funding_documents_for_submission_of_package = '';
-      acquisitionPackage.contracting_shop = '';
-      Summary.hasCurrentStepBeenVisited = false;
+    describe("CurrentlyHasFundingResolver()", () => {
+      let RCESummaryItem = summaryItem;
+    
+      beforeEach(() => {
+        jest.clearAllMocks();
+        // eslint-disable-next-line max-len
+        acquisitionPackage.contracting_shop_require_funding_documents_for_submission_of_package = '';
+        acquisitionPackage.contracting_shop = '';
+        RCESummaryItem = {
+          ...summaryItem,
+          "step":8,
+          "isTouched": true
+        }
+        Summary.doSetSummaryItem(RCESummaryItem);
+      });
+
+      it('returns SummaryStepEight when current is RFD and doesNotNeedFundingDoc is true',
+        async () => {
+          // eslint-disable-next-line max-len
+          acquisitionPackage.contracting_shop_require_funding_documents_for_submission_of_package="NO";
+          await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
+          expect(CurrentlyHasFundingResolver(routeNames.RFD))
+            .toBe(routeNames.SummaryStepEight);
+        });
+
+      it('returns SummaryStepEight when hasCurrentStepBeenVisited is true', () => {
+        
+        expect(CurrentlyHasFundingResolver('any-other-route'))
+          .toBe(routeNames.CurrentlyHasFunding);
+      });
+
+      it('returns CurrentlyHasFunding when user is not a DITCO user', async () => {
+        await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
+        expect(CurrentlyHasFundingResolver('any-other-route'))
+          .toBe(routeNames.CurrentlyHasFunding);
+      });
+
+      it('returns RFD when user is a DITCO user', async () => {
+        acquisitionPackage.contracting_shop = "DITCO";
+        await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
+        const result = CurrentlyHasFundingResolver('any-other-route');
+        expect(result).toBe(routeNames.CurrentlyHasFunding);
+      });
     });
 
-    it('should return SummaryStepEight when current is RFD and doesNotNeedFundingDoc is true',
-      async () => {
-        // eslint-disable-next-line max-len
-        acquisitionPackage.contracting_shop_require_funding_documents_for_submission_of_package="NO";
-        await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
-        const result = CurrentlyHasFundingResolver(routeNames.RFD);
+    
+    describe('GTCInformationResolver', () => {
+      beforeEach(() => {
+        FinancialDetails.setHasFunding('');
+      });
+
+      it('should return GTC route if FinancialDetails has funding', async () => {
+        await FinancialDetails.setHasFunding("HAS_FUNDING");
+        const result = GTCInformationResolver('anyRoute');
+        expect(result).toBe(routeNames.GTC);
+      });
+
+      it('should return GeneratingPackageDocumentsFunding if current route is not ' +
+        'GeneratingPackageDocumentsFunding and no funding', async () => {
+        await FinancialDetails.setHasFunding("HAS_FUNDING");
+        const result = GTCInformationResolver(routeNames.CurrentlyHasFunding);
+        expect(result).toBe(routeNames.GeneratingPackageDocumentsFunding);
+      });
+
+      it('should return CurrentlyHasFunding if current route is ' +
+        'GeneratingPackageDocumentsFunding and no funding', () => {
+        const result = GTCInformationResolver(routeNames.CurrentlyHasFunding);
+        expect(result).toBe(routeNames.GeneratingPackageDocumentsFunding);
+      });
+    });
+
+    describe('MIPRResolver', () => {
+      beforeEach(() => {
+        FinancialDetails.setHasFunding('');
+        FinancialDetails.setFundingRequirement(fundingReq);
+        FinancialDetails.setFundingRequest({ funding_request_type: '' })
+      });
+
+      it('should return CurrentlyHasFunding route if FinancialDetails has no funding and' +
+        ' current page is GeneratingPackageDocsFunding', async () => {
+        await FinancialDetails.setHasFunding("NO_FUNDING");
+        const result = MIPRResolver(routeNames.GeneratingPackageDocumentsFunding);
+        expect(result).toBe(routeNames.CurrentlyHasFunding);
+      });
+
+      it('should return MIPR route if fundingType is MIPR', async () => {
+        const fundingRequest = { funding_request_type: 'MIPR' };
+        FinancialDetails.setFundingRequest(fundingRequest);
+        const result = MIPRResolver('anyRoute');
+        expect(result).toBe(routeNames.MIPR);
+      });
+
+      it('should return SummaryStepEight route if fundingType is FS_FORM', async () => {
+        const fundingRequest = { funding_request_type: 'FS_FORM' };
+        FinancialDetails.setFundingRequest(fundingRequest);
+        const result = MIPRResolver('anyRoute');
         expect(result).toBe(routeNames.SummaryStepEight);
       });
 
-    it('should return SummaryStepEight when hasCurrentStepBeenVisited is true', () => {
-      Summary.hasCurrentStepBeenVisited = true;
-      const result = CurrentlyHasFundingResolver('any-other-route');
-      expect(result).toBe(routeNames.CurrentlyHasFunding);
+      it('should return FundingPlanType route if routing from GTC page', async () => {
+        const result = MIPRResolver(routeNames.GTC);
+        expect(result).toBe(routeNames.FundingPlanType);
+      });
+
+      it('should return GTC route if no other conditions are met', async () => {
+        const result = MIPRResolver('anyRoute');
+        expect(result).toBe(routeNames.GTC);
+      });
     });
 
-    it('should return CurrentlyHasFunding when user is not a DITCO user', async () => {
-      await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
-      const result = CurrentlyHasFundingResolver('any-other-route');
-      expect(result).toBe(routeNames.CurrentlyHasFunding);
-    });
+    describe('Upload7600Resolver', () => {
+      beforeEach(() => {
+        FinancialDetails.setHasFunding('');
+      });
 
-    it('should return RFD when user is a DITCO user', async () => {
-      acquisitionPackage.contracting_shop = "DITCO";
-      await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
-      const result = CurrentlyHasFundingResolver('any-other-route');
-      expect(result).toBe(routeNames.CurrentlyHasFunding);
-    });
-  });
+      it('should return MIPR route if current is FundingPlanType and fundingRequestType ' +
+        'returns "MIPR"', async () => {
+        const fundingRequest = {
+          funding_request_type: 'MIPR'
+        };
+        await FinancialDetails.setFundingRequest(fundingRequest)
+        expect(Upload7600Resolver(routeNames.FundingPlanType)).toBe(routeNames.MIPR);
+      });
 
-  describe('GTCInformationResolver', () => {
-    beforeEach(() => {
-      FinancialDetails.setHasFunding('');
-    });
+      it('should return Upload7600 route if current is FundingPlanType and '+
+        'fundingRequestType does not return "MIPR"', async () => {
+        const fundingRequest = {
+          funding_request_type: 'NOT_MIPR'
+        };
+        await FinancialDetails.setFundingRequest(fundingRequest)
+        expect(Upload7600Resolver(routeNames.FundingPlanType)).toBe(routeNames.Upload7600);
+      });
 
-    it('should return GTC route if FinancialDetails has funding', async () => {
-      await FinancialDetails.setHasFunding("HAS_FUNDING");
-      const result = GTCInformationResolver('anyRoute');
-      expect(result).toBe(routeNames.GTC);
-    });
+      it('returns GTC when current is SeverabilityAndIncrementalFunding', () => {
+        const result = Upload7600Resolver(routeNames.SeverabilityAndIncrementalFunding);
+        expect(result).toBe(routeNames.Upload7600);
+      });
 
-    it('should return GeneratingPackageDocumentsFunding if current route is not ' +
-      'GeneratingPackageDocumentsFunding and no funding', async () => {
-      await FinancialDetails.setHasFunding("HAS_FUNDING");
-      const result = GTCInformationResolver(routeNames.CurrentlyHasFunding);
-      expect(result).toBe(routeNames.GeneratingPackageDocumentsFunding);
-    });
+      it('returns GTC when current is AppropriationOfFunds', () => {
+        const result = Upload7600Resolver(routeNames.AppropriationOfFunds);
+        expect(result).toBe(routeNames.Upload7600);
+      });
 
-    it('should return CurrentlyHasFunding if current route is ' +
-      'GeneratingPackageDocumentsFunding and no funding', () => {
-      const result = GTCInformationResolver(routeNames.CurrentlyHasFunding);
-      expect(result).toBe(routeNames.GeneratingPackageDocumentsFunding);
-    });
-  });
-
-  describe('MIPRResolver', () => {
-    beforeEach(() => {
-      FinancialDetails.setHasFunding('');
-      FinancialDetails.setFundingRequirement(fundingReq);
-      FinancialDetails.setFundingRequest({ funding_request_type: '' })
-    });
-
-    it('should return CurrentlyHasFunding route if FinancialDetails has no funding and' +
-      ' current page is GeneratingPackageDocsFunding', async () => {
-      await FinancialDetails.setHasFunding("NO_FUNDING");
-      const result = MIPRResolver(routeNames.GeneratingPackageDocumentsFunding);
-      expect(result).toBe(routeNames.CurrentlyHasFunding);
-    });
-
-    it('should return MIPR route if fundingType is MIPR', async () => {
-      const fundingRequest = { funding_request_type: 'MIPR' };
-      FinancialDetails.setFundingRequest(fundingRequest);
-      const result = MIPRResolver('anyRoute');
-      expect(result).toBe(routeNames.MIPR);
-    });
-
-    it('should return SummaryStepEight route if fundingType is FS_FORM', async () => {
-      const fundingRequest = { funding_request_type: 'FS_FORM' };
-      FinancialDetails.setFundingRequest(fundingRequest);
-      const result = MIPRResolver('anyRoute');
-      expect(result).toBe(routeNames.SummaryStepEight);
-    });
-
-    it('should return FundingPlanType route if routing from GTC page', async () => {
-      const result = MIPRResolver(routeNames.GTC);
-      expect(result).toBe(routeNames.FundingPlanType);
-    });
-
-    it('should return GTC route if no other conditions are met', async () => {
-      const result = MIPRResolver('anyRoute');
-      expect(result).toBe(routeNames.GTC);
-    });
-  });
-
-
-
-  describe('Upload7600Resolver', () => {
-    beforeEach(() => {
-      FinancialDetails.setHasFunding('');
-    });
-
-    it('should return MIPR route if current is FundingPlanType and fundingRequestType ' +
-      'returns "MIPR"', async () => {
-      const fundingRequest = {
-        funding_request_type: 'MIPR'
-      };
-      await FinancialDetails.setFundingRequest(fundingRequest)
-      expect(Upload7600Resolver(routeNames.FundingPlanType)).toBe(routeNames.MIPR);
-    });
-
-    it('should return Upload7600 route if current is FundingPlanType and fundingRequestType does '+
-      'not return "MIPR"', async () => {
-      const fundingRequest = {
-        funding_request_type: 'NOT_MIPR'
-      };
-      await FinancialDetails.setFundingRequest(fundingRequest)
-      expect(Upload7600Resolver(routeNames.FundingPlanType)).toBe(routeNames.Upload7600);
-    });
-
-    it('returns GTC when current is SeverabilityAndIncrementalFunding', () => {
-      const result = Upload7600Resolver(routeNames.SeverabilityAndIncrementalFunding);
-      expect(result).toBe(routeNames.Upload7600);
-    });
-
-    it('returns GTC when current is AppropriationOfFunds', () => {
-      const result = Upload7600Resolver(routeNames.AppropriationOfFunds);
-      expect(result).toBe(routeNames.Upload7600);
-    });
-
-    it('returns AppropriationOfFunds when there is an exception to fair opp', async () => {
-      acquisitionPackage.fair_opportunity = {exception_to_fair_opportunity: "NO_NONE"};
-      await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
-      const result = Upload7600Resolver('someOtherRoute');
-      // this can be any route that's not in the ones explicitly mentioned
-      expect(result).toBe(routeNames.Upload7600);
+      it('returns AppropriationOfFunds when there is an exception to fair opp', async () => {
+        acquisitionPackage.fair_opportunity = {exception_to_fair_opportunity: "NO_NONE"};
+        await AcquisitionPackage.setAcquisitionPackage(acquisitionPackage);
+        const result = Upload7600Resolver('someOtherRoute');
+        // this can be any route that's not in the ones explicitly mentioned
+        expect(result).toBe(routeNames.Upload7600);
+      });
     });
   });
 });

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1555,17 +1555,18 @@ export const IGCESupportingDocumentationResolver = (current: string): string => 
 
 
 export const AppropriationOfFundsResolver = (current: string): string => {
-  Summary.setHasCurrentStepBeenVisited(isStepTouched(8))
-  if (hasExceptionToFairOpp()){
+  Summary.setHasCurrentStepBeenVisited(isStepTouched(8));
+  const fromIncFunding = current === routeNames.SeverabilityAndIncrementalFunding;
+  if (fromIncFunding && Summary.hasCurrentStepBeenVisited){
+    return routeNames.SummaryStepEight
+  } else if (fromIncFunding && !Summary.hasCurrentStepBeenVisited) {
+    return routeNames.SeverabilityAndIncrementalFunding;
+  } else if (hasExceptionToFairOpp()){
     return routeNames.AppropriationOfFunds
   } else if (evalPlanRequired()){
     return routeNames.SummaryStepEight;
   }
-  
-  return current === routeNames.SeverabilityAndIncrementalFunding
-    && Summary.hasCurrentStepBeenVisited
-    ? routeNames.SummaryStepEight
-    : routeNames.SeverabilityAndIncrementalFunding;
+  return routeNames.AppropriationOfFunds
 }
 
 export const SeverabilityAndIncrementalFundingResolver = (current: string): string => {

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -19,7 +19,7 @@ import IGCE from "@/store/IGCE";
 import { provWorkflowRouteNames } from "../provisionWorkflow"
 import PortfolioStore from "@/store/portfolio";
 import AcquisitionPackageSummary from "@/store/acquisitionPackageSummary";
-import Summary, { isStepComplete, isStepTouched } from "@/store/summary";
+import Summary, { isStepComplete, isStepTouched, isSubStepComplete } from "@/store/summary";
 import PortfolioSummary from "@/store/portfolioSummary";
 
 export const showDITCOPageResolver = (current: string): string => {
@@ -1268,11 +1268,9 @@ const IGCERouteNext = (current: string): string => {
 
 
 export const IGCECannotProceedResolver = (current: string): string => {
-  const isStepFiveComplete = isStepComplete(5);
-  console.log("here's step five completeness",isStepFiveComplete )
+  const canRCEBeDisplayed =  isSubStepComplete(3,1) && isStepComplete(5)
   
-  if (!isStepFiveComplete || !(IGCEStore.requirementsCostEstimate?.has_DOW_and_PoP === "YES"))
-  {
+  if (!canRCEBeDisplayed){
     return routeNames.CannotProceed;
   }
 
@@ -1545,15 +1543,38 @@ export const CreatePriceEstimateResolver = (current:string): string =>{
 
 
 export const IGCESupportingDocumentationResolver = (current: string): string => {
+  const canRCEBeDisplayed =  isSubStepComplete(3,1) && isStepComplete(5)
   if (current === routeNames.EstimatesDeveloped) {
-    return routeNames.SupportingDocumentation;
+    return routeNames.SupportingDocumentation; 
   } else {
-    return current === routeNames.FundingPlanType &&
-    (IGCEStore.requirementsCostEstimate?.has_DOW_and_PoP === "YES")
+    return current === routeNames.SeverabilityAndIncrementalFunding && canRCEBeDisplayed
       ? routeNames.SupportingDocumentation
       : routeNames.CannotProceed;
   }
 };
+
+
+export const AppropriationOfFundsResolver = (current: string): string => {
+  Summary.setHasCurrentStepBeenVisited(isStepTouched(8))
+  if (hasExceptionToFairOpp()){
+    return routeNames.AppropriationOfFunds
+  } else if (evalPlanRequired()){
+    return routeNames.SummaryStepEight;
+  }
+  
+  return current === routeNames.SeverabilityAndIncrementalFunding
+    && Summary.hasCurrentStepBeenVisited
+    ? routeNames.SummaryStepEight
+    : routeNames.SeverabilityAndIncrementalFunding;
+}
+
+export const SeverabilityAndIncrementalFundingResolver = (current: string): string => {
+  return Summary.hasCurrentStepBeenVisited 
+    && current === routeNames.AppropriationOfFunds
+    ? routeNames.SummaryStepEight
+    : routeNames.SeverabilityAndIncrementalFunding
+};
+
 
 export const RFDResolver = (): string => {
   if (!isDitcoUser()) {
@@ -1624,26 +1645,6 @@ export const GeneratingPackageDocumentsFundingResolver = (current: string): stri
   }
   return routeNames.GeneratingPackageDocumentsFunding;
 }
-
-export const AppropriationOfFundsResolver = (current: string): string => {
-  
-  if (hasExceptionToFairOpp()){
-    return routeNames.AppropriationOfFunds
-  } else if (evalPlanRequired()){
-    return routeNames.SummaryStepEight;
-  }
-  
-  return current === routeNames.MIPR
-    ? routeNames.SummaryStepEight
-    : routeNames.MIPR;
-}
-
-export const SeverabilityAndIncrementalFundingResolver = (current: string): string => {
-  return Summary.hasCurrentStepBeenVisited 
-    && ([routeNames.AppropriationOfFunds, routeNames.Upload7600].some(route => route === current))
-    ? routeNames.SummaryStepEight
-    : routeNames.SeverabilityAndIncrementalFunding
-};
 
 const cutOff = 270;
 export async function calcBasePeriod(): Promise<number> {

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -1352,6 +1352,14 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         component: CostSummary
       },
       {
+        menuText: "Estimates Developed",
+        excludeFromMenu: true,
+        path: "estimates-developed",
+        name: routeNames.EstimatesDeveloped,
+        completePercentageWeight: 1,
+        component: EstimatesDeveloped,
+      },
+      {
         menuText: "Supporting Documentation",
         excludeFromMenu: true,
         path: "supporting-documentation",
@@ -1359,14 +1367,6 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
         completePercentageWeight: 1,
         component: SupportingDocumentation,
         routeResolver: IGCESupportingDocumentationResolver
-      },
-      {
-        menuText: "Estimates Developed",
-        excludeFromMenu: true,
-        path: "estimates-developed",
-        name: routeNames.EstimatesDeveloped,
-        completePercentageWeight: 1,
-        component: EstimatesDeveloped,
       },
       {
         menuText: "Appropriation of Funds",

--- a/src/steps/10-FinancialDetails/IGCE/CannotProceed.vue
+++ b/src/steps/10-FinancialDetails/IGCE/CannotProceed.vue
@@ -74,7 +74,7 @@ export default class CannotProceed extends Vue {
   }
 
   get isPerformanceReqsIncomplete(): boolean {
-    return !isStepComplete(5) || DescriptionOfWork.isIncomplete
+    return !isStepComplete(5)
   }
 }
 </script>

--- a/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.spec.ts
+++ b/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.spec.ts
@@ -4,6 +4,8 @@ import { createLocalVue, mount, Wrapper } from "@vue/test-utils";
 import { DefaultProps } from "vue/types/options";
 import GatherPriceEstimates from "@/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue";
 import SlideoutPanel from "@/store/slideoutPanel";
+import AcquisitionPackage from "@/store/acquisitionPackage";
+import IGCE from "@/store/IGCE";
 Vue.use(Vuetify);
 
 describe("Testing GatherPriceEstimates Component", () => {
@@ -35,4 +37,26 @@ describe("Testing GatherPriceEstimates Component", () => {
       wrapper.vm.$nextTick(() => expect(isSlideOutOpen).toBe(true))
     });
   })
+  
+  describe("saveOnLeave()=>", () => {
+    it("successfully execute with NO errors", async()=>{
+      jest.spyOn(console, 'log');
+      jest.spyOn(AcquisitionPackage, "setValidateNow").mockImplementation()
+      jest.spyOn(IGCE, "setCostEstimate").mockImplementation()
+      jest.spyOn(IGCE, "setIgceEstimate").mockImplementation()
+      
+      const _saveOnLeave = wrapper.vm.saveOnLeave();
+      expect(await wrapper.vm.saveOnLeave()).toBe(true);
+    })
+  
+    it("successfully execute with errors", async()=>{
+      const erroredValue = "errored Value";
+      jest.spyOn(console, 'log');
+      jest.spyOn(AcquisitionPackage, "setValidateNow").mockImplementation()
+      jest.spyOn(IGCE, "setCostEstimate").mockRejectedValue(erroredValue)
+      
+      expect(await wrapper.vm.saveOnLeave()).toBe(true);
+      expect(console.log).toHaveBeenCalledWith(erroredValue);
+    })
+  })  
 })

--- a/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
+++ b/src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.vue
@@ -301,14 +301,17 @@ export default class GatherPriceEstimates extends Mixins(SaveOnLeave) {
   }
 
   protected async saveOnLeave(): Promise<boolean> {
-    await AcquisitionPackage.setValidateNow(true);
-    try {
-      await IGCE.setCostEstimate(this.estimateDataSource);
-      await IGCE.setIgceEstimate(this.igceEstimateData);
-    } catch (error) {
-      console.log(error);
+    if (document.getElementsByClassName("field-error").length === 0){
+      await AcquisitionPackage.setValidateNow(true);
+      try {
+        await IGCE.setCostEstimate(this.estimateDataSource);
+        await IGCE.setIgceEstimate(this.igceEstimateData);
+      } catch (error) {
+        console.log(error);
+      }
+      return true;
     }
-    return true;
+    return false;
   }
 }
 </script>

--- a/src/steps/10-FinancialDetails/IGCE/components/Card_Requirement.vue
+++ b/src/steps/10-FinancialDetails/IGCE/components/Card_Requirement.vue
@@ -128,7 +128,7 @@ export default class CardRequirement extends Vue {
   }
 
   get showErrors(): boolean {
-    return this.noMonthlyValue || this.errorMessage !== ""
+    return this.noMonthlyValue || this.errorMessage.length>0 
   }
 
   @Watch("estimate")

--- a/src/store/summary/index.spec.ts
+++ b/src/store/summary/index.spec.ts
@@ -2,7 +2,7 @@
 
 import Vuex, { Store } from 'vuex';
 import { createLocalVue } from "@vue/test-utils";
-import AcquisitionPackage, { isDitcoUser } from "@/store/acquisitionPackage";
+import AcquisitionPackage from "@/store/acquisitionPackage";
 import  { SummaryStore } from "../summary/index";
 import { getModule } from 'vuex-module-decorators';
 import validators from "../../plugins/validation";


### PR DESCRIPTION
2 critical bugs and one annoying navigation bug is resolved

- [x] **Inaccurate validation resolved.** When user satisfies the money values in the textboxes validation is to dissappear. 
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/9219929c-e1b2-4dea-8c5d-7662d8126744)
---

- [x] this page was showing up after the cost estimate summary.  Have removed it.
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/be75b260-b4cb-4608-b85a-a635d45329e1)

---
- [x] Funding page was showing up in the middle of requirements cost estimate section.  Have modified the navigation.
![image](https://github.com/dod-ccpo/atat-web-ui/assets/84856468/07de8d88-fdf0-4ac6-911d-2bc480bc92b7)

