### PR TITLE
PR 2204 - feature/AT-10119-step-5

### DIFF
--- a/src/components/DOW/InstanceConfig.vue
+++ b/src/components/DOW/InstanceConfig.vue
@@ -5,6 +5,7 @@
         <ATATTextField
           v-if="!isDOW"
           id="Licensing"
+          ref="LicensingRef"
           label="Licensing"
           :value="offeringData.licensing"
           @update:value="offeringData.licensing = $event"
@@ -20,6 +21,7 @@
       <v-col class="col-sm-12 col-md-3">
         <ATATTextField
           id="NumberOfVCPUs"
+          ref="NumberOfVCPUsRef"
           label="Number of vCPUs"
           :value="offeringData.numberOfVCPUs"
           @update:value="offeringData.numberOfVCPUs = $event"
@@ -36,6 +38,7 @@
       <v-col class="col-sm-12 col-md-3">
         <ATATTextField
           id="ProcessorSpeed"
+          ref="ProcessorSpeedRef"
           label="Processor speed"
           :value="offeringData.processorSpeed"
           @update:value="offeringData.processorSpeed = $event"
@@ -52,6 +55,7 @@
       <v-col class="col-sm-12 col-md-6">
         <ATATTextField
           id="OperatingSystem"
+          ref="OperatingSystemRef"
           label="Operating system"
           :value="offeringData.operatingSystem"
           @update:value="offeringData.operatingSystem = $event"
@@ -67,6 +71,7 @@
       <v-col class="col-sm-12 col-md-3">
         <ATATTextField
           id="Memory"
+          ref="MemoryRef"
           label="Memory"
           :value="offeringData.memoryAmount"
           @update:value="offeringData.memoryAmount = $event"
@@ -86,6 +91,7 @@
       <v-col class="col-sm-12 col-md-3">
         <ATATSelect
           id="StorageType"
+          ref="StorageTypeRef"
           label="Storage type"
           :items="storageTypes"
           :selectedValue="offeringData.storageType"
@@ -100,6 +106,7 @@
       <v-col class="col-sm-12 col-md-3">
         <ATATTextField
           id="StorageAmount"
+          ref="StorageAmountRef"
           label="Storage size"
           :value="offeringData.storageAmount"
           @update:value="offeringData.storageAmount = $event"

--- a/src/components/DOW/PerformanceTier.vue
+++ b/src/components/DOW/PerformanceTier.vue
@@ -2,6 +2,7 @@
   <div id="PerformanceTier" class="mt-10">
     <ATATRadioGroup 
       id="PerformanceTierOptions"
+      ref="PerformanceTierOptions"
       v-if="!isDatabase"
       :items="performanceTiers"
       legend="Performance tier"
@@ -15,6 +16,7 @@
 
     <ATATTextField
       id="NetworkPerformance"
+      ref="NetworkPerformance"
       v-if="isDatabase"
       class="mt-8 _input-max-width-240"
       :value="(offeringData as OtherServiceOfferingData).networkPerformance"
@@ -28,6 +30,7 @@
 
     <ATATTextField
       id="NumberOfInstances"
+      ref="NumberOfInstances"
       class="mt-8 _input-max-width-240"
       :value="offeringData.numberOfInstances"
       @update:value="offeringData.numberOfInstances = $event"
@@ -41,6 +44,7 @@
 
     <ATATTextField
       id="MonthlyDataEgress"
+      ref="MonthlyDataEgress"
       v-if="!isDOW"
       class="mt-8 _input-max-width-240 _has-appended-dropdown"
       label="Approximate data/internet egress per month"

