### PR TITLE
PR 2206 - feature/AT-10120-step-6-change-back-button-text

### DIFF
--- a/src/router/resolvers/index.ts
+++ b/src/router/resolvers/index.ts
@@ -1050,7 +1050,7 @@ export const OfferingDetailsPathResolver = (
 
   if (DescriptionOfWork.summaryBackToContractDetails) {
     DescriptionOfWork.setBackToContractDetails(false)
-    return 'current-contract/current-contract'
+    return '/current-contract'
   }
 
   const missingClassification = DescriptionOfWork.missingClassificationLevels
@@ -1264,18 +1264,10 @@ export const DowSummaryPathResolver = (
   )
   Steps.clearAltBackButtonText()
   if (current === routeNames.DOWLandingPage) {
-    const hasCurrentContract =
-      AcquisitionPackage.currentContracts && AcquisitionPackage.currentContracts.length>0;
-    if (hasCurrentContract) {
-      return CurrentEnvironment.currentEnvironment.current_environment_exists === "YES"
-        && CurrentEnvironment.currentEnvInstances.length > 0
-        ? "/current-contract/environment-summary"
-        : "/current-contract/summary-step-four"
-    } else {
-      return "/current-contract/current-contract"
-    }
-    // TODO - check if this is needed when routing fixed
-    return '/current-contract/summary-step-four'
+    Summary.setHasCurrentStepBeenVisited(isStepTouched(4))
+    return isStepTouched(4)
+      ? "/summary-step-four"
+      : "/current-contract"
   }
 
   const atServicesEnd = DescriptionOfWork.isEndOfServiceOfferings

--- a/src/steps/05-PerformanceRequirements/DOW/DOWLandingPage.vue
+++ b/src/steps/05-PerformanceRequirements/DOW/DOWLandingPage.vue
@@ -156,6 +156,15 @@ import {buildClassificationLabel} from "@/helpers";
   }
 })
 class DOWLandingPage extends Vue {
+  
+  @Hook
+  public async beforeRouteLeave(to: To, from: From) {
+    return await beforeRouteLeaveFunction({ to, from, 
+      saveOnLeave: this.saveOnLeave, 
+      form: this.$refs as SaveOnLeaveRefs, 
+      nextTick: this.$nextTick,
+    }).catch()
+  }
 
   displayWarning = false;
   totalSections = 3;


### PR DESCRIPTION
- [x] removed `Back to Step 4` text from back button 
      - 1. that appeared after step 5 was touched
      - 2. persisted in the other steps
- [x] fixed the incorrect navigation when the user clicks the `Back to Step 4`
AT-10120