### PR TITLE
feature/vue3-step3-contract-type-fix

### DIFF
--- a/src/steps/04-ContractDetails/ContractType.vue
+++ b/src/steps/04-ContractDetails/ContractType.vue
@@ -26,6 +26,7 @@
               </p>
             <ATATCheckboxGroup
               id="ContractTypesCheckboxes"
+              :key="selectedContractTypes.toString()"
               :value="selectedContractTypes"
               @update:value="selectedContractTypes = $event"
               :items="checkboxItems"
@@ -105,6 +106,7 @@ class ContractType extends Vue {
   protected selectedContractTypesChanged(newSelections: string[]): void {
     this.firmFixedPriceSelected = newSelections.indexOf("FFP") > -1 ? "true" : "false";
     this.timeAndMaterialsSelected = newSelections.indexOf("T&M") > -1 ? "true" : "false";
+
   }
 
   @Watch("timeAndMaterialsSelected")
@@ -177,6 +179,7 @@ class ContractType extends Vue {
           this.selectedContractTypes.push("T&M");
         }
         
+        console.log('parent: ', this.selectedContractTypes)
       }
     } else {
       AcquisitionPackage.setContractType(this.currentData);

--- a/src/steps/04-ContractDetails/ContractType.vue
+++ b/src/steps/04-ContractDetails/ContractType.vue
@@ -178,8 +178,6 @@ class ContractType extends Vue {
         if (this.timeAndMaterialsSelected === "true") {
           this.selectedContractTypes.push("T&M");
         }
-        
-        console.log('parent: ', this.selectedContractTypes)
       }
     } else {
       AcquisitionPackage.setContractType(this.currentData);


### PR DESCRIPTION
The checkboxgroup was refusing to update when "value" changed. I even set up a simple @Watch on value, and it wouldn't fire when I'd change the value on component load. After it loaded up it would fire. There's some interesting and mysterious race condition going on in this component probably due to the .value vs ._selected setup. So to solve this issue on this component, which refused to be solved from any other option, I set the key of the checkboxgroup to change when the parent's value changes. This forces a re-render of the checkboxgroup component, controlled by the parent's value, instead of relying on the child, which fails to notice any value update. 