### PR TITLE
PR 2047 - bugfix/step-8-funding-subsection-10-16

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --no-cache --watch src/store/summary/index.spec.ts",
+    "test-file:watch": "jest --no-cache --watch src/router/resolvers/index.spec.ts",
     "test-files": "jest --no-cache src/steps/03-Background/components/",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --no-cache --watch src/router/resolvers/index.spec.ts",
+    "test-file:watch": "jest --no-cache --watch src/store/summary/index.spec.ts",
     "test-files": "jest --no-cache src/steps/03-Background/components/",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build:iso-test-folder": "npm run build:isolated_tests && npm run postbuild:cypress",
     "test:unit-watch": "vue-cli-service test:unit --watch ",
     "test": "jest --no-cache",
-    "test-file:watch": "jest --no-cache --watch /src/steps/10-FinancialDetails/IGCE/GatherPriceEstimates.spec.ts",
+    "test-file:watch": "jest --no-cache --watch src/router/resolvers/index.spec.ts",
     "test-files": "jest --no-cache src/steps/03-Background/components/",
     "test:coverage": "jest --coverage",
     "test:e2e": "node ./node_modules/cypress/bin/cypress run",

--- a/src/router/resolvers/__test__/index.spec.ts
+++ b/src/router/resolvers/__test__/index.spec.ts
@@ -278,39 +278,6 @@ describe("testing src/router/index.ts", () => {
     expect(result).toBe("Financial_POC_Form")
   });
 
