### PR TITLE
PR 2069 - feature/AT-9936-global-components-1 (first iteration of changes)

### DIFF
--- a/src/components/ATATAddressForm.vue
+++ b/src/components/ATATAddressForm.vue
@@ -39,13 +39,13 @@
       <v-col
         class="col-12"
         :class="[
-          _selectedAddressType !== addressTypes.FOR
+          _selectedAddressType !== addressTypes?.FOR ?? ''
             ? 'col-lg-5'
             : 'col-lg-4',
         ]"
       >
         <ATATTextField
-          v-if="_selectedAddressType !== addressTypes.MIL"
+          v-if="_selectedAddressType !== addressTypes?.MIL ?? ''"
           id="City"
           label="City"
           :class="inputClass"
@@ -53,7 +53,7 @@
           :rules="getRules('City')"
         />
         <ATATSelect
-          v-if="_selectedAddressType === addressTypes.MIL"
+          v-if="_selectedAddressType === addressTypes?.MIL ?? ''"
           id="APO_FPO_DPO"
           label="APO/FPO/DPO"
           :class="inputClass"
@@ -67,7 +67,7 @@
       <v-col
         class="col-12"
         :class="[
-          _selectedAddressType !== addressTypes.FOR
+          _selectedAddressType !== addressTypes?.FOR ?? ''
             ? 'col-lg-3'
             : 'col-lg-4',
         ]"
@@ -75,7 +75,7 @@
         <ATATAutoComplete
           id="State"
           label="State"
-          v-if="_selectedAddressType === addressTypes.USA"
+          v-if="_selectedAddressType === addressTypes?.USA ?? ''"
           :class="inputClass"
           titleKey="text"
           :searchFields="['text', 'value']"
@@ -87,7 +87,7 @@
         />
 
         <ATATSelect
-          v-if="_selectedAddressType === addressTypes.MIL"
+          v-if="_selectedAddressType === addressTypes?.MIL ?? ''"
           id="StateCode"
           label="AA/AE/AP"
           :class="inputClass"
@@ -99,7 +99,7 @@
         />
 
         <ATATTextField
-          v-if="_selectedAddressType === addressTypes.FOR"
+          v-if="_selectedAddressType === addressTypes?.FOR ?? ''"
           id="StateProvince"
           label="State or Province"
           :value.sync="_stateOrProvince"
@@ -120,7 +120,7 @@
         />
       </v-col>
     </v-row>
-    <v-row v-if="_selectedAddressType === addressTypes.FOR">
+    <v-row v-if="_selectedAddressType === addressTypes?.FOR ?? ''">
       <v-col class="col-12 col-lg-4">
         <ATATAutoComplete
           id="Country"
@@ -143,8 +143,8 @@
 
 <script lang="ts">
 /*eslint prefer-const: 1 */
-import Vue from "vue";
-import { Component, Prop, PropSync } from "vue-property-decorator";
+import Vue, { ComponentPublicInstance } from "vue";
+import { Component, Prop, PropSync } from "vue-facing-decorator";
 
 import ATATAutoComplete from "./ATATAutoComplete.vue";
 import ATATDialog from "./ATATDialog.vue";