--- a/src/mixins/saveOnLeave.ts
+++ b/src/mixins/saveOnLeave.ts
@@ -18,13 +18,14 @@ export const validateAllForms = async (forms:SaveOnLeaveRefs): Promise<boolean> 
   for (const f in forms){
     const form = (forms as unknown as FormRef)[f];
     if (form){
-      console.log('22: => ' + f)
       if (Object.prototype?.hasOwnProperty?.call(form, "setErrorMessage")){
+        console.log('ref1: => ' + f  + ': setErrorMessage');
         form.setErrorMessage();
       } 
       if (form.$?.type.name?.toLowerCase() === "vform"){
         const isFormValid = (await form.validate())?.valid;
         isFormsValid.push(isFormValid);
+        console.log('ref1: => ' + f  + ': form.validate');
       } else {
         await(getRef(form))
       }
@@ -38,17 +39,17 @@ async function getRef(form:ComponentPublicInstance):Promise<void>{
   const refs = form?.$refs || form;
   if (refs){
     for (const ref in refs){
-      console.log('42: => ' + ref)
       const _formRef = (refs as unknown as FormRef)[ref];
       if (_formRef){
-        if (_formRef.$?.type.name?.toLowerCase() === "vform"){
-          isFormsValid.push((await(_formRef.validate())).valid);
-        }
         if (Object.prototype?.hasOwnProperty?.call(_formRef, "setErrorMessage")){
+          console.log('ref2: => ' + ref  + ': setErrorMessage');
           (_formRef).setErrorMessage()
         }
+        if (_formRef.$?.type.name?.toLowerCase() === "vform"){
+          isFormsValid.push((await(_formRef.validate())).valid);
+          console.log('ref2: => ' + ref  + ': form.validate');
+        }
       }
-
       await getRef(_formRef);
     }
   }

--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -597,6 +597,7 @@ const setDontNeedButton = (groupId: string) => {
 const otherServiceOfferings = DescriptionOfWork.otherServiceOfferings
 
 const basePerformanceRequirementsPath = '/performance-requirements'
+const DOWLandingPagePath = 'dow-landing-page'
 const requirementCategories = '/requirement-categories'
 const descriptionOfWorkSummaryPath = '/dow-summary'
 const DOWSecurityRequitementsPath ='/dow-security-requirements'
@@ -731,6 +732,10 @@ export const RequirementsPathResolver = (
       previousGroup,
       lastOfferingForGroup.name
     )
+  }
+
+  if (current === routeNames.ArchitecturalDesignDetails){
+    return DOWLandingPagePath;
   }
 
   return basePerformanceRequirementsPath

--- a/src/router/stepper.ts
+++ b/src/router/stepper.ts
@@ -1106,7 +1106,7 @@ export const stepperRoutes: Array<StepperRouteConfig> = [
       },
       {
         menuText: "Landing Page",
-        path: "/",
+        path: "/dow-landing-page",
         excludeFromMenu: true,
         name: routeNames.DOWLandingPage,
         completePercentageWeight: 1,

--- a/src/steps/05-PerformanceRequirements/DOW/ArchitecturalDesign.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ArchitecturalDesign.vue
@@ -176,7 +176,7 @@ class ArchitecturalDesign extends Vue {
     source: "DOW",
     statement: "",
     applications_needing_design: "",
-    data_classification_levels: "",
+    data_classification_levels: [],
     external_factors: "",
     acquisition_package: AcquisitionPackage.packageId,
     needs_architectural_design_services:""
@@ -203,7 +203,7 @@ class ArchitecturalDesign extends Vue {
     const emptyArchObject = {
       statement: "",
       applications_needing_design: "",
-      data_classification_levels: "",
+      data_classification_levels: [],
       external_factors: "",
     }
     try {

--- a/src/steps/05-PerformanceRequirements/DOW/ArchitecturalDesignDOW.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ArchitecturalDesignDOW.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-form lazy-validation>
+  <v-form ref="form" lazy-validation>
     <ArchitecturalDesignForm
       ref="ArchitecturalDesignFormRef"
       :isDOW="true"
@@ -60,7 +60,7 @@ class ArchitectureDesignDOW extends Vue {
     source: "DOW",
     statement: "",
     applications_needing_design: "",
-    data_classification_levels: "",
+    data_classification_levels: [],
     external_factors: "",
     acquisition_package: AcquisitionPackage.packageId,
     needs_architectural_design_services:""

--- a/src/steps/05-PerformanceRequirements/DOW/ComputeFormElements.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/ComputeFormElements.vue
@@ -2,6 +2,7 @@
   <div>
     <ATATRadioGroup
       id="EnvironmentType"
+      ref="EnvironmentTypeRef"
       legend="What type of environment is this instance?"
       :value="offeringData.environmentType"
       @update:value="offeringData.environmentType = $event"
@@ -13,6 +14,7 @@
 
     <ATATRadioGroup
       id="OperatingEnvType"
+      ref="OperatingEnvTypeRef"
       legend="What type of operating environment do you need?"
       :value="offeringData.operatingEnvironment"
       @update:value="offeringData.operatingEnvironment = $event"
@@ -24,6 +26,7 @@
 
     <ATATRadioGroup
       id="OSLicensingType"
+      ref="OSLicensingTypeRef"
       legend="Operating system licensing"
       :value="offeringData.operatingSystemAndLicensing"
       @update:value="offeringData.operatingSystemAndLicensing = $event"

--- a/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/OtherOfferings.vue
@@ -218,6 +218,7 @@
     </v-form>
 
     <ClassificationsModal 
+      ref="ClassificationModalRef"
       :showDialog="showDialog"
       @cancelClicked="modalCancelClicked"
       @okClicked="classificationLevelsChanged"
@@ -325,7 +326,6 @@ class OtherOfferings extends Vue
   public availablePeriodCheckboxItems: Checkbox[] = [];
   public formHasBeenTouched = false;
   public formHasErrors = false;
-  public errorBagValues: boolean[] = []
   public hasErrorsOnLoad = false;
   public validateOtherTierNow = false;
   public validateOtherTierOnBlur = false;
@@ -532,7 +532,6 @@ class OtherOfferings extends Vue
       ? await this.setErrorMessages()
       : this.validateOtherTierOnBlur = true;
 
-    return;
   }
 
   public async mounted(): Promise<void> {
@@ -540,17 +539,12 @@ class OtherOfferings extends Vue
     await this.setComponentSpecificData();
   }
 
-  @Watch("errorBagValues")
-  public errorBagChange(): void {
-    this.setErrorMessages();
-  }
 
   private setErrorMessages(): void {
     this.$nextTick(() => {
       this.$refs.form.validate().then(
         async (response:SubmitEventPromise)=>{
-          this.errorBagValues = [(await (response)).valid]; 
-          this.formHasErrors = this.errorBagValues.includes(true);
+          this.formHasErrors = (await (response)).valid === false;
         }
       );
     });

--- a/src/store/descriptionOfWork/index.ts
+++ b/src/store/descriptionOfWork/index.ts
@@ -852,7 +852,7 @@ export const defaultDOWArchitecturalNeeds: ArchitecturalDesignRequirementDTO = {
   source: "DOW",
   statement: "",
   applications_needing_design: "",
-  data_classification_levels: [""],
+  data_classification_levels: [],
   external_factors: "",
   acquisition_package: "",
   needs_architectural_design_services:""


### PR DESCRIPTION
### **Issue 1 - Architectural Design solution issue**
:white_check_mark:  missing validations and getting blank page with continue button on ‘Tell us more about your architectural design requirements’
:white_check_mark: When user click on architectural design form, blank page displays
:white_check_mark:  The classifications that user selected in Architectural solution form are not retrieving when user revisits the form. (Showstopper)

### **Issue 2 0 Xaas categories with instance grid summary pages freezing browser**
 :white_check_mark:  Issue#2:All the Categories that have instance grid summary page, when user clicks on the Edit icon for the instance record in the summary page, hen browser is in responsive. User has to restart the browser.(Compute, Database, general xaas paas)

### **Issue#3- Database:** 
1. The licensing information for the operating system is not being saved in SNOW, causing missing information to appear in the grid.
    - This issue is an existing bug in the backlog and will not be resolved at this time.  AT-9518: Step 5 - Database service offering field not saving as expected

### ** Issue#5 Cloud Support packages:
1. Portability: Continue button is not working, user is not able to proceed to next page.(Showstopper)
    - Could not reproduce on my local.  Screenshared with Santi to ensure I had the correct context to initiate the error, and we could not duplicate the error.
5. When the 'I don’t need a Portability plan' button is clicked, a Delete modal pops up. However, upon clicking 'Delete' in the modal, the portability requirement is not being deleted, and the user remains on the page.
    - Could not reproduce on my local.  Screenshared with Santi to ensure I had the correct context to initiate the error, and we could not duplicate the error.