-  describe('RFDResolver', () => {
-
-    it('should return routeNames.RFD when isDitcoUser() returns false', () => {
-      jest
-        .spyOn(acqPackageExportedFunctions, "isDitcoUser")
-        .mockReturnValue(false);
-      const result = RFDResolver();
-      expect(result).toBe(routeNames.RFD);
-    });
-
-    it('should return routeNames.SummaryStepEight when Summary.hasCurrentStepBeenVisited is true',
-      () => {
-        jest
-          .spyOn(acqPackageExportedFunctions, "isDitcoUser")
-          .mockReturnValue(true);
-        Summary.setHasCurrentStepBeenVisited(true) ;
-
-        const result = RFDResolver();
-        expect(result).toBe(routeNames.SummaryStepEight);
-      });
-    //
-    // eslint-disable-next-line max-len
-    it('should return routeNames.CurrentlyHasFunding when Summary.hasCurrentStepBeenVisited is false', () => {
-      jest
-        .spyOn(acqPackageExportedFunctions, "isDitcoUser")
-        .mockReturnValue(true);
-      Summary.setHasCurrentStepBeenVisited(false) ;
-      const result = RFDResolver();
-
-      expect(result).toBe(routeNames.CurrentlyHasFunding);
-    });
-  });
-
   describe('CurrentlyHasFundingResolver', () => {
     it('return SummaryStepEight when current is RFD and doesNotNeedFundingDoc is true',
       async () => {

--- a/src/router/resolvers/index.spec.ts
+++ b/src/router/resolvers/index.spec.ts
@@ -213,7 +213,7 @@ describe("testing route resolvers", () => {
         RCESummaryItem.isTouched = false;
         expect(AppropriationOfFundsResolver(
           routeNames.SeverabilityAndIncrementalFunding
-        )).toBe(routeNames.SeverabilityAndIncrementalFunding)
+        )).toBe(routeNames.AppropriationOfFunds)
       });
 
       it('returns AppropriationOfFunds if hasExceptionToFairOpp', async () =>{

--- a/src/router/resolvers/index.spec.ts
+++ b/src/router/resolvers/index.spec.ts
@@ -14,6 +14,7 @@ import {
   SeverabilityAndIncrementalFundingResolver,
   RFDResolver,
   FinancialPOCResolver,
+  IGCECannotProceedResolver,
   
 } from "./index"
 import * as ExportedResolverFunctions from "./index";
@@ -158,6 +159,35 @@ describe("testing route resolvers", () => {
           routeNames.SeverabilityAndIncrementalFunding
         )).toBe(routeNames.CannotProceed)
       });
+    })
+
+    describe('IGCECannotProceedResolver()', () => {
+      it('returns routeNames.SurgeCapacity by default ' +
+          'if current === routeNames.CreatePriceEstimate)', 
+      async () =>{
+        expect(IGCECannotProceedResolver(
+          routeNames.CreatePriceEstimate
+        )).toBe(routeNames.SurgeCapacity)
+      });
+
+      it('returns routeNames.CreatePriceEstimate by default ' +
+        'if current === routeNames.OptimizeOrReplicate)', 
+      async () =>{
+        expect(IGCECannotProceedResolver(
+          routeNames.OptimizeOrReplicate
+        )).toBe(routeNames.CreatePriceEstimate)
+      });
+      
+      it('returns current by default' +
+        'if !current.includes(routeNames.OptimizeOrReplicate, ' +
+        'ArchitecturalDesignDetails,routeNames.GatherPriceEstimates,' +
+        'CreatePriceEstimates)', 
+      async () =>{
+        const current = "customRouteName"
+        expect(IGCECannotProceedResolver(current)).toBe(current)
+      });
+
+
     })
 
     describe('AppropriationOfFundsResolver()', () => {

--- a/src/router/resolvers/index.spec.ts
+++ b/src/router/resolvers/index.spec.ts
@@ -12,6 +12,8 @@ import {
   IGCESupportingDocumentationResolver,
   AppropriationOfFundsResolver,
   SeverabilityAndIncrementalFundingResolver,
+  RFDResolver,
+  FinancialPOCResolver,
   
 } from "./index"
 import * as ExportedResolverFunctions from "./index";
@@ -298,6 +300,67 @@ describe("testing route resolvers", () => {
         'GeneratingPackageDocumentsFunding and no funding', () => {
         const result = GTCInformationResolver(routeNames.CurrentlyHasFunding);
         expect(result).toBe(routeNames.GeneratingPackageDocumentsFunding);
+      });
+    });
+
+    describe('RFDResolver', () => {
+      let RCESummaryItem = summaryItem;
+    
+      beforeEach(() => {
+        jest.clearAllMocks();
+        // eslint-disable-next-line max-len
+        RCESummaryItem = {
+          ...summaryItem,
+          "step":8,
+          "isTouched": true
+        }
+        Summary.doSetSummaryItem(RCESummaryItem);
+      });
+
+      it('should return routeNames.SummaryStepEight when Summary.hasCurrentStepBeenVisited '
+          + '&& current === routeNames.FinancialPOCForm', () => {
+        expect(RFDResolver(routeNames.FinancialPOCForm))
+          .toBe(routeNames.SummaryStepEight)
+      });
+
+      it('should return routeNames.RFD if !isDitcoUser()', () => {
+        acquisitionPackage.contracting_shop = "is not ditco user";
+        expect(RFDResolver(''))
+          .toBe(routeNames.RFD)
+      });
+
+      it('should return routeNames.CurrentlyHasFunding if isDitcoUser()', () => {
+        acquisitionPackage.contracting_shop = "DITCO";
+        expect(RFDResolver(''))
+          .toBe(routeNames.CurrentlyHasFunding)
+      });
+    });
+
+    describe('FinancialPOCResolver', () => {
+      let RCESummaryItem = summaryItem;
+    
+      beforeEach(() => {
+        jest.clearAllMocks();
+        // eslint-disable-next-line max-len
+        RCESummaryItem = {
+          ...summaryItem,
+          "step":8,
+          "isTouched": true
+        }
+        Summary.doSetSummaryItem(RCESummaryItem);
+      });
+
+      it('should return routeNames.SummaryStepEight when Summary.hasCurrentStepBeenVisited '
+          + '&& current === routeNames.RFD', () => {
+        expect(FinancialPOCResolver(routeNames.RFD))
+          .toBe(routeNames.SummaryStepEight)
+      });
+
+      it('should return routeNames.FinancialPOCForm when !Summary.hasCurrentStepBeenVisited '
+          + '&& current === routeNames.RFD', () => {
+        RCESummaryItem.isTouched=false;
+        expect(FinancialPOCResolver(routeNames.RFD))
+          .toBe(routeNames.FinancialPOCForm)
       });
     });
 

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1268,17 +1268,17 @@ const IGCERouteNext = (current: string): string => {
 
 
 export const IGCECannotProceedResolver = (current: string): string => {
-  const canRCEBeDisplayed =  isSubStepComplete(3,1) && isStepComplete(5)
-  
-  if (!canRCEBeDisplayed){
-    return routeNames.CannotProceed;
-  }
-
+  const potentialCurrentPages = [
+    routeNames.OptimizeOrReplicate, 
+    routeNames.ArchitecturalDesignDetails,
+    routeNames.GatherPriceEstimates
+  ]
   if (current === routeNames.CreatePriceEstimate) {
     return IGCERouteNext(current);
+  } else if (potentialCurrentPages.some(pcp => pcp === current)){
+    return routeNames.CreatePriceEstimate
   }
-
-  return routeNames.CreatePriceEstimate;
+  return current;
 }
 
 export const IGCEOptimizeOrReplicateResolver = (current: string): string => {

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1282,10 +1282,7 @@ export const IGCECannotProceedResolver = (current: string): string => {
 }
 
 export const IGCEOptimizeOrReplicateResolver = (current: string): string => {
-  if (current === routeNames.CannotProceed){
-    return routeNames.FundingPlanType;
-  }
-
+ 
   if (needsReplicateOrOptimize()) {
     return routeNames.OptimizeOrReplicate;
   }
@@ -1560,7 +1557,7 @@ export const AppropriationOfFundsResolver = (current: string): string => {
   if (fromIncFunding && Summary.hasCurrentStepBeenVisited){
     return routeNames.SummaryStepEight
   } else if (fromIncFunding && !Summary.hasCurrentStepBeenVisited) {
-    return routeNames.SeverabilityAndIncrementalFunding;
+    return routeNames.AppropriationOfFunds;
   } else if (hasExceptionToFairOpp()){
     return routeNames.AppropriationOfFunds
   } else if (evalPlanRequired()){

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1577,13 +1577,15 @@ export const SeverabilityAndIncrementalFundingResolver = (current: string): stri
 };
 
 
-export const RFDResolver = (): string => {
-  if (!isDitcoUser()) {
-    return routeNames.RFD
+export const RFDResolver = (current: string): string => {
+  Summary.setHasCurrentStepBeenVisited(isStepTouched(8))
+  if (current === routeNames.FinancialPOCForm && Summary.hasCurrentStepBeenVisited){
+    return routeNames.SummaryStepEight
   }
-  return Summary.hasCurrentStepBeenVisited
-    ? routeNames.SummaryStepEight
-    : routeNames.CurrentlyHasFunding
+  else if (!isDitcoUser()) {
+    return routeNames.RFD
+  } 
+  return routeNames.CurrentlyHasFunding
 }
 
 export const CurrentlyHasFundingResolver = (current: string): string => {
@@ -1698,18 +1700,12 @@ export const IncrementalFundingResolver = (current: string): string => {
 }
 
 export const FinancialPOCResolver =  (current: string): string => {
-  const isIncrementallyFunded = FinancialDetails.fundingRequirement?.incrementally_funded;
-  let baseDuration
-  calcBasePeriod().then(value => {
-    baseDuration = value
-  })
-  if (current === routeNames.ReadyToGeneratePackage && baseDuration && baseDuration < cutOff ||
-      current === routeNames.ReadyToGeneratePackage && isIncrementallyFunded === "NO") {
-    return routeNames.SeverabilityAndIncrementalFunding;
-  }
-  if (current === routeNames.RFD) return routeNames.SummaryStepEight;
-  return current === routeNames.FinancialPOCForm
-    ? routeNames.ReadyToGeneratePackage
+  Summary.setHasCurrentStepBeenVisited(isStepTouched(8))
+  const fromFunding = 
+    [routeNames.RFD, routeNames.CurrentlyHasFunding].some(route => route === current)
+  
+  return fromFunding && Summary.hasCurrentStepBeenVisited
+    ? routeNames.SummaryStepEight
     : routeNames.FinancialPOCForm
 }
 

--- a/src/store/summary/index.spec.ts
+++ b/src/store/summary/index.spec.ts
@@ -31,62 +31,59 @@ const _summaryItem = {
   substep: 0
 }
 
-const contactAcorValid: ContactDTO = {
-  type: 'ACOR', // Mission Owner, COR, ACOR
-  role: 'Military', // Military, Civilian, Contractor
+
+const contact: ContactDTO = {
+  type: '',
+  role: '',
   rank_components: '',
   salutation: '',
+  first_name: '',
+  last_name: '',
+  middle_name: '',
+  suffix: '',
+  title: '',
+  phone: '',
+  phone_extension: '',
+  email: '',
+  grade_civ: '',
+  dodaac: '',
+  can_access_package: '',
+  manually_entered: '',
+  acquisition_package: ''
+}
+
+const contactAcorValid: ContactDTO = {
+  ...contact,
+  type: 'ACOR', // 
+  role: 'Military', 
   first_name: 'John',
   last_name: 'Smith',
   middle_name: 'T',
-  suffix: '',
-  title: '',
   phone: '555-555-1234',
   phone_extension: '1234',
   email: 'john.smith.tester@mail.mil',
-  grade_civ: '',
-  dodaac: '',
-  can_access_package: '',
-  manually_entered: '',
-  acquisition_package: '',
 }
 
 const contactAcorMissingFullName: Partial<ContactDTO> = {
+  ...contact,
   type: 'ACOR', // Mission Owner, COR, ACOR
   role: 'Military', // Military, Civilian, Contractor
-  rank_components: '',
-  salutation: '',
   middle_name: 'T',
-  suffix: '',
-  title: '',
   phone: '555-555-1234',
   phone_extension: '1234',
   email: 'john.smith.tester@mail.mil',
-  grade_civ: '',
-  dodaac: '',
-  can_access_package: '',
-  manually_entered: '',
-  acquisition_package: '',
 }
 
 const contactAcorMissingFirstName: Partial<ContactDTO> = {
+  ...contact,
   type: 'ACOR', // Mission Owner, COR, ACOR
   role: 'Military', // Military, Civilian, Contractor
-  rank_components: '',
-  salutation: '',
   middle_name: 'T',
-  suffix: '',
-  title: '',
   first_name: 'John',
   phone: '555-555-1234',
   phone_extension: '1234',
   email: 'john.smith.tester@mail.mil',
-  grade_civ: '',
-  dodaac: '',
-  can_access_package: '',
-  manually_entered: '',
-  acquisition_package: '',
-}
+  }
 
 describe("Summary Store", () => {
   let summaryStore: SummaryStore;
@@ -209,6 +206,28 @@ describe("Summary Store", () => {
       },
     ]);
   });
+
+  describe('hasCompleteIncrementalFundingAndPOC', () => {
+    // eslint-disable-next-line max-len
+    it('should return "Funding documents are not required" when not required by contracting office', async () => {
+      const funding = {
+        req: {
+          has_funding: '',
+        } as FundingRequirementDTO,
+        poc:{
+          ...contact,
+          first_name: "firstName",
+          last_name: "lastName",
+          phone: "123-456-7890",
+          email: "email@mail.mil",
+          role: "MILITARY"
+        }
+        
+      };
+      expect(await summaryStore.hasCompleteIncrementalFundingAndPOC(funding)).toBe(false);
+    });
+  });
+    
 
   describe('setFundingDescription', () => {
     // eslint-disable-next-line max-len
@@ -481,6 +500,30 @@ describe("Summary Store", () => {
       const isComplete = await summaryStore.isFundingComplete(funding);
 
       await expect(isComplete).toBe(true);
+    });
+
+    it('should return true when !isDitco && !needsFunding', async () => {
+      const funding = {
+        request: {
+          funding_request_type: 'FS_FORM',
+          appropriation_fiscal_year: '2023',
+          appropriation_funds_type: 'W_C',
+        } as FundingRequestDTO,
+        gInv: {
+          gInvoiceNumber: 'Invoice123',
+        } as baseGInvoiceData,
+        fsForm: null as unknown as FundingRequestFSFormDTO,
+        mipr: null as unknown as FundingRequestMIPRFormDTO,
+        hasFairOpp: true,
+        fundingRequirement: {
+          has_funding: 'NO_FUNDING',
+        } as FundingRequirementDTO,
+        isDitco: true,
+      };
+      
+      const isComplete = await summaryStore.isFundingComplete(funding);
+
+      await expect(isComplete).toBe(false);
     });
 
   })

--- a/src/store/summary/index.spec.ts
+++ b/src/store/summary/index.spec.ts
@@ -83,7 +83,7 @@ const contactAcorMissingFirstName: Partial<ContactDTO> = {
   phone: '555-555-1234',
   phone_extension: '1234',
   email: 'john.smith.tester@mail.mil',
-  }
+}
 
 describe("Summary Store", () => {
   let summaryStore: SummaryStore;

--- a/src/store/summary/index.ts
+++ b/src/store/summary/index.ts
@@ -2553,10 +2553,13 @@ export class SummaryStore extends VuexModule {
     if(!funding.isDitco && !needsFunding){
       return true
     }
+    if (funding.fsForm === null && funding.mipr === null){
+      return false
+    }
     const keysToIgnore = Object.keys(funding.fsForm).filter(k=>!k.includes("fs_form_7600a"))
     const fsForm700AComplete = await this.isComplete({object: funding.fsForm, keysToIgnore})
         && funding.fsForm.gt_c_number !== ""
-    const needsFundingInfo = funding.fundingRequirement.has_funding === "NO_FUNDING"
+    const needsFundingInfo = funding.fundingRequirement?.has_funding === "NO_FUNDING"
     const hasFunding = (needsFundingInfo && fsForm700AComplete)
     if (funding.request && funding.fsForm){
       let hasAppropriationOfFunds = false;
@@ -2717,12 +2720,12 @@ export class SummaryStore extends VuexModule {
 
     // determines if POC is valid
     let isPOCComplete = false;
-    isPOCComplete = funding.poc.first_name !== ""
-        && funding.poc.last_name !== ""
-        && funding.poc.phone !== ""
-        && funding.poc.email !== ""
+    isPOCComplete = funding.poc?.first_name !== ""
+      && funding.poc?.last_name !== ""
+      && funding.poc?.phone !== ""
+      && funding.poc?.email !== ""
 
-    if (funding.poc.role === "MILITARY"){
+    if (funding.poc?.role === "MILITARY"){
       isPOCComplete = isPOCComplete && funding.poc.rank_components !== ""
     }
     return isFundingIncrementsComplete


### PR DESCRIPTION
**- [ ] Ensure Step 8 summary appears as expected.**
To test:
1. Go to Step 9.
2. Click Back to navigate to Step 8 Summary page
3. Ensure Step 8 summary page displays as expected.
---
**- [ ] Removed `Cannot proceed` from Step 8 - Requirements Cost Estimate.**
To test
1. Open a new acquisition package
2. Navigate to Step 8 (without adding any PoP or Step 5 items)
3. Click Continue
4. Should be navigated to `Surge Requirements` page
5. Click Back.
6. Should be navigated to the first page of Step 8

---
**- [ ] Financial POC prevents user from opening package**  (Testing found the sometimes the POC wouldn't retrieve from the app and that would break the opening screen.  I tried to reproduce this 6 times and could not reproduce it.  So I made it more bulletproof, that is the empty POC will not prevent the user from reentering the screen.)

1. Open an existing or new package.
2. Navigate to Step 8 / Inc Funding substep.
3. Click Yes
4. Click Continue 2x to view the Financial POC page.  
5. Add a POC.  Click Continue to save the POC
6. Check the `Funding Req` table in the database to ensure the POC was saved.
7. Remove the Funding POC from the SNOW Database.
8. Refresh the app and reenter the package.
9. Ensure the package successfully opens.





   