@@ -175,7 +175,7 @@ import {
 
 export default class ATATAddressForm extends Vue {
   $refs!: {
-    atatAddressForm: Vue & {
+    atatAddressForm: ComponentPublicInstance & {
       resetValidation: () => void;
       reset: () => void;
     };
@@ -265,20 +265,20 @@ export default class ATATAddressForm extends Vue {
 
   public resetData(): void {
     Vue.nextTick(() => {
-     
-      //iterate over the forms children ref manually set their 'errorMessages' array to empty
-      const formChildren = this.$refs.atatAddressForm.$children;
-      formChildren.forEach(ref=> ((ref as unknown) as {errorMessages:[]}).errorMessages = []);
-      this.$refs.atatAddressForm.reset();
-      Vue.nextTick(() => {
-        this.$refs.atatAddressForm.resetValidation();
-      });
+      // TODO: REFACTOR AFTER VUE3 UPGRADE
+      // //iterate over the forms children ref manually set their 'errorMessages' array to empty
+      // const formChildren = this.$refs.atatAddressForm.$children;
+      // formChildren.forEach(ref=> ((ref as unknown) as {errorMessages:[]}).errorMessages = []);
+      // this.$refs.atatAddressForm.reset();
+      // Vue.nextTick(() => {
+      //   this.$refs.atatAddressForm.resetValidation();
+      // });
     });
   }
   // computed
 
   get inputClass(): string {
-    return this.$vuetify.breakpoint.mdAndDown
+    return this.$vuetify.display.mdAndDown
       ? "_input-max-width my-2"
       : "my-2";
   }

--- a/src/components/ATATAlert.vue
+++ b/src/components/ATATAlert.vue
@@ -79,7 +79,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 import PortfolioStore from "@/store/portfolio";
 
 @Component({})
@@ -130,8 +130,8 @@ export default class ATATAlert extends Vue {
       return alertClasses + " bg-" + this.calloutBackground;
     }
     alertClasses = "_" + this.type + "-alert";
-    alertClasses = this.borderLeft ? alertClasses + " _border-left-thick" : alertClasses;
-    alertClasses = this.maxHeight ? alertClasses + " py-0 pr-0" : alertClasses;
+    alertClasses = this.borderLeft ? alertClasses + "_border-left-thick" : alertClasses;
+    alertClasses = this.maxHeight ? alertClasses + "py-0 pr-0" : alertClasses;
     return alertClasses;
   }
 

--- a/src/components/ATATAutoComplete.vue
+++ b/src/components/ATATAutoComplete.vue
@@ -60,10 +60,10 @@
 
 <script lang="ts">
 /* eslint vue/no-v-text-v-html-on-component: 1 */
-import Vue from "vue";
+import Vue, { ComponentPublicInstance } from "vue";
 import { AutoCompleteItem } from "types/Global";
 
-import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
+import { Component, Prop, PropSync, Watch } from "vue-facing-decorator";
 import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
 import AcquisitionPackage from "@/store/acquisitionPackage";
 
@@ -76,7 +76,7 @@ import AcquisitionPackage from "@/store/acquisitionPackage";
 export default class ATATAutoComplete extends Vue {
   // refs
   $refs!: {
-    atatAutoComplete: Vue &
+    atatAutoComplete: ComponentPublicInstance &
     {
       errorBucket: string[];
       errorCount: number;

--- a/src/components/ATATCheckboxGroup.vue
+++ b/src/components/ATATCheckboxGroup.vue
@@ -39,7 +39,7 @@
         :error="error"
         :disabled="disabled"
         :rules="checkboxRules"
-        @mouseup="checkBoxClicked(item.value, index)"
+        @mouseup="checkBoxClicked(item.value)"
         multiple
         :hide-details="true"
         :ref="index === 0 ? 'checkboxGroup' : ''"
@@ -147,8 +147,8 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
+import Vue, { ComponentPublicInstance } from "vue";
+import { Component, Prop, PropSync, Watch } from "vue-facing-decorator";
 
 import ATATTextArea from "@/components/ATATTextArea.vue";
 import ATATTextField from "@/components/ATATTextField.vue";
@@ -172,12 +172,12 @@ import ClassificationRequirements from "@/store/classificationRequirements";
 export default class ATATCheckboxGroup extends Vue {
   // refs
   $refs!: {
-    checkboxGroup: (Vue & {
+    checkboxGroup: (ComponentPublicInstance & {
       errorBucket: string[];
       errorCount: number;
       validate: () => boolean;
     })[];
-    atatTextInput: (Vue & { errorBucket: string[]; errorCount: number })[];
+    atatTextInput: (ComponentPublicInstance & { errorBucket: string[]; errorCount: number })[];
   };
 
   // props

--- a/src/components/ATATContactForm.vue
+++ b/src/components/ATATContactForm.vue
@@ -157,8 +157,8 @@
 </template>
 
 <script lang="ts">
-import Vue from "vue";
-import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
+import Vue, { ComponentPublicInstance } from "vue";
+import { Component, Prop, PropSync, Watch } from "vue-facing-decorator";
 import ATATAutoComplete from "@/components/ATATAutoComplete.vue";
 import ATATPhoneInput from "@/components/ATATPhoneInput.vue";
 import ATATRadioGroup from "@/components/ATATRadioGroup.vue";
@@ -186,7 +186,7 @@ import { convertSystemChoiceToSelect } from "@/helpers";
 })
 export default class ATATContactForm extends Vue {
   $refs!: {
-    atatGlobalContact: Vue & {
+    atatGlobalContact: ComponentPublicInstance & {
       resetValidation: () => void;
       reset: () => void;
     };

--- a/src/components/ATATDatePicker.vue
+++ b/src/components/ATATDatePicker.vue
@@ -87,8 +87,8 @@
   </div>
 </template>
 <script lang="ts">
-import { Component, Prop, Watch } from "vue-property-decorator";
-import Vue from "vue";
+import Vue, { ComponentPublicInstance } from "vue";
+import { Component, Prop, Watch } from "vue-facing-decorator";
 import { add, format, formatISO, isValid } from "date-fns";
 import ATATTooltip from "@/components/ATATTooltip.vue";
 import ATATErrorValidation from "@/components/ATATErrorValidation.vue";
@@ -103,14 +103,14 @@ import AcquisitionPackage from "@/store/acquisitionPackage";
 export default class ATATDatePicker extends Vue {
   // refs
   $refs!: {
-    atatDatePicker: Vue & { 
+    atatDatePicker: ComponentPublicInstance & {
       errorBucket: string[]; 
       errorCount: number; 
       validate: () => boolean;
       value: string;
       resetValidation: ()=> boolean;
     };
-    atatDatePickerMenu: Vue & {
+    atatDatePickerMenu: ComponentPublicInstance & {
       save: (selectedDate: string) => Record<string, never>;
     };
   };

--- a/src/components/ATATDialog.vue
+++ b/src/components/ATATDialog.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script lang="ts">
-import {Component, Prop, PropSync} from "vue-property-decorator";
+import { Component, Prop, PropSync } from "vue-facing-decorator";
 import Vue from "vue";
 import { Component as VueComponent } from "vue";
 

--- a/src/components/ATATDivider.vue
+++ b/src/components/ATATDivider.vue
@@ -11,7 +11,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 @Component({})
 

--- a/src/components/ATATErrorValidation.vue
+++ b/src/components/ATATErrorValidation.vue
@@ -16,7 +16,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 @Component({})
 export default class ATATErrorValidation extends Vue {

--- a/src/components/ATATExpandableLink.vue
+++ b/src/components/ATATExpandableLink.vue
@@ -44,7 +44,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import {Component, Prop, PropSync} from "vue-property-decorator";
+import {Component, Prop, PropSync} from "vue-facing-decorator";
 
 @Component({})
 export default class ExpandableLink extends Vue {

--- a/src/components/ATATFeedbackForm.vue
+++ b/src/components/ATATFeedbackForm.vue
@@ -231,7 +231,7 @@
 /* eslint-disable camelcase */
 
 import Vue from "vue";
-import { Component, Watch } from "vue-property-decorator";
+import { Component, Watch } from "vue-facing-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import acquisitionPackage from "@/store/acquisitionPackage";
 import AcquisitionPackage from "@/store/acquisitionPackage";

--- a/src/components/ATATFileList.vue
+++ b/src/components/ATATFileList.vue
@@ -38,7 +38,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
+import { Component, Prop, PropSync, Watch } from "vue-facing-decorator";
 import ATATFileListItem from "@/components/ATATFileListItem.vue";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import ATATDialog from "./ATATDialog.vue";

--- a/src/components/ATATFileListItem.vue
+++ b/src/components/ATATFileListItem.vue
@@ -117,7 +117,7 @@
 
 <script lang='ts'>
 import Vue from "vue";
-import { Component, Prop, Watch } from "vue-property-decorator";
+import { Component, Prop, Watch } from "vue-facing-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import { format } from "date-fns";
 import { formatInTimeZone } from "date-fns-tz";

--- a/src/components/ATATFileUpload.vue
+++ b/src/components/ATATFileUpload.vue
@@ -145,8 +145,8 @@
 <script lang="ts">
 /* eslint camelcase: 0 */
 
-import Vue from "vue";
-import { Component, Prop, PropSync, Watch } from "vue-property-decorator";
+import Vue, { ComponentPublicInstance } from "vue";
+import { Component, Prop, PropSync, Watch } from "vue-facing-decorator";
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import ATATFileList from "@/components/ATATFileList.vue";
 import {
@@ -168,7 +168,7 @@ import { setItemToPlural } from "@/helpers";
 export default class ATATFileUpload extends Vue {
   // refs
   $refs!: {
-    atatFileUpload: Vue & {
+    atatFileUpload: ComponentPublicInstance & {
       errorBucket: string[];
       errorCount: number;
       resetValidation: () => void;
@@ -552,9 +552,7 @@ export default class ATATFileUpload extends Vue {
     window.addEventListener("dragover", this.preventDrop, false);
 
     //try to grab the attachment service via the service factory
-    this.fileAttachmentService = AttachmentServiceFactory(
-      this.attachmentServiceName
-    );
+    this.fileAttachmentService = AttachmentServiceFactory(this.attachmentServiceName);
 
     this._invalidFiles = [];
   }

--- a/src/components/ATATFooter.vue
+++ b/src/components/ATATFooter.vue
@@ -42,7 +42,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Watch } from "vue-property-decorator";
+import { Component, Watch } from "vue-facing-decorator";
 import { UserDTO } from "@/api/models";
 import CurrentUserStore from "@/store/user";
 import AcquisitionPackage from "@/store/acquisitionPackage";

--- a/src/components/ATATLoader.vue
+++ b/src/components/ATATLoader.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 @Component({})
 

--- a/src/components/ATATLoadingPackageModal.vue
+++ b/src/components/ATATLoadingPackageModal.vue
@@ -38,7 +38,7 @@ import Vue from "vue";
 
 import AcquisitionPackage from "@/store/acquisitionPackage";
 import AppSections from "@/store/appSections";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 @Component({})
 

--- a/src/components/ATATMeatballMenu.vue
+++ b/src/components/ATATMeatballMenu.vue
@@ -36,8 +36,8 @@
             v-if="item.icon"
             :name="item.icon.name"
             :color="item.icon.color"
-            :width="item.icon.width"
-            :height="item.icon.height"           
+            :width="item.icon.width as number"
+            :height="item.icon.height as number"
           />
         </v-list-item-title>
       </v-list-item>
@@ -47,7 +47,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue";
 import { MeatballMenuItem } from "types/Global";

--- a/src/components/ATATNoResults.vue
+++ b/src/components/ATATNoResults.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop } from "vue-facing-decorator";
 
 import ATATSVGIcon from "@/components/icons/ATATSVGIcon.vue"
 

--- a/src/components/ATATPageHead.vue
+++ b/src/components/ATATPageHead.vue
@@ -81,16 +81,16 @@
       v-if="isMissionOwner"
       :showModal.sync="showDeleteModal"
       :packageName="packageName"
-      :hasContributor="hasContributor"
-      :waitingForSignature="isWaitingForSignature"
+      :hasContributor="hasContributor()"
+      :waitingForSignature="isWaitingForSignature()"
       @okClicked="updateStatus('DELETED')"
     />
     <ArchiveModal
       v-if="isMissionOwner"
       :showModal.sync="showArchiveModal"
-      :hasContributor="hasContributor"
+      :hasContributor="hasContributor()"
       :packageName="packageName"
-      :waitingForSignature="isWaitingForSignature"
+      :waitingForSignature="isWaitingForSignature()"
       @okClicked="updateStatus('ARCHIVED')"
     />
 
@@ -101,7 +101,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Watch } from "vue-property-decorator";
+import { Component, Watch } from "vue-facing-decorator";
 
 import AppSections from "@/store/appSections";
 import SlideoutPanel from "@/store/slideoutPanel";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,8 +31,7 @@
   },
   "vueCompilerOptions": { 
     //gets rid of the red squiggly lines in the vue component
-    // "target": 2.7,
-    "target": 2, // For Vue version <= 2.6.14
+    "target": 3,
     "experimentalUseElementAccessInTemplate": true
   },
   "include": [


### PR DESCRIPTION
First round of changes to global components part 1:
- Updated from `vue-class-decorator` to `vue-facing-decorator`
- Changed from extending `Mixins` to `Vue`
- Changed use of `Vue` in `$refs!` declaration to `ComponentPublicInstance`